### PR TITLE
Fix workspace matching

### DIFF
--- a/lua/neorg/modules/core/norg/dirman/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/module.lua
@@ -202,8 +202,8 @@ module.public = {
         -- Find a matching workspace
         for workspace, location in pairs(module.config.public.workspaces) do
             if workspace ~= "default" then
-                -- Expand all special symbols like ~ etc.
-                local expanded = vim.fn.expand(location)
+                -- Expand all special symbols like ~ etc. and escape special characters
+                local expanded = string.gsub(vim.fn.expand(location), "%p", "%%%1")
 
                 -- If the workspace location is a parent directory of our current realcwd
                 -- or if the ws location is the same then set it as the real workspace


### PR DESCRIPTION
This is similar to 76a621f00b8f631879dd7b75d63c788b40171764.  Get_workspace_match is unable to match 
workspace directories containing special characters.  In my case, its hyphens.