### PR TITLE
feat: horizontal lines

### DIFF
--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -93,6 +93,12 @@
 
 And using 3 or more `=` signs will drop you right back to the root level!
 
+You can also place horizontal lines using three or more underscores like so:
+___
+This will never affect the indentation level of the following text, but it will immediately
+terminate the paragraph which is why this is a new paragraph despite the absence of two (or more)
+consective new lines.
+
  ** Links
     We borrow the basic link syntax from markdown: `[link text](link source)`
     Here are some example which also show you a special list kind for links:

--- a/docs/EXAMPLE.norg
+++ b/docs/EXAMPLE.norg
@@ -93,6 +93,12 @@
 
 And using 3 or more `=` signs will drop you right back to the root level!
 
+You can also place horizontal lines using three or more underscores like so:
+___
+This will never affect the indentation level of the following text, but it will immediately
+terminate the paragraph which is why this is a new paragraph despite the absence of two (or more)
+consective new lines.
+
  ** Links
     We borrow the basic link syntax from markdown: `[link text](link source)`
     Here are some example which also show you a special list kind for links:

--- a/docs/NFF-0.1-spec.md
+++ b/docs/NFF-0.1-spec.md
@@ -807,6 +807,18 @@ This text belongs to the root of the document
 - Text that belongs and doesn't belong to the heading is easier to distinguish, especially if you have headings that span over a few screens in your neovim session.
   It can give you insight into the document's structure at a glance.
 
+#### Horizontal Lines
+There is one more delimiting modifier: the horizontal line. It looks like this: `___` (or any higher number of underscores).
+This modifier will get rendered as a horizontal line and as such is equivalent to Markdown's `---` syntax.
+Note, that this modifier does *NOT* affect the indentation of the following paragraphs!
+If you want to also change the heading level you should combine this with one of the aforementioned delimiting modifiers.
+It does however immediately terminate the current paragraph resulting in the following:
+```
+This is a paragraph.
+___
+This is an entirely different paragraph despite of the absence of two (or more) consecutive new lines because of the `___` delimiter.
+```
+
 # Data Tags
 Neorg provides several inbuilt data tags to represent different things. Those exact things will be detailed here:
 - `@document.meta` - describes metadata about the document. Attributes are stored as key-value pairs. Values may have

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -263,6 +263,7 @@ module.config.public = {
 
         StrongParagraphDelimiter = "+TSPunctDelimiter",
         WeakParagraphDelimiter = "+TSPunctDelimiter",
+        HorizontalLine = "+TSPunctDelimiter",
     },
 
     dim = {

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -370,6 +370,18 @@ module.config.public = {
                     }
                 end,
             },
+
+            horizontal_line = {
+                enabled = true,
+                icon = "─",
+                highlight = "NeorgHorizontalLine",
+                query = "(horizontal_line) @icon",
+                render = function(self, text)
+                    return {
+                        { string.rep(self.icon, vim.api.nvim_win_get_width(0)), self.highlight },
+                    }
+                end,
+            },
         },
     },
 

--- a/queries/norg/highlights.scm
+++ b/queries/norg/highlights.scm
@@ -159,3 +159,4 @@
 ; Paragraph Delimiters
 (strong_paragraph_delimiter) @NeorgStrongParagraphDelimiter
 (weak_paragraph_delimiter) @NeorgWeakParagraphDelimiter
+(horizontal_line) @NeorgHorizontalLine


### PR DESCRIPTION
Adds the horizontal line delimiting modifier, `___`, as discussed over on discord:
![screenshot_1632590239](https://user-images.githubusercontent.com/21973473/134780431-4ed5ebc5-c242-4b8d-a561-afa27c3a85e6.png)

:warning: depends on https://github.com/nvim-neorg/tree-sitter-norg/pull/16