### PR TITLE
Add more intelligent TODO item toggling

### DIFF
--- a/lua/neorg/modules/core/defaults/module.lua
+++ b/lua/neorg/modules/core/defaults/module.lua
@@ -12,5 +12,6 @@ return neorg.modules.create_meta(
     "core.mode",
     "core.norg.qol.todo_items",
     "core.norg.esupports",
-    "core.integrations.treesitter"
+    "core.integrations.treesitter",
+    "core.norg.manoeuvre"
 )

--- a/lua/neorg/modules/core/keybinds/default_keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/default_keybinds.lua
@@ -18,6 +18,9 @@ return function(neorg_leader)
                 { "<CR>", "core.norg.esupports.goto_link" },
 
                 { "<C-s>", "core.integrations.telescope.find_linkable" },
+
+                { "<M-k>", "core.norg.manoeuvre.item_up" },
+                { "<M-j>", "core.norg.manoeuvre.item_down" },
             },
 
             i = {

--- a/lua/neorg/modules/core/norg/manoeuvre/module.lua
+++ b/lua/neorg/modules/core/norg/manoeuvre/module.lua
@@ -1,0 +1,124 @@
+-- [[
+-- A Neorg module for moving around different elements up and down
+-- ]]
+
+require('neorg.modules.base')
+
+local module = neorg.modules.create("core.norg.manoeuvre")
+
+module.setup = function()
+    return { success = true, requires = { "core.keybinds", "core.integrations.treesitter" } }
+end
+
+module.load = function()
+    module.required["core.keybinds"].register_keybinds(
+        module.name,
+        { "item_up", "item_down" }
+    )
+end
+
+module.config.public = {
+    moveables = {
+        headings = {
+            "heading%d",
+            "heading%d",
+        },
+        todo_items = {
+            "todo_item%d",
+            {
+                "todo_item%d",
+                "unordered_list%d"
+            }
+        },
+        unordered_list_elements = {
+            "unordered_list%d",
+            {
+                "todo_item%d",
+                "unordered_list%d"
+            }
+        }
+    }
+}
+
+module.public = {
+    get_element_from_cursor = function(node_pattern)
+        local node_at_cursor = module.required["core.integrations.treesitter"].get_ts_utils().get_node_at_cursor()
+
+        if not node_at_cursor:parent():type():match(node_pattern) then
+            log.trace(string.format("Could not find element of pattern '%s' under the cursor", node_pattern))
+            return
+        end
+
+        return node_at_cursor:parent()
+    end,
+
+    move_item_down = function(pattern, expected_sibling_name)
+        local element = module.public.get_element_from_cursor(pattern)
+
+        if not element then
+            return
+        end
+
+        local next_element = element:next_named_sibling()
+
+        if type(expected_sibling_name) == "string" then
+            if next_element and next_element:type():match(expected_sibling_name) then
+                -- TODO: This is a bit buggy and doesn't always set the cursor position to where you'd expect
+                module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(element, next_element, 0, true)
+            end
+        else
+            for _, expected in ipairs(expected_sibling_name) do
+                if next_element and next_element:type():match(expected) then
+                    module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(element, next_element, 0, true)
+                    return
+                end
+            end
+        end
+    end,
+
+    move_item_up = function(pattern, expected_sibling_name)
+        local element = module.public.get_element_from_cursor(pattern)
+
+        if not element then
+            return
+        end
+
+        local prev_element = element:prev_named_sibling()
+
+        if type(expected_sibling_name) == "string" then
+            if prev_element and prev_element:type():match(expected_sibling_name) then
+                module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(element, prev_element, 0, true)
+            end
+        else
+            for _, expected in ipairs(expected_sibling_name) do
+                if prev_element and prev_element:type():match(expected) then
+                    module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(element, prev_element, 0, true)
+                    return
+                end
+            end
+        end
+    end,
+}
+
+module.on_event = function(event)
+    local config = module.config.public.moveables
+
+    if event.split_type[2] == "core.norg.manoeuvre.item_down" then
+        for _, data in pairs(config) do
+            module.public.move_item_down(data[1], data[2])
+        end
+    elseif event.split_type[2] == "core.norg.manoeuvre.item_up" then
+        for _, data in pairs(config) do
+            module.public.move_item_up(data[1], data[2])
+        end
+    end
+end
+
+module.events.subscribed = {
+    ["core.keybinds"] = {
+        ["core.norg.manoeuvre.item_down"] = true,
+        ["core.norg.manoeuvre.item_up"] = true,
+    }
+}
+
+return module

--- a/lua/neorg/modules/core/norg/manoeuvre/module.lua
+++ b/lua/neorg/modules/core/norg/manoeuvre/module.lua
@@ -2,7 +2,7 @@
 -- A Neorg module for moving around different elements up and down
 -- ]]
 
-require('neorg.modules.base')
+require("neorg.modules.base")
 
 local module = neorg.modules.create("core.norg.manoeuvre")
 
@@ -11,10 +11,7 @@ module.setup = function()
 end
 
 module.load = function()
-    module.required["core.keybinds"].register_keybinds(
-        module.name,
-        { "item_up", "item_down" }
-    )
+    module.required["core.keybinds"].register_keybinds(module.name, { "item_up", "item_down" })
 end
 
 module.config.public = {
@@ -27,17 +24,17 @@ module.config.public = {
             "todo_item%d",
             {
                 "todo_item%d",
-                "unordered_list%d"
-            }
+                "unordered_list%d",
+            },
         },
         unordered_list_elements = {
             "unordered_list%d",
             {
                 "todo_item%d",
-                "unordered_list%d"
-            }
-        }
-    }
+                "unordered_list%d",
+            },
+        },
+    },
 }
 
 module.public = {
@@ -64,12 +61,22 @@ module.public = {
         if type(expected_sibling_name) == "string" then
             if next_element and next_element:type():match(expected_sibling_name) then
                 -- TODO: This is a bit buggy and doesn't always set the cursor position to where you'd expect
-                module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(element, next_element, 0, true)
+                module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(
+                    element,
+                    next_element,
+                    0,
+                    true
+                )
             end
         else
             for _, expected in ipairs(expected_sibling_name) do
                 if next_element and next_element:type():match(expected) then
-                    module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(element, next_element, 0, true)
+                    module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(
+                        element,
+                        next_element,
+                        0,
+                        true
+                    )
                     return
                 end
             end
@@ -87,12 +94,22 @@ module.public = {
 
         if type(expected_sibling_name) == "string" then
             if prev_element and prev_element:type():match(expected_sibling_name) then
-                module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(element, prev_element, 0, true)
+                module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(
+                    element,
+                    prev_element,
+                    0,
+                    true
+                )
             end
         else
             for _, expected in ipairs(expected_sibling_name) do
                 if prev_element and prev_element:type():match(expected) then
-                    module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(element, prev_element, 0, true)
+                    module.required["core.integrations.treesitter"].get_ts_utils().swap_nodes(
+                        element,
+                        prev_element,
+                        0,
+                        true
+                    )
                     return
                 end
             end
@@ -118,7 +135,7 @@ module.events.subscribed = {
     ["core.keybinds"] = {
         ["core.norg.manoeuvre.item_down"] = true,
         ["core.norg.manoeuvre.item_up"] = true,
-    }
+    },
 }
 
 return module

--- a/lua/neorg/modules/core/norg/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/norg/qol/todo_items/module.lua
@@ -1,23 +1,24 @@
 --[[
-	Module for implementing todo lists.
+    Module for implementing todo lists.
 
     Available binds:
-    - todo.task_done
-    - todo.task_undone
-    - todo.task_pending
-    - todo.task_cycle
-
-    TODO: get rid of the pattern matching stuff within the on_event() local functions once the scanner module is ready
-    TODO: use sym.states within the on_event() local funtions once global utility functions become a thing
+        - todo.task_done
+        - todo.task_undone
+        - todo.task_pending
+        - todo.task_cycle
 
     The same as:
-
         ["core.norg.qol.todo_items.todo"] = {
             ["task_done"] = true
             ["task_undone"] = true
             ["task_pending"] = true
             ["task_cycle"] = true
         }
+
+    ISSUES:
+        - The parent element should be marked as pending if all children are also pending (?)
+        - Editing the text doesn't update anything, only using the keybinds does (make this realtime thing configurable)
+        - Toggling between items
 --]]
 
 require("neorg.modules.base")
@@ -25,103 +26,182 @@ require("neorg.modules.base")
 local module = neorg.modules.create("core.norg.qol.todo_items")
 
 module.setup = function()
-    return { success = true, requires = { "core.keybinds" } }
+    return { success = true, requires = { "core.keybinds", "core.autocommands", "core.integrations.treesitter" } }
 end
-
-module.config.private = {
-    sym = {
-        states = {
-            done = "x",
-            undone = " ",
-            pending = "*",
-        },
-        left_bracket = "[",
-        right_bracket = "]",
-    },
-}
 
 module.load = function()
     module.required["core.keybinds"].register_keybinds(
         module.name,
         { "todo.task_done", "todo.task_undone", "todo.task_pending", "todo.task_cycle" }
     )
+
+    -- module.required["core.autocommands"].enable_autocommand("TextChanged")
+    -- module.required["core.autocommands"].enable_autocommand("TextChangedI")
 end
 
-module.on_event = function(event)
-    local sym = module.config.private.sym
+module.public = {
+    --- Updates the parent todo item for the current todo item if it exists
+    --- @param recursion_level number the index of the parent to change. The higher the number the more the code will traverse up the syntax tree.
+    update_parent = function(recursion_level)
+        -- Force a reparse (this is required because otherwise some cached nodes will be incorrect)
+        vim.treesitter.get_parser(0, "norg"):parse()
 
-    if event.split_type[1] == "core.keybinds" then
-        -- @Summary Sets the current todo item's state
-        -- @Param  state (string) - a string of characters to replace the current todo state
-        local set_todo_item_state = function(state)
-            -- Grab the current line
-            local current_line = event.line_content
+        -- If present grab the list item that is under the cursor
+        local list_node_at_cursor = module.public.get_list_item_from_cursor()
 
-            -- Before you die of a heart attack, the below regex is supposed to pattern match a todo item,
-            -- for example one that looks like this: - [x] Example!
-            local str, _ = current_line:gsub(
-                "^(%s*%-+%s+%" .. sym.left_bracket .. "%s*)[x%*%s](%s*%" .. sym.right_bracket .. "%s+)",
-                "%1" .. state .. "%2",
-                1
-            )
+        -- If we set a recursion level then go through and traverse up the syntax tree `recursion_level` times
+        for _ = 0, recursion_level do
+            list_node_at_cursor = list_node_at_cursor:parent()
+        end
 
-            -- If the current line differs from what we already have then change it!
-            if current_line ~= str then
-                vim.api.nvim_buf_set_lines(0, event.cursor_position[1] - 1, event.cursor_position[1], true, { str })
+        -- If the list node isn't present or if the list element's type isn't a todo_item then return
+        if list_node_at_cursor and not list_node_at_cursor:type():match("todo_item%d") then
+            return
+        end
+
+        local done_item_count = 0
+        local counter = 0
+
+        -- Go through all the children of the current todo item node and count the amount of "done" children
+        for node in list_node_at_cursor:iter_children() do
+            if vim.startswith(node:type(), "todo_item") then
+                if node:type():match("todo_item%d") and node:named_child(1):type() == "todo_item_done" then
+                    done_item_count = done_item_count + 1
+                end
+
+                counter = counter + 1
             end
         end
 
-        -- @Summary Gets the current todo item's state
-        -- @Description Pattern matches the current line to query the current todo item.
-        local get_todo_item_state = function()
-            return event.line_content:match(
-                "^%s*%-+%s+%" .. sym.left_bracket .. "%s*([x%*%s])%s*%" .. sym.right_bracket .. "%s+"
-            )
+        -- [[
+        --  Compare the counter to the amount of done items.
+        --  If the counter is the same as the done item count then that means all items are complete and we should display a done item in the parent.
+        --  If the done item count is 0 then no task has been completed and we should set an undone item as the parent.
+        --  If all other checks fail and the done item count is less than the total number of todo items then set a pending item.
+        -- ]]
+
+        local resulting_char = ""
+
+        if (counter - 1) == done_item_count then
+            resulting_char = "x"
+        elseif done_item_count == 0 then
+            resulting_char = " "
+        elseif done_item_count < (counter - 1) then
+            resulting_char = "*"
         end
 
-        -- @Summary Cycles todo items
-        -- @Description Queries the todo item on the current line and cycles it between a predefined list of states
-        local cycle_todo_item = function()
-            -- Define that states and query the current state
-            local states = { " ", "x", "*" }
-            local next_state = get_todo_item_state()
+        local range = module.required["core.integrations.treesitter"].get_node_range(list_node_at_cursor)
 
-            -- If the current state cannot be found (ie. the current line is not a valid todo item) then don't do anything
-            if not next_state then
+        -- Replace the line where the todo item is situated
+        local current_line = vim.fn.getline(range.row_start + 1):gsub(
+            "^(%s*%-+%s+%[%s*)[x%*%s](%s*%]%s+)",
+            "%1" .. resulting_char .. "%2"
+        )
+
+        vim.fn.setline(range.row_start + 1, current_line)
+
+        module.public.update_parent(recursion_level + 1)
+    end,
+
+    --- Tries to locate a todo_item node under the cursor
+    --- @return userdata nil if no such node could be found else returns the todo_item node
+    get_list_item_from_cursor = function()
+        local node_at_cursor = module.required["core.integrations.treesitter"].get_ts_utils().get_node_at_cursor()
+
+        while node_at_cursor:type() ~= "document_content" and not node_at_cursor:type():match("todo_item%d") do
+            node_at_cursor = node_at_cursor:parent()
+        end
+
+        if node_at_cursor:type() == "document_content" then
+            log.trace("Could not find TODO item under cursor, aborting...")
+            return
+        end
+
+        return node_at_cursor
+    end,
+
+    --- Converts the current node and all its children to a certain type
+    --- @param node userdata the node to modify
+    --- @param todo_item_type string one of "done", "pending" or "undone"
+    --- @param char string the character to place within the square brackets of the todo item (one of "x", "*" or " ")
+    make_all = function(node, todo_item_type, char)
+        --- Returns the type of a todo item (either "done", "pending" or "undone")
+        local function get_todo_item_type(todo_node)
+            local todo_type = todo_node:named_child(1):type()
+
+            return todo_type and todo_type:sub(string.len("todo_item_") + 1) or ""
+        end
+
+        if not node then
+            return
+        end
+
+        local range = module.required["core.integrations.treesitter"].get_node_range(node)
+        local position = range.row_start
+        local type = get_todo_item_type(node)
+
+        -- If the type of the current todo item differs from the one we want to change to then
+        -- We do this because we don't want to be unnecessarily modifying a line that doesn't need changing
+        if type ~= todo_item_type then
+            -- 3 is the default amount of children a todo_item should have. If it has more then it has children
+            -- and we should handle those too
+            if node:named_child_count() <= 3 then
+                local current_line = vim.fn.getline(position + 1):gsub(
+                    "^(%s*%-+%s+%[%s*)[x%*%s](%s*%]%s+)",
+                    "%1" .. char .. "%2"
+                )
+
+                vim.fn.setline(position + 1, current_line)
                 return
-            end
+            else
+                local current_line = vim.fn.getline(position + 1):gsub(
+                    "^(%s*%-+%s+%[%s*)[x%*%s](%s*%]%s+)",
+                    "%1" .. char .. "%2"
+                )
 
-            -- Loop through all values and find the next element
-            for i, state in ipairs(states) do
-                -- If we have found the current element
-                if next_state == state then
-                    -- Then either wrap around to the beginning of the table if we're reading too far into it
-                    if i == #states then
-                        i = 1
-                    else -- Or advance the i variable by one
-                        i = i + 1
+                vim.fn.setline(position + 1, current_line)
+
+                local index = 3
+
+                -- Go through all children and set them recursively too
+                for _ = range.row_start, range.row_end, 1 do
+                    local child = node:named_child(index)
+
+                    if child then
+                        module.public.make_all(child, todo_item_type, char)
+                        index = index + 1
+                    else
+                        break
                     end
-
-                    -- Define the next todo item state and exit the loop, everything was successful
-                    next_state = states[i]
-                    break
                 end
             end
+        end
+    end
+}
 
-            -- Actually set the item state
-            set_todo_item_state(next_state)
+module.on_event = function(event)
+    local todo_str = "core.norg.qol.todo_items.todo."
+
+    if event.split_type[1] == "core.keybinds" then
+        local node_at_cursor = module.public.get_list_item_from_cursor()
+
+        if not node_at_cursor then
+            return
         end
 
-        -- Depending on the event received perform different todo actions
-        if event.split_type[2] == "core.norg.qol.todo_items.todo.task_done" then
-            set_todo_item_state(sym.states.done)
-        elseif event.split_type[2] == "core.norg.qol.todo_items.todo.task_undone" then
-            set_todo_item_state(sym.states.undone)
-        elseif event.split_type[2] == "core.norg.qol.todo_items.todo.task_pending" then
-            set_todo_item_state(sym.states.pending)
-        elseif event.split_type[2] == "core.norg.qol.todo_items.todo.task_cycle" then
-            cycle_todo_item()
+        if event.split_type[2] == todo_str .. "task_done" then
+            module.public.make_all(node_at_cursor, "done", "x")
+            module.public.update_parent(0)
+        elseif event.split_type[2] == todo_str .. "task_undone" then
+            module.public.make_all(node_at_cursor, "undone", " ")
+            module.public.update_parent(0)
+        elseif event.split_type[2] == todo_str .. "task_pending" then
+            module.public.make_all(node_at_cursor, "pending", "*")
         end
+    elseif vim.startswith(event.type, "core.autocommands.events.textchanged") then
+       -- if module.public.get_list_item_from_cursor() then
+       --     module.public.update_parent(0)
+       -- end
     end
 end
 
@@ -132,6 +212,11 @@ module.events.subscribed = {
         ["core.norg.qol.todo_items.todo.task_pending"] = true,
         ["core.norg.qol.todo_items.todo.task_cycle"] = true,
     },
+
+    ["core.autocommands"] = {
+        textchanged = true,
+        textchangedi = true,
+    }
 }
 
 return module

--- a/lua/neorg/modules/core/norg/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/norg/qol/todo_items/module.lua
@@ -29,9 +29,6 @@ module.load = function()
         module.name,
         { "todo.task_done", "todo.task_undone", "todo.task_pending", "todo.task_cycle" }
     )
-
-    -- module.required["core.autocommands"].enable_autocommand("TextChanged")
-    -- module.required["core.autocommands"].enable_autocommand("TextChangedI")
 end
 
 module.config.public = {
@@ -246,10 +243,6 @@ module.on_event = function(event)
             module.public.make_all(todo_item_at_cursor, next[1], next[2])
             module.public.update_parent(0)
         end
-    elseif vim.startswith(event.type, "core.autocommands.events.textchanged") then
-        -- if module.public.get_list_item_from_cursor() then
-        --     module.public.update_parent(0)
-        -- end
     end
 end
 

--- a/lua/neorg/modules/core/norg/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/norg/qol/todo_items/module.lua
@@ -16,7 +16,7 @@
         }
 
     ISSUES:
-        - The parent element should be marked as pending if all children are also pending (?)
+        - The parent element should be marked as pending if one of the children is pending
         - Editing the text doesn't update anything, only using the keybinds does (make this realtime thing configurable)
         - Toggling between items
 --]]

--- a/lua/neorg/modules/core/norg/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/norg/qol/todo_items/module.lua
@@ -14,11 +14,6 @@
             ["task_pending"] = true
             ["task_cycle"] = true
         }
-
-    ISSUES:
-        - The parent element should be marked as pending if one of the children is pending
-        - Editing the text doesn't update anything, only using the keybinds does (make this realtime thing configurable)
-        - Toggling between items
 --]]
 
 require("neorg.modules.base")
@@ -176,7 +171,7 @@ module.public = {
                 end
             end
         end
-    end
+    end,
 }
 
 module.on_event = function(event)
@@ -199,9 +194,9 @@ module.on_event = function(event)
             module.public.make_all(node_at_cursor, "pending", "*")
         end
     elseif vim.startswith(event.type, "core.autocommands.events.textchanged") then
-       -- if module.public.get_list_item_from_cursor() then
-       --     module.public.update_parent(0)
-       -- end
+        -- if module.public.get_list_item_from_cursor() then
+        --     module.public.update_parent(0)
+        -- end
     end
 end
 
@@ -216,7 +211,7 @@ module.events.subscribed = {
     ["core.autocommands"] = {
         textchanged = true,
         textchangedi = true,
-    }
+    },
 }
 
 return module

--- a/lua/neorg/modules/core/norg/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/norg/qol/todo_items/module.lua
@@ -225,6 +225,7 @@ module.on_event = function(event)
             local next = types[get_index(types, todo_item_type)]
 
             module.public.make_all(todo_item_at_cursor, next[1], next[2])
+            module.public.update_parent(0)
         end
     elseif vim.startswith(event.type, "core.autocommands.events.textchanged") then
         -- if module.public.get_list_item_from_cursor() then


### PR DESCRIPTION
This PR makes TODO items bind themselves to each other and all in all makes them a lot more intelligent.
![showcase](https://user-images.githubusercontent.com/76052559/132569718-261d1b5e-b5e9-4d2f-87d2-e00d1575fe37.gif)

There's still a few issues that need fleshing out:
- [x] The parent element should be marked as pending if one of the children is pending
- [ ] ~~Editing the text doesn't update anything, only using the keybinds does (make this realtime updating as-you-type thing configurable)~~
- [x] Toggling between items with `<C-Space>`

I'll be working on those bit by bit and will try to merge this branch as quickly  as possible. There's a lot that I have to track and do simultaneously but this one should be easy.