### PR TITLE
fix check for no data

### DIFF
--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -577,7 +577,7 @@ module.private = {
     goto_node = function()
         local data = module.private.get_by_var()
 
-        if not data then
+        if data == nil or #data == 0 then
             return
         end
 


### PR DESCRIPTION
get_by_var can return either {} or nil. Prior to this pull request the if statement could pass when `data == {}`