### PR TITLE
Footnotes

### DIFF
--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -267,81 +267,99 @@ consective new lines.
     There are two kinds of defintions:
 
   *** Single-paragraph definitions
+      @code norg
+      $ Object to be defined
+      @end
       $ Object to be defined
       The definition of the object in a single paragraph.
-
+      
       This is already the next paragraph.
-
+      
   *** Multi-paragraph definitions
+      @code norg
+      $$ Object to be defined
+      @end
       $$ Object to be defined
       Here, I can place any number of paragraphs or other format objects.
-
+      
       Even a code example:
       @code lua
       print("Hello world!")
       @end
       $$
+      @code
+      $$
+      @end
       This is no longer part of the definition because the `$$` on the previous line marked its end.
-
+      
  ** Footnotes
     There are also two kinds of footnotes:
-
+      
   *** Single-paragraph footnotes
+      @code norg
+      ^ This is the title of my footnote. I can use this as a link target.
+      @end
       ^ This is the title of my footnote. I can use this as a link target.
       This is the actual footnote content.
-
+      
       This is no longer part of the footnote.
-
+      
   *** Multi-paragraph footnotes
+      @code norg
+      ^^ This is a multi-paragraph footnote.
+      @end
       ^^ This is a multi-paragraph footnote.
       Here go the actual contents...
-
+      
       ... which I can even continue down here.
       ^^
+      @code norg
+      ^^
+      @end
       Now, the footnote has ended.
-
+      
  ** Data Tags
     Neorg supports a number of tags. The general format is:
     @data possible parameters
     contents
     @end
-
+      
   *** Carryover
       There is also an infectious carryover variant which allows shorter syntax. Its format is:
       `#data possible parameters`, which will apply the `data` tag *only* to the following
       paragraph or element.
-
+      
   *** Comments
       #comment
       This is a comment.
       This is also still a comment because the paragraph has not ended, yet.
-
+      
       The double line break ended the paragraph so this is no longer part of the comment.
-
+      
       Note, that you can also add in-line comments using the `#`-attached modifier. #E.g. like this#
-
+      
   *** Name
       #name quotes
       > This is a quote.
       > We can talk about anything we like
-
+      
       This quote now has a /name/!
-
+      
   *** List ordering
       You can affect ordered lists and specify their /start/, /step/ and /spacing/ values (all of
       them default to 1).
-
+      
       #ordered 2 2 2
       ~ First entry
       ~ Second entry
-
+      
       This will render as:
       @code
       2. First entry
       
       4. Second entry
       @end
-
+      
   *** Tables
       @table
       Column 1 | Column 2
@@ -349,30 +367,30 @@ consective new lines.
       This is in a new row | which got separated by a horizontal line
       And check this out: I can span the columns!
       @end
-
+      
       Tables will become OP in the future!
-
+      
   *** Code Blocks
       @code
       console.log("But I want syntax highlighting...")
       @end
-
+      
       @code javascript
       console.log("Thank you!")
       @end
-
+      
   *** Media
       You can embed images directly in base64 format like so:
       @image png svg jpeg jfif exif
       <base64-encoded image data>
       @end
       Obviously you need to pick one of the available formats.
-
+      
       You can embed external image or video files like so:
       @embed image
       https://github.com/vhyrro/neorg/blob/main/res/neorg.svg
       @end
-
+      
   *** Math
       There are two ways of typesetting mathematics:
       ~ Inline mathematics using the `$` attached modifier like so: $f(x) = y$.
@@ -382,36 +400,36 @@ consective new lines.
       @end
       A `numbered` carryover tag in a similar vain to the `ordered` one for lists is planned to add
       easy equation numbering support.
-
+      
  ** Advanced markup
     There are some more advanced markup features:
-
+      
   *** The Link modifier
       If you want to mark-up text which is not surrounded by punctuation or whitespace, you need to
       use the *link* modifier, `:`, like so:
-
+      
       W:*h*:y w:/oul/:d a:_nyon_:e w:-an-:t to do t:`hi`:s?
-
+      
   *** Nested markup
       You can nest multiple markup groups to combine their effect. Some examples:
       - *Text can be bold _and underlined_!*
       - You can create ,/italic subscripts/,.
       - If you want to shout in the internet, use */_DOUBLY EMPHASIZED AND UNDERLINED CAPS_/*
-
+      
       Note: You can:*not* combine sub- and superscripts like so:
       @code norg
       ^,This should be super- and subscript.,^ Why though?
       @end
       You will notice that this get's highlighted as an error:
       ^,This should be super- and subscript.,^
-
+      
   *** Object continuation
       The `~` trailing modifier causes the line break to be ignored. This allows you to do things
       like this:
-
+      
    **** This is a super duper long heading which I am so proud of and I absolutely cannot shorten~
         to fit onto a single line
-
+      
   *** Variables
       You can define variables which you can access later in your document like so:
       @code norg
@@ -422,7 +440,7 @@ consective new lines.
       @code norg
       Insert my =variable=.
       @end
-
+      
   *** Insertions
       These are dynamically expanded objects which you can add to your document.
       The simplest example of an insertion is the /table of contents/ which looks like
@@ -431,6 +449,6 @@ consective new lines.
       @end
       This shows the basic syntax `= <capitalized insertion name> <arguments>` and it also explains
       why {# Variables} have to be lowercased.
-
+      
 #comment
 vim:tw=100:ft=norg:norl:

--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -157,7 +157,7 @@ consective new lines.
       - `| Marker`
       - `> Quote` (+ nesting levels)
       - `^ Footnote`
-      - `$ Definiton`
+      - `$ Definition`
       - `# magic` (any of the above)
       - `:path:# magic` (target in another norg file at a given path)
       - `:path:` (another norg file at a given path without specific target)
@@ -251,6 +251,23 @@ consective new lines.
       @end
       $$
       This is no longer part of the definition because the `$$` on the previous line marked its end.
+
+ ** Footnotes
+    There are also two kinds of footnotes:
+
+  *** Single-paragraph footnotes
+      ^ This is the title of my footnote. I can use this as a link target.
+      This is the actual footnote content.
+
+      This is no longer part of the footnote.
+
+  *** Multi-paragraph footnotes
+      ^^ This is a multi-paragraph footnote.
+      Here go the actual contents...
+
+      ... which I can even continue down here.
+      ^^
+      Now, the footnote has ended.
 
  ** Data Tags
     Neorg supports a number of tags. The general format is:

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -85,7 +85,13 @@ module.config.public = {
             [""] = "+TSPunctDelimiter",
             End = "+TSPunctDelimiter",
             Title = "+TSStrong",
-            -- TODO: figure out odd highlighting of ranged tag when using TSNone
+            Content = "+TSEmphasis",
+        },
+
+        Footnote = {
+            [""] = "+TSPunctDelimiter",
+            End = "+TSPunctDelimiter",
+            Title = "+TSStrong",
             Content = "+TSEmphasis",
         },
 

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -1553,6 +1553,29 @@ Note: this will produce icons like `1.)`, `2.)`, etc.
             },
         },
 
+        footnote = {
+            enabled = true,
+
+            single = {
+                enabled = true,
+                icon = "†",
+                highlight = "NeorgFootnote",
+                query = "(single_footnote_prefix) @icon",
+            },
+            multi_prefix = {
+                enabled = true,
+                icon = "‡ ",
+                highlight = "NeorgFootnote",
+                query = "(multi_footnote_prefix) @icon",
+            },
+            multi_suffix = {
+                enabled = true,
+                icon = "‡ ",
+                highlight = "NeorgFootnote",
+                query = "(multi_footnote_suffix) @icon",
+            },
+        },
+
         delimiter = {
             enabled = true,
 

--- a/lua/neorg/modules/core/norg/concealer/preset_diamond.lua
+++ b/lua/neorg/modules/core/norg/concealer/preset_diamond.lua
@@ -30,10 +30,19 @@ module.config.private.icon_preset_diamond = {
     },
 
     marker = {
-        enabled = true,
         icon = "",
-        highlight = "NeorgMarker",
-        query = "(marker_prefix) @icon",
+    },
+
+    footnote = {
+        single = {
+            icon = "⁎",
+        },
+        multi_prefix = {
+            icon = "⁑ ",
+        },
+        multi_suffix = {
+            icon = "⁑ ",
+        },
     },
 }
 

--- a/lua/neorg/modules/core/norg/concealer/preset_varied.lua
+++ b/lua/neorg/modules/core/norg/concealer/preset_varied.lua
@@ -28,6 +28,18 @@ module.config.private.icon_preset_varied = {
             icon = "⤷",
         },
     },
+
+    footnote = {
+        single = {
+            icon = "🦶",
+        },
+        multi_prefix = {
+            icon = "👣 ",
+        },
+        multi_suffix = {
+            icon = "👣 ",
+        },
+    },
 }
 
 return module

--- a/queries/norg/highlights.scm
+++ b/queries/norg/highlights.scm
@@ -170,6 +170,10 @@
 (single_definition (single_definition_prefix) @NeorgDefinition title: (paragraph_segment) @NeorgDefinitionTitle definition: (_)* @NeorgDefinitionContent)
 (multi_definition (multi_definition_prefix) @NeorgDefinition title: (paragraph_segment) @NeorgDefinitionTitle content: (_)* @NeorgDefinitionContent end: (multi_definition_suffix) @NeorgDefinitionEnd)
 
+; Footnotes
+(single_footnote (single_footnote_prefix) @NeorgFootnote title: (paragraph_segment) @NeorgFootnoteTitle content: (_)* @NeorgFootnoteContent)
+(multi_footnote (multi_footnote_prefix) @NeorgFootnote title: (paragraph_segment) @NeorgFootnoteTitle content: (_)* @NeorgFootnoteContent end: (multi_footnote_suffix) @NeorgFootnoteEnd)
+
 ; Escape sequences (\char)
 (escape_sequence) @NeorgEscapeSequence
 


### PR DESCRIPTION
Add highlights + concealing for footnotes.

## Basic preset (default)
![screenshot_1639930144](https://user-images.githubusercontent.com/21973473/146682003-d27db42e-9534-4fe6-9684-77cf447c5316.png)

## Diamond preset
![screenshot_1639930159](https://user-images.githubusercontent.com/21973473/146682009-c0b3e6d3-0463-447f-9419-0e04df261b17.png)
(should we switch this and basic? This is more round and might fit the round heading icons of the basic preset better..)

## Varied preset
![screenshot_1639930171](https://user-images.githubusercontent.com/21973473/146682016-64257b62-8fbb-473b-b368-454572bf2626.png)
(just for the jokes I'm open to suggestions :sweat_smile:)