### PR TITLE
fix(modules): pass custom config to load_module

### DIFF
--- a/lua/neorg.lua
+++ b/lua/neorg.lua
@@ -82,9 +82,9 @@ function neorg.org_file_entered(manual, arguments)
     end
 
     -- After all configurations are merged proceed to actually load the modules
-    for name, _ in pairs(module_list) do
+    for name, module in pairs(module_list) do
         -- If it could not be loaded then halt
-        if not neorg.modules.load_module(name) then
+        if not neorg.modules.load_module(name, module.config) then
             log.fatal("Halting loading of modules due to error...")
             break
         end

--- a/lua/neorg/modules/core/keybinds/default_keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/default_keybinds.lua
@@ -1,9 +1,11 @@
 local module = neorg.modules.extend("core.keybinds")
 
 module.public = {
-    generate_keybinds = function()
+    generate_keybinds = function(neorg_leader)
         local neorg_callbacks = require("neorg.callbacks")
-        local neorg_leader = module.config.public.neorg_leader
+        if not neorg_leader then
+            neorg_leader = module.config.public.neorg_leader
+        end
 
         neorg_callbacks.on_event("core.keybinds.events.enable_keybinds", function(_, keybinds)
             -- Map all the below keybinds only when the "norg" mode is active

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -28,7 +28,7 @@ module.load = function()
     module.required["core.autocommands"].enable_autocommand("BufLeave")
 
     if module.config.public.default_keybinds then
-        module.public.generate_keybinds()
+        module.public.generate_keybinds(module.config.public.neorg_leader)
     end
 end
 


### PR DESCRIPTION
I found a bug related to custom module config loading. Looks it doesn't work as expected

Another bug I've found is that neorg leader is not passed to `default_keybinds.lua`. It always loads default value (I can't say why, but looks lua saves reference to module.config.public on module load and doesn't use it's updated version). main branch doesn't have this problem because it uses `neorg_leader` as argument.