### PR TITLE
feat: add callback for completions

### DIFF
--- a/lua/neorg/modules/core/norg/completion/module.lua
+++ b/lua/neorg/modules/core/norg/completion/module.lua
@@ -249,7 +249,9 @@ module.public = {
         -- Loop through every completion
         for _, completion_data in ipairs(completions) do
             -- Construct a variable that will be returned on a successful match
-            local ret_completions = { items = completion_data.complete, options = completion_data.options or {} }
+            local items = type(completion_data.complete) == "table"
+                and completion_data.complete or completion_data.complete(context, prev, saved)
+            local ret_completions = { items = items, options = completion_data.options or {} }
 
             -- If the completion data has a regex variable
             if completion_data.regex then


### PR DESCRIPTION
I'd like to enable completion for project tags for this [extension](https://github.com/esquires/neorg-gtd-project-tags) where the set of completions updates changes depending on changes that are made after load time (e.g., a user adds another project/subproject tag).  This small PR enables that to happen. You can see its use in the `add-completion` branch of the extension [here](https://github.com/esquires/neorg-gtd-project-tags/blob/add-completion/lua/neorg/modules/utilities/gtd-project-tags/module.lua#L34)