### PR TITLE
Conceal link modifier

### DIFF
--- a/docs/NFF-0.1-spec.md
+++ b/docs/NFF-0.1-spec.md
@@ -442,11 +442,20 @@ changes:
   This is the only modifier that does not fall into any of the 4 categories of modifiers (attached, detached, trailing and delimiting). The `:`
   symbol is marked the **link modifier**. It exists to link different "categories" of text together.
   The rules for the link modifier are a twist on the rules of the attached modifier, meaning a link modifier must form a pair.
-  [//]: # "TODO: discuss limitations of link modifier as defined below."
-  [//]: # "NOTE: this is mostly a temporary marker to allow me to easily place a review comment on Github."
-  An opening link modifier must be prefixed by a non-whitespace character and must be followed by an attached modifier or by whitespace (if at the end of a word).
-  Note that the link modifier is **not** an attached modifier, so chaining them like `::<attached modifier>` will simply result in the first colon
-  being treated as punctuation. A closing link modifier may only be prefixed with an attached modifier. The syntactical equivalent of markdown's `so*me*thing` will look as such: `so:*me*:thing`.
+  The opening link modifier must be immediately followed by an attached modifier.
+  Accordingly, the closing link modifier must be immediately preceded by one.
+  Note that the link modifier is **not** an attached modifier, so chaining
+  them like `::<attached modifier>` will simply result in the first colon being
+  treated as punctuation.
+  There are no other constraints on the placement of link modifiers.
+  Let's give some quick examples comparing with Markdown:
+
+| Markdown       | Neorg            |
+|----------------|------------------|
+| `so*me*thing`  | `so:*me*:thing`  |
+| `*im*possible` | `:*im*:possible` |
+| `can*not*`     | `can:*not*:`     |
+
   At first it looks weird, doesn't it? Hah.
   We believe that since you will find yourself injecting modifiers into a word rather infrequently it is worth trading some
   extra characters for infinitely more syntactical stability in the file format. Want to do something like `t**his black** magic`? You also can,

--- a/docs/NFF-0.1-spec.md
+++ b/docs/NFF-0.1-spec.md
@@ -442,6 +442,8 @@ changes:
   This is the only modifier that does not fall into any of the 4 categories of modifiers (attached, detached, trailing and delimiting). The `:`
   symbol is marked the **link modifier**. It exists to link different "categories" of text together.
   The rules for the link modifier are a twist on the rules of the attached modifier, meaning a link modifier must form a pair.
+  [//]: # "TODO: discuss limitations of link modifier as defined below."
+  [//]: # "NOTE: this is mostly a temporary marker to allow me to easily place a review comment on Github."
   An opening link modifier must be prefixed by a non-whitespace character and must be followed by an attached modifier or by whitespace (if at the end of a word).
   Note that the link modifier is **not** an attached modifier, so chaining them like `::<attached modifier>` will simply result in the first colon
   being treated as punctuation. A closing link modifier may only be prefixed with an attached modifier. The syntactical equivalent of markdown's `so*me*thing` will look as such: `so:*me*:thing`.

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -469,7 +469,7 @@ module.public = {
         if conceals.bold then
             vim.schedule(function()
                 vim.cmd([[
-                    syn region NeorgConcealBold matchgroup=Normal start="\([?!:;,.<>()\[\]{}'"/#%&$£€\-_\~\W \t\n]\&[^\\]\)\@<=\*\%\([^ \t\n\*]\)\@=" end="[^ \t\n\\]\@<=\*\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~\W \t\n]\)\@=" oneline concealends
+                    syn region NeorgConcealBold matchgroup=Normal start="\([?!:;,.<>()\[\]{}'"/#%&$£€\-_\~`\W \t\n]\&[^\\]\)\@<=\*\%\([^ \t\n\*]\)\@=" end="[^ \t\n\\]\@<=\*\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~`\W \t\n]\)\@=" oneline concealends
                 ]])
             end)
         end
@@ -477,7 +477,7 @@ module.public = {
         if conceals.italic then
             vim.schedule(function()
                 vim.cmd([[
-                    syn region NeorgConcealItalic matchgroup=Normal start="\([?!:;,.<>()\[\]{}'"#%&$£€\-_\~\W \t\n]\&[^\\]\)\@<=/\%\([^ \t\n/]\)\@=" end="[^ \t\n\\]\@<=/\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_~\W \t\n]\)\@=" oneline concealends
+                    syn region NeorgConcealItalic matchgroup=Normal start="\([?!:;,.<>()\[\]{}\*'"#%&$£€\-_\~`\W \t\n]\&[^\\]\)\@<=/\%\([^ \t\n/]\)\@=" end="[^ \t\n\\]\@<=/\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~`\W \t\n]\)\@=" oneline concealends
                 ]])
             end)
         end
@@ -485,7 +485,7 @@ module.public = {
         if conceals.underline then
             vim.schedule(function()
                 vim.cmd([[
-                    syn region NeorgConcealUnderline matchgroup=Normal start="\([?!:;,.<>()\[\]{}'"/#%&$£€\-\~\W \t\n]\&[^\\]\)\@<=_\%\([^ \t\n_]\)\@=" end="[^ \t\n\\]\@<=_\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~\W \t\n]\)\@=" oneline concealends
+                    syn region NeorgConcealUnderline matchgroup=Normal start="\([?!:;,.<>()\[\]{}\*'"/#%&$£€\-\~`\W \t\n]\&[^\\]\)\@<=_\%\([^ \t\n_]\)\@=" end="[^ \t\n\\]\@<=_\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~`\W \t\n]\)\@=" oneline concealends
                 ]])
             end)
         end
@@ -493,7 +493,7 @@ module.public = {
         if conceals.strikethrough then
             vim.schedule(function()
                 vim.cmd([[
-                    syn region NeorgConcealStrikethrough matchgroup=Normal start="\([?!:;,.<>()\[\]{}'"/#%&$£€\-_\~\W \t\n]\&[^\\]\)\@<=\-\%\([^ \t\n\-]\)\@=" end="[^ \t\n\\]\@<=\-\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~\W \t\n]\)\@=" oneline concealends
+                    syn region NeorgConcealStrikethrough matchgroup=Normal start="\([?!:;,.<>()\[\]{}\*'"/#%&$£€\-_\~`\W \t\n]\&[^\\]\)\@<=\-\%\([^ \t\n\-]\)\@=" end="[^ \t\n\\]\@<=\-\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~`\W \t\n]\)\@=" oneline concealends
                 ]])
             end)
         end
@@ -501,7 +501,7 @@ module.public = {
         if conceals.verbatim then
             vim.schedule(function()
                 vim.cmd([[
-                    syn region NeorgConcealMonospace matchgroup=Normal start="\([?!:;,.<>()\[\]{}'"/#%&$£€\-_\~\W \t\n]\&[^\\]\)\@<=`\%\([^ \t\n`]\)\@=" end="[^ \t\n\\]\@<=`\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~`\W \t\n]\)\@=" oneline concealends
+                    syn region NeorgConcealMonospace matchgroup=Normal start="\([?!:;,.<>()\[\]{}\*'"/#%&$£€\-_\~\W \t\n]\&[^\\]\)\@<=`\%\([^ \t\n`]\)\@=" end="[^ \t\n\\]\@<=`\%\([?!:;,.<>()\[\]{}\*'"/#%&$£\-_\~`\W \t\n]\)\@=" oneline concealends
                 ]])
             end)
         end

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -265,6 +265,7 @@ module.config.public = {
         strikethrough = true,
         verbatim = true,
         trailing = true,
+        link = true,
     },
 }
 
@@ -512,6 +513,14 @@ module.public = {
                 ]])
             end)
         end
+
+        if conceals.link then
+            vim.schedule(function()
+                vim.cmd([[
+                    syn region NeorgConcealLink matchgroup=Normal start=":[\*/_\-`]\@=" end="[\*/_\-`]\@<=:" contains=NeorgConcealBold,NeorgConcealItalic,NeorgConcealUnderline,NeorgConcealStrikethrough,NeorgConcealMonospace oneline concealends
+                ]])
+            end)
+        end
     end,
 
     -- @Summary Clears conceals for the current buffer
@@ -522,6 +531,7 @@ module.public = {
             silent! syn clear NeorgConcealItalic
             silent! syn clear NeorgConcealBold
             silent! syn clear NeorgConcealUnderline
+            silent! syn clear NeorgConcealLink
         ]])
     end,
 }

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -528,9 +528,13 @@ module.public = {
     clear_conceals = function()
         vim.cmd([[
             silent! syn clear NeorgConcealURL
+            silent! syn clear NeorgConcealURLValue
             silent! syn clear NeorgConcealItalic
             silent! syn clear NeorgConcealBold
             silent! syn clear NeorgConcealUnderline
+            silent! syn clear NeorgConcealMonospace
+            silent! syn clear NeorgConcealStrikethrough
+            silent! syn clear NeorgConcealTrailing
             silent! syn clear NeorgConcealLink
         ]])
     end,


### PR DESCRIPTION
This adds support for concealing the link modifier, `:`. Since tree-sitter will not allow us to do concealing natively we will have to rely on our trusty Vim syntax regions defined via regexes anyways.

### Actual text
![screenshot_1631138571](https://user-images.githubusercontent.com/21973473/132591922-83996dbd-e956-45e5-91c0-06501f1c45c0.png)
### Concealed
![screenshot_1631138580](https://user-images.githubusercontent.com/21973473/132591924-398dff92-6e1e-41d9-a815-9ee608d722b4.png)

## Up for discussion
Right now, I implemented the link modifier regex to only require being suff- and prefixed with another markup modifier on the opening and closing link modifiers, respectively. However, this somewhat contradicts the current spec which requires a **non-whitespace character** in front of the opening modifier. However, I find that is a limitation because it will prevent e.g. the following: `This is :*im*:possible!`
I believe, that this is a not uncommon scenario so I am open for suggestions on how to rephrase the spec accordingly. I placed a temporary TODO comment at the relevant position of the markdown file.
As of right now, the spec does not contain a similar limitation for the closing `:`.


_PS: I also did some minor touch-ups on the other conceal elements_