### PR TITLE
docs: update readme to mention regex fallback for codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ and chat there.
 # :camera: Extra GIFs
 ### Language Injection
 Get syntax highlighting for any language supported by NeoVim.
-Neorg will use treesitter first, falling back to Vim regex for languages not supported by treesitter seemlessly.
+Neorg will use treesitter first, falling back to Vim regex for languages not supported by treesitter seamlessly.
 
 ![Injection](https://user-images.githubusercontent.com/13149513/125274035-5f7e1a80-e32f-11eb-8de3-060b6e752185.gif)
 

--- a/README.md
+++ b/README.md
@@ -411,7 +411,8 @@ and chat there.
 
 # :camera: Extra GIFs
 ### Language Injection
-Get syntax highlighting for any language that's supported by treesitter.
+Get syntax highlighting for any language supported by NeoVim.
+Neorg will use treesitter first, falling back to Vim regex for languages not supported by treesitter seemlessly.
 
 ![Injection](https://user-images.githubusercontent.com/13149513/125274035-5f7e1a80-e32f-11eb-8de3-060b6e752185.gif)
 


### PR DESCRIPTION
Didn't see this changed yet, felt it was important to mention