### PR TITLE
move ret_completions after check for match

### DIFF
--- a/lua/neorg/modules/core/norg/completion/module.lua
+++ b/lua/neorg/modules/core/norg/completion/module.lua
@@ -241,7 +241,6 @@ module.public = {
 
         -- Loop through every completion
         for _, completion_data in ipairs(completions) do
-
             -- If the completion data has a regex variable
             if completion_data.regex then
                 -- Attempt to match the current line before the cursor with that regex

--- a/lua/neorg/modules/core/norg/completion/module.lua
+++ b/lua/neorg/modules/core/norg/completion/module.lua
@@ -241,10 +241,6 @@ module.public = {
 
         -- Loop through every completion
         for _, completion_data in ipairs(completions) do
-            -- Construct a variable that will be returned on a successful match
-            local items = type(completion_data.complete) == "table" and completion_data.complete
-                or completion_data.complete(context, prev, saved)
-            local ret_completions = { items = items, options = completion_data.options or {} }
 
             -- If the completion data has a regex variable
             if completion_data.regex then
@@ -253,6 +249,11 @@ module.public = {
 
                 -- If our match was successful
                 if match then
+                    -- Construct a variable that will be returned on a successful match
+                    local items = type(completion_data.complete) == "table" and completion_data.complete
+                        or completion_data.complete(context, prev, saved)
+                    local ret_completions = { items = items, options = completion_data.options or {} }
+
                     -- Set the match variable for the integration module
                     ret_completions.match = match
 


### PR DESCRIPTION
Neorg had slowed down a lot for me recently. This fixed the slowdown I observed (it was calling [this function](https://github.com/esquires/neorg-gtd-project-tags/blob/master/lua/neorg/modules/utilities/gtd-project-tags/module.lua#L41) in [gtd-project-tags](https://github.com/esquires/neorg-gtd-project-tags) every time text changed).

Prior to this commit, when completion_data.complete was a function it would be called every time text was changed. This calculation is unnecessary though when the regex does not match.

Related to #233 