### PR TITLE
add zettelkasten module

### DIFF
--- a/lua/neorg/modules/core/keybinds/default_keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/default_keybinds.lua
@@ -32,6 +32,11 @@ module.public = {
 
                     { "<M-k>", "core.norg.manoeuvre.item_up" },
                     { "<M-j>", "core.norg.manoeuvre.item_down" },
+
+                    -- Key for managing zettelkasten
+                    { neorg_leader .. "zn", "core.zettelkasten.zettel.new" },
+                    { neorg_leader .. "zr", "core.zettelkasten.edit.random" },
+                    { neorg_leader .. "zi", "core.zettelkasten.edit.id" },
                 },
 
                 i = {

--- a/lua/neorg/modules/core/norg/dirman/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/module.lua
@@ -272,9 +272,20 @@ module.public = {
     -- @Summary Creates a new Neorg file
     -- @Description Takes in a path (can include directories) and creates a .norg file from that path
     -- @Param  path (string) - a path to place the .norg file in
-    create_file = function(path)
+    create_file = function(path, workspace)
         -- Grab the current workspace's full path
-        local fullpath = module.public.get_current_workspace()[2]
+        -- Taken form #182 Journal PR
+        local fullpath
+        if workspace ~= nil then
+            fullpath = module.public.get_workspace(workspace)
+        else
+            fullpath = module.public.get_current_workspace()[2]
+        end
+
+        if fullpath == nil then
+            log.error("Error in fetching workspace path")
+            return
+        end
 
         -- Split the path at every /
         local split = vim.split(vim.trim(path), "/", true)
@@ -515,6 +526,7 @@ module.on_event = function(event)
     if event.type == "core.keybinds.events.core.norg.dirman.new.note" then
         module.required["core.ui"].create_prompt("NeorgNewNote", "New Note: ", function(text)
             -- Create the file that the user has entered
+            print(text)
             module.public.create_file(text)
         end, {
             center_x = true,

--- a/lua/neorg/modules/core/zettelkasten/module.lua
+++ b/lua/neorg/modules/core/zettelkasten/module.lua
@@ -1,0 +1,239 @@
+--[[
+File: zettelkasten_module
+Title: Zettelkasten module for neorg
+Summary: Easily work with for a zettelkasten
+---
+
+How to use this module:
+This module creates a couple of commands.
+- `Neorg zettel new` create a new zettel
+- `Neorg zettel random` edit a random zettel
+--]]
+
+require("neorg.modules.base")
+
+local module = neorg.modules.create("core.zettelkasten")
+local log = require("neorg.external.log")
+
+module.setup = function()
+    return {
+        success = true,
+        requires = {
+            "core.norg.dirman",
+            "core.keybinds",
+            "core.ui",
+            "core.neorgcmd",
+        },
+    }
+end
+
+module.private = {
+    create_charset = function()
+        local charset = {}
+        do -- [0-9a-zA-Z]
+            for c = 48, 57 do
+                table.insert(charset, string.char(c))
+            end
+            for c = 65, 90 do
+                table.insert(charset, string.char(c))
+            end
+            for c = 97, 122 do
+                table.insert(charset, string.char(c))
+            end
+        end
+        return charset
+    end,
+
+    random_prefix = function(length)
+        math.randomseed(os.clock() ^ 5)
+        local res = ""
+        for _ = 1, length do
+            res = res .. module.config.private.charset[math.random(1, #module.config.private.charset)]
+        end
+        return res
+    end,
+
+    timestamp = function()
+        -- Format date as YYYYMMDDHHMM
+        return os.date("%Y%m%d%H%M")
+    end,
+
+    unix_timestamp = function()
+        return os.time(os.date("!*t"))
+    end,
+
+    -- Write a very basic template to the end of the file. This is only save, if the file is newly created.
+    inject_template = function(opts)
+        local template = module.config.public.template
+
+        local result = {}
+        for _, data in ipairs(template) do
+            table.insert(result, data[1] .. tostring(type(data[2]) == "function" and data[2](opts) or data[2]))
+        end
+
+        vim.api.nvim_buf_set_lines(0, -1, -1, false, result)
+    end,
+}
+
+module.config.public = {
+    -- Workspace name to use for gtd related lists
+    workspace = "default",
+
+    -- Choose from "random", "unix", "timestamp"
+    id_generator = "timestamp",
+
+    template = {
+        {
+            "* ",
+            function(opts)
+                return opts.title
+            end,
+        },
+        { "", "" },
+        { "* Related", "" },
+        { "", "" },
+        { "* Further Reading", "" },
+        { "", "" },
+        { "* References", "" },
+    },
+}
+
+module.config.private = {
+    id_fn = nil,
+
+    -- Used to generate random characters for prefixes
+    charset = module.private.create_charset(),
+}
+
+module.load = function()
+    -- Choose prefix functions
+    if module.config.public.id_generator == "random" then
+        module.config.private.id_fn = module.private.random_prefix
+    elseif module.config.public.id_generator == "unix" then
+        module.config.private.id_fn = module.private.unix_timestamp
+    elseif module.config.public.id_generator == "timestamp" then
+        module.config.private.id_fn = module.private.timestamp
+    else
+        error("Unknown prefix function")
+    end
+
+    module.required["core.keybinds"].register_keybinds(module.name, { "zettel.new", "edit.random", "edit.id" })
+
+    -- Add neorgcmd capabilities
+    -- All zettelkasten commands start with :Neorg zettel ...
+    module.required["core.neorgcmd"].add_commands_from_table({
+        definitions = {
+            zettel = {
+                new = {},
+                edit = {
+                    random = {},
+                    id = {},
+                },
+            },
+        },
+        data = {
+            zettel = {
+                args = 1,
+                subcommands = {
+                    new = { args = 0, name = "zettelkasten.zettel.new" },
+                    edit = {
+                        subcommands = {
+                            random = { args = 0, name = "zettelkasten.edit.random" },
+                            id = { args = 1, name = "zettelkasten.edit.id" },
+                        },
+                    },
+                },
+            },
+        },
+    })
+end
+
+module.on_event = function(event)
+    if vim.tbl_contains({ "core.keybinds", "core.neorgcmd" }, event.split_type[1]) then
+        if vim.tbl_contains({ "zettelkasten.zettel.new", "core.zettelkasten.zettel.new" }, event.split_type[2]) then
+            module.required["core.ui"].create_prompt("NeorgNewZettel", "Zettel Title: ", function(title)
+                module.public.create_zettel(title)
+            end, {
+                center_x = true,
+                center_y = true,
+            }, {
+                width = 50,
+                height = 1,
+                row = 10,
+                col = 0,
+            })
+        elseif
+            vim.tbl_contains({ "zettelkasten.edit.random", "core.zettelkasten.edit.random" }, event.split_type[2])
+        then
+            module.public.open_random_zettel()
+        elseif vim.tbl_contains({ "zettelkasten.edit.id" }, event.split_type[2]) then
+            module.public.open_zettel_by_id(event.content[1])
+        elseif vim.tbl_contains({ "core.zettelkasten.edit.id" }, event.split_type[2]) then
+            -- TODO: Would be nice to use a (telescope) picker here instead
+            module.required["core.ui"].create_prompt("NeorgEditId", "Zettel id: ", function(id)
+                module.public.open_zettel_by_id(id)
+            end, {
+                center_x = true,
+                center_y = true,
+            }, {
+                width = 50,
+                height = 1,
+                row = 10,
+                col = 0,
+            })
+        end
+    end
+end
+
+module.public = {
+    version = "0.0.1",
+
+    create_zettel = function(title)
+        -- Generate id/prefix
+        local prefix = module.config.private.id_fn()
+
+        -- Remove leading and trailing whitespace
+        local stripped_title = string.lower(string.gsub(title, "^%s*(.-)%s*$", "%1"))
+        local filename = string.format("%s-%s", prefix, string.gsub(stripped_title, "%s+", "-"))
+
+        -- Create file
+        module.required["core.norg.dirman"].create_file(filename, module.config.public.workspace)
+
+        module.private.inject_template({ title = title })
+    end,
+
+    open_zettel_by_id = function(id)
+        local zettels = module.required["core.norg.dirman"].get_norg_files(module.config.public.workspace)
+
+        for _, zettel in ipairs(zettels) do
+            -- TODO: Can they have a path prefix, which I should remove?
+            local zid, _ = string.match(zettel, "([^-]+)-(.*).norg")
+
+            if zid == id then
+                module.required["core.norg.dirman"].create_file(zettel, module.config.public.workspace)
+                break
+            end
+        end
+    end,
+
+    open_random_zettel = function()
+        local zettels = module.required["core.norg.dirman"].get_norg_files(module.config.public.workspace)
+        local random_zettel = zettels[math.random(#zettels)]
+        module.required["core.norg.dirman"].open_file(module.config.public.workspace, random_zettel)
+    end,
+}
+
+module.events.subscribed = {
+    ["core.keybinds"] = {
+        ["core.zettelkasten.zettel.new"] = true,
+        ["core.zettelkasten.edit.random"] = true,
+        ["core.zettelkasten.edit.id"] = true,
+    },
+    ["core.neorgcmd"] = {
+        ["zettelkasten.zettel.new"] = true,
+        ["zettelkasten.edit.random"] = true,
+        ["zettelkasten.edit.id"] = true,
+    },
+}
+
+return module


### PR DESCRIPTION
Don't get to exited this is not even alpha yet ;-)

I've mostly been trying to get familiar with neorg and the codebase, and put some things in place which will be needed in some for or the other. So basic creation of a new zettel is implemented and opening a zettel with a known id or a random is. Nothing more.

There are many areas which would need work. This is just a very rough summary of what has been discussed on discord the last couple of minutes:

- Goals
  - Links
    Links should use topic (first heading1?) as link text
    - Follow
       - follow links (already implemented in neorg)
       - splits
       - directly
    - Completion
      - get completion for links to other zettels
       - by name (topic?)
       - zettel number
    - Preview
      - allow to preview other zettels
      - just preview document.meta `description|
      - split
      - float
      - virtual text?
    - Backlinks
      There must a way of *automatic| backlinking:
     - In zettel **a** you create a link to zettel **b** > in zettel **b**< there will be a subsection `backlinks| with a link to $a|
  - Tags
   Use the categories from the document.meta
    - Searching, allow searching by categories
    - Quick adding, provide a quick way to add categories to a Zettel

- Structure
  - Zettel
    - Document meta
    -- Categories: used to search
    -- description: can be displayed for links
    - Heading 1: is used as title for zettel (link text)
    - Actual text
    - Backlinks
  - Zettelkasten
    - all the zettels, can be in folders
    - and index file with all zettels listed
    - file where zettels are sorted with categories
    - what do we do with zettels with multiple categories?

- Implementation Ideas
  - Linking
    - Database
      - sqlite.nvim
      - real database like org-roam v2
