### PR TITLE
docs: update README regarding lazyload

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,29 @@ You can install through any plugin manager (it can even be vimscript plugin mana
   Here's an example:
 
   ```lua
-  use { "nvim-neorg/neorg", ft = "norg", config = ... }
+  use {
+    "nvim-neorg/neorg", 
+    -- in case you turn off filetype detection when startup neovim
+    setup = vim.cmd("autocmd BufRead,BufNewFile *.norg setlocal filetype=norg"),
+    ft = "norg",
+    config = function()
+      local loader = require"packer".loader
+      -- lazy load treesitter
+      if not packer_plugins['nvim-treesitter'].loaded then
+        loader("nvim-treesitter")
+      end
+      -- lazy load other modules, e.g. telescope etc
+      ...
+      -- setup neorg
+      require('neorg').setup {
+        ...
+      }
+
+    end
+  }
   ```
 
-  However don't expect everything to work. TreeSitter highlights are known to fail, amongst other things.
+  However, don't expect everything to work. You might need additional setups depending on how your lazyloading system is configured.
   Neorg practically lazy loads itself - only a few lines of code are run on startup, these lines check whether the current
   extension is `.norg`, if it's not then nothing else loads. You shouldn't have to worry about performance issues.
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ You can install through any plugin manager (it can even be vimscript plugin mana
   ```lua
   use {
     "nvim-neorg/neorg", 
-    -- in case you turn off filetype detection when startup neovim
+    -- in case you turn off filetype detection when startup neovim, or ft detection failure for norg
     setup = vim.cmd("autocmd BufRead,BufNewFile *.norg setlocal filetype=norg"),
     ft = "norg",
     config = function()

--- a/README.md
+++ b/README.md
@@ -166,18 +166,12 @@ You can install through any plugin manager (it can even be vimscript plugin mana
 
   ```lua
   use {
-    "nvim-neorg/neorg", 
+    "nvim-neorg/neorg",
     -- in case you turn off filetype detection when startup neovim, or ft detection failure for norg
     setup = vim.cmd("autocmd BufRead,BufNewFile *.norg setlocal filetype=norg"),
+    after = {"nvim-treesitter"},  -- you may also specify telescope
     ft = "norg",
     config = function()
-      local loader = require"packer".loader
-      -- lazy load treesitter
-      if not packer_plugins['nvim-treesitter'].loaded then
-        loader("nvim-treesitter")
-      end
-      -- lazy load other modules, e.g. telescope etc
-      ...
       -- setup neorg
       require('neorg').setup {
         ...
@@ -201,7 +195,7 @@ You can install through any plugin manager (it can even be vimscript plugin mana
    ```
    
    Afterwards resource the current file and to install plugins run `:PlugInstall`.
-   
+
    You can put this initial configuration in your init.vim file:
    ```vim
    lua << EOF


### PR DESCRIPTION
To allow lazy load work, might need to 
1) add filetype `neorg` (if init.lua set syntex&filetype detection to be off when launch neovim, or, in any case nvim failed to detect filetype for `neorg`)
2) manually load `treesitter` before setup `neorg`

I think this would solve most problems related to lazy loading. But please comment on if it still failed to work.