### PR TITLE
feat(ui): fold shows heading icons

### DIFF
--- a/lua/neorg/external/helpers.lua
+++ b/lua/neorg/external/helpers.lua
@@ -5,6 +5,23 @@
 
 neorg.utils = {
 
+  ---Render folded text.
+  ---Support showing heading icons
+  ---@return string
+  foldtext = function ()
+    local line = vim.fn.getline(vim.v.foldstart)
+    local _, count = string.gsub(line, "%*", "")
+    if count ~= 0 then
+      local config = require("neorg.modules.core.norg.concealer.module").config.public.icons.heading
+      local icon = config["level_" .. count].icon
+      line = line:gsub(("%*"):rep(count), icon)
+    end
+
+    local res = line:gsub([[\\t]], ([[\ ]]):rep(vim.o.tabstop)) .. " …"
+
+    return res
+  end,
+
     -- @Summary Gets the current system username
     -- @Description An OS agnostic way of querying the current user
     get_username = function()

--- a/lua/neorg/modules/core/norg/esupports/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/module.lua
@@ -1017,6 +1017,7 @@ module.on_event = function(event)
             if module.config.public.folds.enabled then
                 vim.opt_local.foldmethod = "expr"
                 vim.opt_local.foldexpr = "nvim_treesitter#foldexpr()"
+                vim.opt_local.foldtext = "v:lua.neorg.utils.foldtext()"
                 vim.opt_local.foldlevel = module.config.public.folds.foldlevel
             end
         end


### PR DESCRIPTION
### Purpose

Keep showing user customized heading icons in folds.

![Screen Shot 2021-10-13 at 3 23 39 AM](https://user-images.githubusercontent.com/65782666/137046417-2e726b53-d517-4771-9402-069e5ff9c195.png)

To achive same results:

~~~lua
vim.cmd[[hi Folded gui=bold guibg=NONE]]
vim.cmd[[set fillchars+=fold:\ ]]
~~~