### PR TITLE
Unprocessed tasks logic

### DIFF
--- a/doc/gtd.norg
+++ b/doc/gtd.norg
@@ -232,10 +232,11 @@
 
    **** Changes from base GTD
     ***** Inbox list
-          There is not concept of a inbox list. However, we have what we call `Unclarified` tasks
-          and projects. 
-          - For a task to be processed, it should require at minima 1 context.
-          - For a project to be processed, it should require at minima 1 task.
+          The inbox list is a set of all tasks and projects that are:
+          - In the inbox list (default: `inbox.norg` file)
+          - /Unclarified/, and not in inbox list
+          -- For a task to be clarified, it should require at minima 1 context.
+          -- For a project to be clarified, it should require at minima 1 task.
     ***** Context Lists
           There is no concept of context lists. Instead there are tags, e.g. `#contexts home`.
           Special contexts:

--- a/doc/gtd.norg
+++ b/doc/gtd.norg
@@ -25,6 +25,8 @@
 -- {# Projects management}:
 --- Added specs for projects
 --- Changed syntax
+- 15/01/2022:
+-- Added {# Inbox list}
 
 
 | *Disclaimers*:
@@ -66,7 +68,6 @@
   *** Top-level organization
 
       This is the proposed approach which is directly related to {# Organize}.
-      - The inbox file is at the root of the workspace.
       - Every `.norg` file is just a placeholder.
       - The workspace allows an unlimited amount of nested folders, but they mean nothing except the
         meaning the user wants for them.
@@ -75,7 +76,6 @@
 
       @code
           .
-          ├── inbox.norg
           ├── index.norg
           ├── reference
           │   └── next_house.norg
@@ -89,7 +89,6 @@
 
       @code
           .
-          ├── inbox.norg
           ├── active_projects.norg
           ├── next_actions.norg
           └── someday_maybe.norg
@@ -171,9 +170,8 @@
       This is the first stage of GTD, and it involves placing all ideas/things to do/notes/reminders
       in a centralized place, called /Inbox/.
 
-      - The capture file is called `inbox.norg` by default (but could be customized) and is placed at the root of the workspace.
-      - Everything in the Inbox is a task. So if a note is written in the inbox, it'll be
-        interpreted as a task.
+      - Every task is by default created in `index.norg`. For a task to be marked as processed, it
+      is required to have at least one context.
 
    **** Quick capture
         Capturing should not take longer than actually doing the task.
@@ -187,18 +185,16 @@
       This part is what I commonly refer as:
       > Processing the inbox
 
-      It is a set of actions to take in order to process what each task means (and removing it from
-      the inbox in the process). A best practice is to process each task at a time, following a FIFO
+      It is a set of actions to take in order to process what each task means. 
+      A best practice is to process each task at a time, following a FIFO
       convention. We should design the user interaction with that in mind.
 
       We should allow the user to:
-      - Modify/Add fields of the task (this does not mean removing the task from inbox)
+      - Modify/Add fields of the task
       - Delete the task (called *Eliminate*)
       - Move it to the someday/maybe list
       - Make it a reference, removing it from all GTD views and moving it to an external note.
       - Convert it to a project (see {*** Organize})
-
-      A processed task should be deleted from the inbox, and moved to another place (see {# Organize}).
 
   *** Organize
       Where should all processed tasks go?
@@ -235,6 +231,11 @@
         That means it is the work we could do now.
 
    **** Changes from base GTD
+    ***** Inbox list
+          There is not concept of a inbox list. However, we have what we call `Unprocessed` tasks
+          and projects. 
+          - For a task to be processed, it should require at minima 1 context.
+          - For a project to be processed, it should require at minima 1 task.
     ***** Context Lists
           There is no concept of context lists. Instead there are tags, e.g. `#contexts home`.
           Special contexts:
@@ -253,7 +254,7 @@
    **** Daily review
         The daily review is a process of shallowly reviewing:
         - What's been done yesterday
-        - What's in the inbox
+        - What's in the inbox (unprocessed tasks and projects)
 
         No user interaction per se is necessary for this part.
 

--- a/doc/gtd.norg
+++ b/doc/gtd.norg
@@ -232,7 +232,7 @@
 
    **** Changes from base GTD
     ***** Inbox list
-          There is not concept of a inbox list. However, we have what we call `Unprocessed` tasks
+          There is not concept of a inbox list. However, we have what we call `Unclarified` tasks
           and projects. 
           - For a task to be processed, it should require at minima 1 context.
           - For a project to be processed, it should require at minima 1 task.
@@ -254,7 +254,7 @@
    **** Daily review
         The daily review is a process of shallowly reviewing:
         - What's been done yesterday
-        - What's in the inbox (unprocessed tasks and projects)
+        - What's in the inbox (unclarified tasks and projects)
 
         No user interaction per se is necessary for this part.
 

--- a/lua/neorg/external/helpers.lua
+++ b/lua/neorg/external/helpers.lua
@@ -300,7 +300,7 @@ neorg.lib = {
     --- Iterates over all elements of a table and returns the first value returned by the callback.
     --- @param tbl table #The table to iterate over
     --- @param callback function #The callback function that should be invoked on each iteration.
-    --  Can return a value in which case that value will be returned from the `filter()` call.
+    --- Can return a value in which case that value will be returned from the `filter()` call.
     --- @return any|nil #The value returned by `callback`, if any
     filter = function(tbl, callback)
         for k, v in pairs(tbl) do
@@ -352,6 +352,28 @@ neorg.lib = {
         end
 
         return result
+    end,
+
+    --- Wraps a conditional "not" function in a vim.tbl callback
+    --- @param cb function #The function to wrap
+    --- @vararg ... #The arguments to pass to the wrapped function
+    --- @return function #The wrapped function in a vim.tbl callback
+    wrap_cond_not = function(cb, ...)
+        local params = { ... }
+        return function(v)
+            return not cb(v, unpack(params))
+        end
+    end,
+
+    --- Wraps a conditional function in a vim.tbl callback
+    --- @param cb function #The function to wrap
+    --- @vararg ... #The arguments to pass to the wrapped function
+    --- @return function #The wrapped function in a vim.tbl callback
+    wrap_cond = function(cb, ...)
+        local params = { ... }
+        return function(v)
+            return cb(v, unpack(params))
+        end
     end,
 
     --- Wraps a function in a callback

--- a/lua/neorg/modules/core/gtd/base/module.lua
+++ b/lua/neorg/modules/core/gtd/base/module.lua
@@ -42,10 +42,7 @@ end
 module.config.public = {
     -- Workspace name to use for gtd related lists
     workspace = "default",
-    -- Filenames to use for default lists
-    default_lists = {
-        inbox = "inbox.norg",
-    },
+
     -- You can exclude files or directories from gtd parsing by passing them here (relative file path from workspace root)
     exclude = {},
 

--- a/lua/neorg/modules/core/gtd/base/module.lua
+++ b/lua/neorg/modules/core/gtd/base/module.lua
@@ -46,6 +46,11 @@ module.config.public = {
     -- You can exclude files or directories from gtd parsing by passing them here (relative file path from workspace root)
     exclude = {},
 
+    -- Default lists used for GTD
+    default_lists = {
+        inbox = "inbox.norg"
+    },
+
     -- The syntax to use for gtd.
     syntax = {
         context = "#contexts",

--- a/lua/neorg/modules/core/gtd/base/module.lua
+++ b/lua/neorg/modules/core/gtd/base/module.lua
@@ -48,7 +48,7 @@ module.config.public = {
 
     -- Default lists used for GTD
     default_lists = {
-        inbox = "inbox.norg"
+        inbox = "inbox.norg",
     },
 
     -- The syntax to use for gtd.

--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -77,6 +77,14 @@ module.public = {
                     return t.project_uuid == data.uuid
                 end, tasks)
 
+                if vim.tbl_isempty(project_tasks) then
+                    return false
+                end
+
+                project_tasks = vim.tbl_filter(function(t)
+                    return t.state ~= "done"
+                end, project_tasks)
+
                 return not vim.tbl_isempty(project_tasks)
             end,
         })

--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -73,7 +73,7 @@ module.public = {
                     return
                 end
 
-                local project_tasks = vim.tbl_map(function(t)
+                local project_tasks = vim.tbl_filter(function(t)
                     return t.project_uuid == data.uuid
                 end, tasks)
 

--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -58,7 +58,7 @@ module.public = {
     end,
 
     --- Checks if the data is processed or not.
-    --- Check out :h neorg-gtd to know what is an unprocessed task or project
+    --- Check out :h neorg-gtd to know what is an unclarified task or project
     --- @param data core.gtd.queries.task|core.gtd.queries.project
     --- @param tasks core.gtd.queries.task[]?
     is_processed = function(data, tasks)

--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -65,11 +65,13 @@ module.public = {
         return neorg.lib.match({
             data.type,
             ["task"] = function()
-                return type(data.contexts) == "table" and not vim.tbl_isempty(data.contexts) and not data.inbox
+                return (
+                        type(data.contexts) == "table" and not vim.tbl_isempty(data.contexts)
+                        or (type(data["waiting.for"]) == "table" and not vim.tbl_isempty(data["waiting.for"]))
+                    ) and not data.inbox
             end,
             ["project"] = function()
                 if not tasks then
-                    log.error("No tasks provided")
                     return
                 end
 

--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -53,7 +53,6 @@ module.public = {
     get_gtd_excluded_files = function()
         local gtd_config = module.private.get_gtd_config()
         local res = vim.deepcopy(gtd_config.exclude) or {}
-        table.insert(res, gtd_config.default_lists.inbox)
 
         return res
     end,

--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -75,6 +75,16 @@ module.public = {
                     return
                 end
 
+                -- If the project is in someday, do not count it as unprocessed
+                if
+                    type(data.contexts) == "table"
+                    and not vim.tbl_isempty(data.contexts)
+                    and vim.tbl_contains(data.contexts, "someday")
+                then
+                    return true
+                end
+
+                -- All projects in inbox are unprocessed
                 if data.inbox then
                     return false
                 end
@@ -83,10 +93,12 @@ module.public = {
                     return t.project_uuid == data.uuid
                 end, tasks)
 
+                -- Empty projects (without tasks) are unprocessed
                 if vim.tbl_isempty(project_tasks) then
                     return false
                 end
 
+                -- Do not count done tasks for unprocessed projects
                 project_tasks = vim.tbl_filter(function(t)
                     return t.state ~= "done"
                 end, project_tasks)

--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -65,12 +65,16 @@ module.public = {
         return neorg.lib.match({
             data.type,
             ["task"] = function()
-                return type(data.contexts) == "table" and not vim.tbl_isempty(data.contexts)
+                return type(data.contexts) == "table" and not vim.tbl_isempty(data.contexts) and not data.inbox
             end,
             ["project"] = function()
                 if not tasks then
                     log.error("No tasks provided")
                     return
+                end
+
+                if data.inbox then
+                    return false
                 end
 
                 local project_tasks = vim.tbl_filter(function(t)

--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -56,6 +56,31 @@ module.public = {
 
         return res
     end,
+
+    --- Checks if the data is processed or not.
+    --- Check out :h neorg-gtd to know what is an unprocessed task or project
+    --- @param data core.gtd.queries.task|core.gtd.queries.project
+    --- @param tasks core.gtd.queries.task[]?
+    is_processed = function(data, tasks)
+        return neorg.lib.match({
+            data.type,
+            ["task"] = function()
+                return type(data.contexts) == "table" and not vim.tbl_isempty(data.contexts)
+            end,
+            ["project"] = function()
+                if not tasks then
+                    log.error("No tasks provided")
+                    return
+                end
+
+                local project_tasks = vim.tbl_map(function(t)
+                    return t.project_uuid == data.uuid
+                end, tasks)
+
+                return not vim.tbl_isempty(project_tasks)
+            end,
+        })
+    end,
 }
 
 module.private = {

--- a/lua/neorg/modules/core/gtd/queries/retrievers.lua
+++ b/lua/neorg/modules/core/gtd/queries/retrievers.lua
@@ -12,6 +12,7 @@ local module = neorg.modules.extend("core.gtd.queries.retrievers")
 ---@field position number
 
 ---@class core.gtd.queries.task
+---@field inbox boolean
 ---@field content string
 ---@field type string
 ---@field project? string
@@ -25,6 +26,7 @@ local module = neorg.modules.extend("core.gtd.queries.retrievers")
 ---@field external? table
 
 ---@class core.gtd.queries.project
+---@field inbox boolean
 ---@field content string
 ---@field type string
 ---@field area_of_focus? string
@@ -201,6 +203,9 @@ module.public = {
             exported.uuid = exported.internal.node:id()
             exported.type = type
             exported.content = get_key("content", module.private.get_content, exported, type, opts)
+
+            local inbox = neorg.modules.get_module_config("core.gtd.base").default_lists.inbox
+            exported.inbox = vim.uri_from_bufnr(exported.internal.bufnr):sub(-#inbox) == inbox
 
             if type == "task" then
                 exported.project_uuid = get_key(

--- a/lua/neorg/modules/core/gtd/ui/capture_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/capture_popup.lua
@@ -83,20 +83,21 @@ module.private = {
                             { newline = false }
                         )
                     end)
-                    :flag("<CR>", "Add to index", function()
+                    :flag("<CR>", "Add to inbox", function()
                         local workspace = neorg.modules.get_module_config("core.gtd.base").workspace
                         local workspace_path = module.required["core.norg.dirman"].get_workspace(workspace)
 
                         local files = module.required["core.norg.dirman"].get_norg_files(workspace)
-                        if not vim.tbl_contains(files, "index.norg") then
-                            log.error([[ Index file is not from gtd workspace.
+                        local inbox = neorg.modules.get_module_config("core.gtd.base").default_lists.inbox
+                        if not vim.tbl_contains(files, inbox) then
+                            log.error([[ Inbox file is not from gtd workspace.
                             Please verify if the file exists in your gtd workspace.
                             Type :messages to show the full error report
                             ]])
                             return
                         end
 
-                        local uri = vim.uri_from_fname(workspace_path .. "/index.norg")
+                        local uri = vim.uri_from_fname(workspace_path .. "/" .. inbox)
                         local buf = vim.uri_to_bufnr(uri)
                         local end_row, projectAtEnd = module.required["core.gtd.queries"].get_end_document_content(buf)
 

--- a/lua/neorg/modules/core/gtd/ui/capture_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/capture_popup.lua
@@ -83,21 +83,20 @@ module.private = {
                             { newline = false }
                         )
                     end)
-                    :flag("<CR>", "Add to inbox", function()
-                        local inbox = neorg.modules.get_module_config("core.gtd.base").default_lists.inbox
+                    :flag("<CR>", "Add to index", function()
                         local workspace = neorg.modules.get_module_config("core.gtd.base").workspace
                         local workspace_path = module.required["core.norg.dirman"].get_workspace(workspace)
 
                         local files = module.required["core.norg.dirman"].get_norg_files(workspace)
-                        if not vim.tbl_contains(files, inbox) then
-                            log.error([[ Inbox file is not from gtd workspace.
+                        if not vim.tbl_contains(files, "index.norg") then
+                            log.error([[ Index file is not from gtd workspace.
                             Please verify if the file exists in your gtd workspace.
                             Type :messages to show the full error report
                             ]])
                             return
                         end
 
-                        local uri = vim.uri_from_fname(workspace_path .. "/" .. inbox)
+                        local uri = vim.uri_from_fname(workspace_path .. "/index.norg")
                         local buf = vim.uri_to_bufnr(uri)
                         local end_row, projectAtEnd = module.required["core.gtd.queries"].get_end_document_content(buf)
 
@@ -247,12 +246,8 @@ module.private = {
 
                 selection:title("Add to project"):blank():text("Append task to existing project")
 
-                local gtd_config = neorg.modules.get_module_config("core.gtd.base")
-                local exclude_files = gtd_config.exclude
-                table.insert(exclude_files, gtd_config.default_lists.inbox)
-
                 -- Get all projects
-                local projects = module.required["core.gtd.queries"].get("projects", { exclude_files = exclude_files })
+                local projects = module.required["core.gtd.queries"].get("projects")
                 --- @type core.gtd.queries.project
                 projects = module.required["core.gtd.queries"].add_metadata(projects, "project")
 
@@ -297,12 +292,7 @@ module.private = {
                                     :text("Project name: " .. project.content)
                                     :blank()
 
-                                local workspace = neorg.modules.get_module_config("core.gtd.base").workspace
-                                local files = module.required["core.norg.dirman"].get_norg_files(workspace)
-
-                                for _, excluded_file in pairs(exclude_files) do
-                                    files = module.required["core.gtd.queries"].remove_from_table(files, excluded_file)
-                                end
+                                local files = module.required["core.gtd.helpers"].get_gtd_files()
 
                                 if vim.tbl_isempty(files) then
                                     selection:text("No files found...")

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -487,8 +487,8 @@ module.public = {
             "Welcome to the inbox: every " .. type .. " not properly formulated is shown here",
             "In order for a " .. type .. " to be processed, it needs to be:",
             "- Removed from the inbox file (`" .. inbox .. "`)",
-            "/OR/",
         }
+
         table.insert(res, type == "task" and "- Have one or more contexts" or "- Have one or more tasks")
         table.insert(res, "")
         local positions = {}

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -493,9 +493,14 @@ module.public = {
         table.insert(res, "")
         local positions = {}
 
+        data = vim.tbl_filter(function(d)
+            return d.state ~= "done"
+        end, data)
+
         local in_inbox = vim.tbl_filter(function(d)
             return d.inbox
         end, data)
+
         local unclarified = vim.tbl_filter(function(d)
             return not d.inbox
         end, data)

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -488,7 +488,7 @@ module.public = {
             "Here is like your inbox: every " .. type .. " not properly formulated is shown here",
             "In order for a " .. type .. " to be processed, it needs to be given:",
         }
-        table.insert(res, type == "task" and "~~ One or more contexts" or "~ One or more tasks")
+        table.insert(res, type == "task" and "~ One or more contexts" or "~ One or more tasks")
         table.insert(res, "")
         local positions = {}
 

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -480,7 +480,7 @@ module.public = {
     --- @return number
     display_unclarified = function(type, data)
         local inbox = neorg.modules.get_module_config("core.gtd.base").default_lists.inbox
-        local name = "Unclarified tasks"
+        local name = "Unclarified " .. type .. "s"
         local res = {
             "* " .. name,
             "",

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -474,14 +474,14 @@ module.public = {
         return module.private.generate_display(name, positions, res)
     end,
 
-    --- Display every task or project that is unprocessed
+    --- Display every task or project that is unclarified
     --- @param type string
     --- @param data core.gtd.queries.task[]|core.gtd.queries.project[]
     --- @param tasks core.gtd.queries.task[]
     --- @return number
     ---@overload fun(type, data)
-    display_unprocessed = function(type, data, tasks)
-        local name = "Unprocessed tasks"
+    display_unclarified = function(type, data, tasks)
+        local name = "Unclarified tasks"
         local res = {
             "* " .. name,
             "",
@@ -492,11 +492,11 @@ module.public = {
         table.insert(res, "")
         local positions = {}
 
-        local unprocessed = vim.tbl_filter(function(d)
+        local unclarified = vim.tbl_filter(function(d)
             return not module.required["core.gtd.helpers"].is_processed(d, tasks)
         end, data)
 
-        for _, d in pairs(unprocessed) do
+        for _, d in pairs(unclarified) do
             local result = "- " .. d.content
             table.insert(res, result)
             positions[#res] = d
@@ -562,6 +562,7 @@ module.private = {
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, res)
         vim.api.nvim_buf_set_option(buf, "modifiable", false)
 
+        P(module.private.current_bufnr)
         return buf
     end,
 

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -587,7 +587,6 @@ module.private = {
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, res)
         vim.api.nvim_buf_set_option(buf, "modifiable", false)
 
-        P(module.private.current_bufnr)
         return buf
     end,
 

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -479,14 +479,17 @@ module.public = {
     --- @param data core.gtd.queries.task[]|core.gtd.queries.project[]
     --- @return number
     display_unclarified = function(type, data)
+        local inbox = neorg.modules.get_module_config("core.gtd.base").default_lists.inbox
         local name = "Unclarified tasks"
         local res = {
             "* " .. name,
             "",
-            "Here is like your inbox: every " .. type .. " not properly formulated is shown here",
-            "In order for a " .. type .. " to be processed, it needs to be given:",
+            "Welcome to the inbox: every " .. type .. " not properly formulated is shown here",
+            "In order for a " .. type .. " to be processed, it needs to be:",
+            "- Removed from the inbox file (`" .. inbox .. "`)",
+            "/OR/",
         }
-        table.insert(res, type == "task" and "~ One or more contexts" or "~ One or more tasks")
+        table.insert(res, type == "task" and "- Have one or more contexts" or "- Have one or more tasks")
         table.insert(res, "")
         local positions = {}
 

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -485,11 +485,16 @@ module.public = {
             "* " .. name,
             "",
             "Welcome to the inbox: every " .. type .. " not properly formulated is shown here",
-            "In order for a " .. type .. " to be processed, it needs to be:",
-            "- Removed from the inbox file (`" .. inbox .. "`)",
+            "In order for a " .. type .. " to be processed, it needs to:",
+            "- Be removed from the inbox file (`" .. inbox .. "`), *and*",
         }
 
-        table.insert(res, type == "task" and "- Have one or more contexts" or "- Have one or more tasks")
+        neorg.lib.when(type == "task", function()
+            table.insert(res, "- Have one or more `contexts`, *or*")
+            table.insert(res, "- Have one or more `waiting_for`")
+        end, function()
+            table.insert(res, "- Have one or more tasks")
+        end)
         table.insert(res, "")
         local positions = {}
 

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -485,18 +485,9 @@ module.public = {
             "* " .. name,
             "",
             "Welcome to the inbox: every " .. type .. " not properly formulated is shown here",
-            "In order for a " .. type .. " to be processed, it needs to:",
-            "- Be removed from the inbox file (`" .. inbox .. "`), *and*",
+            "",
         }
 
-        neorg.lib.when(type == "task", function()
-            table.insert(res, "- Have one or more `contexts`, *or*")
-            table.insert(res, "- Have one or more `waiting_for`")
-        end, function()
-            table.insert(res, "- Have one or more tasks, *or*")
-            table.insert(res, "- Be in `someday`")
-        end)
-        table.insert(res, "")
         local positions = {}
 
         data = vim.tbl_filter(function(d)
@@ -520,6 +511,7 @@ module.public = {
         end
 
         table.insert(res, "** In Inbox file")
+        table.insert(res, "> - Be removed from the inbox file (`" .. inbox .. "`)")
         table.insert(res, "")
 
         neorg.lib.when(vim.tbl_isempty(in_inbox), function()
@@ -531,6 +523,11 @@ module.public = {
         end)
 
         table.insert(res, "** Unclarified " .. type .. "s")
+        neorg.lib.when(type == "task", function()
+            table.insert(res, "> - Have one or more `contexts` or `waiting_for`")
+        end, function()
+            table.insert(res, "> - Have one or more tasks or be in `someday`")
+        end)
         table.insert(res, "")
 
         neorg.lib.when(vim.tbl_isempty(unclarified), function()

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -473,6 +473,37 @@ module.public = {
 
         return module.private.generate_display(name, positions, res)
     end,
+
+    --- Display every task or project that is unprocessed
+    --- @param type string
+    --- @param data core.gtd.queries.task[]|core.gtd.queries.project[]
+    --- @param tasks core.gtd.queries.task[]
+    --- @return number
+    ---@overload fun(type, data)
+    display_unprocessed = function(type, data, tasks)
+        local name = "Unprocessed tasks"
+        local res = {
+            "* " .. name,
+            "",
+            "Here is like your inbox: every " .. type .. " not properly formulated is shown here",
+            "In order for a " .. type .. " to be processed, it needs to be given:",
+        }
+        table.insert(res, type == "task" and "~~ One or more contexts" or "~ One or more tasks")
+        table.insert(res, "")
+        local positions = {}
+
+        local unprocessed = vim.tbl_filter(function(d)
+            return not module.required["core.gtd.helpers"].is_processed(d, tasks)
+        end, data)
+
+        for _, d in pairs(unprocessed) do
+            local result = "- " .. d.content
+            table.insert(res, result)
+            positions[#res] = d
+        end
+
+        return module.private.generate_display(name, positions, res)
+    end,
 }
 
 --- @class private_core.gtd.ui

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -493,7 +493,8 @@ module.public = {
             table.insert(res, "- Have one or more `contexts`, *or*")
             table.insert(res, "- Have one or more `waiting_for`")
         end, function()
-            table.insert(res, "- Have one or more tasks")
+            table.insert(res, "- Have one or more tasks, *or*")
+            table.insert(res, "- Be in `someday`")
         end)
         table.insert(res, "")
         local positions = {}

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -493,11 +493,38 @@ module.public = {
         table.insert(res, "")
         local positions = {}
 
-        for _, d in pairs(data) do
-            local result = "- " .. d.content
-            table.insert(res, result)
-            positions[#res] = d
+        local in_inbox = vim.tbl_filter(function(d)
+            return d.inbox
+        end, data)
+        local unclarified = vim.tbl_filter(function(d)
+            return not d.inbox
+        end, data)
+
+        local function construct(tbl)
+            for _, d in pairs(tbl) do
+                local result = "- " .. d.content
+                table.insert(res, result)
+                positions[#res] = d
+            end
         end
+
+        table.insert(res, "** In Inbox file")
+        table.insert(res, "")
+
+        neorg.lib.when(vim.tbl_isempty(in_inbox), function()
+            table.insert(res, "/No " .. type .. "s found in inbox/")
+            table.insert(res, "")
+        end, function()
+            construct(in_inbox)
+            table.insert(res, "")
+        end)
+
+        table.insert(res, "** Unclarified " .. type .. "s")
+        table.insert(res, "")
+
+        neorg.lib.when(vim.tbl_isempty(unclarified), function()
+            table.insert(res, "/No " .. type .. "s unclarified/")
+        end, neorg.lib.wrap(construct, unclarified))
 
         return module.private.generate_display(name, positions, res)
     end,

--- a/lua/neorg/modules/core/gtd/ui/displayers.lua
+++ b/lua/neorg/modules/core/gtd/ui/displayers.lua
@@ -477,10 +477,8 @@ module.public = {
     --- Display every task or project that is unclarified
     --- @param type string
     --- @param data core.gtd.queries.task[]|core.gtd.queries.project[]
-    --- @param tasks core.gtd.queries.task[]
     --- @return number
-    ---@overload fun(type, data)
-    display_unclarified = function(type, data, tasks)
+    display_unclarified = function(type, data)
         local name = "Unclarified tasks"
         local res = {
             "* " .. name,
@@ -492,11 +490,7 @@ module.public = {
         table.insert(res, "")
         local positions = {}
 
-        local unclarified = vim.tbl_filter(function(d)
-            return not module.required["core.gtd.helpers"].is_processed(d, tasks)
-        end, data)
-
-        for _, d in pairs(unclarified) do
+        for _, d in pairs(data) do
             local result = "- " .. d.content
             table.insert(res, result)
             positions[#res] = d

--- a/lua/neorg/modules/core/gtd/ui/helpers.lua
+++ b/lua/neorg/modules/core/gtd/ui/helpers.lua
@@ -6,7 +6,6 @@ local module = neorg.modules.extend("core.gtd.ui.helpers", "core.gtd.ui")
 ---@class core.gtd.ui
 module.public = {
     get_data_for_views = function()
-        -- Exclude files explicitely provided by the user, and the inbox file
         local exclude_files = module.required["core.gtd.helpers"].get_gtd_excluded_files()
 
         -- Reset state of previous fetches

--- a/lua/neorg/modules/core/gtd/ui/helpers.lua
+++ b/lua/neorg/modules/core/gtd/ui/helpers.lua
@@ -36,16 +36,17 @@ module.private = {
     --- Try to re-fetch the node with newer content (after an update for example)
     --- @param node table
     --- @param type string
-    --- @return core.gtd.queries.task?
+    --- @return core.gtd.queries.task|core.gtd.queries.project
     refetch_data_not_extracted = function(node, type)
         -- Get all nodes from the bufnr and add metadatas to it
         -- This is mandatory because we need to have the correct task position, else the update will not work
         local nodes = module.required["core.gtd.queries"].get(type .. "s", { bufnr = node[2] })
+        --- @type core.gtd.queries.task[]|core.gtd.queries.project[]
         nodes = module.required["core.gtd.queries"].add_metadata(nodes, type, { extract = false, same_node = true })
 
         -- Find the correct task node
         local found_data = vim.tbl_filter(function(n)
-            return n.node:id() == node[1]:id()
+            return n.internal.node:id() == node[1]:id()
         end, nodes)
 
         if #found_data == 0 then

--- a/lua/neorg/modules/core/gtd/ui/module.lua
+++ b/lua/neorg/modules/core/gtd/ui/module.lua
@@ -77,7 +77,7 @@ module.private = {
     end,
 
     edit_task = function(task)
-        task = module.private.refetch_data_not_extracted({ task.node, task.bufnr }, "task")
+        task = module.private.refetch_data_not_extracted({ task.internal.node, task.internal.bufnr }, "task")
         module.public.edit_task(task)
     end,
 }

--- a/lua/neorg/modules/core/gtd/ui/module.lua
+++ b/lua/neorg/modules/core/gtd/ui/module.lua
@@ -19,6 +19,7 @@ module.load = function()
     -- Set up callbacks
     module.public.callbacks.goto_task_function = module.private.goto_node_internal
     module.public.callbacks.edit_task = module.private.edit_task
+    module.public.callbacks.is_processed = module.required["core.gtd.helpers"].is_processed
 end
 
 module.setup = function()
@@ -47,6 +48,9 @@ end
 
 ---@class core.gtd.ui
 module.public = {
+    get_callback = function(name)
+        return module.public.callbacks[name]
+    end,
     callbacks = {},
 }
 

--- a/lua/neorg/modules/core/gtd/ui/views_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/views_popup.lua
@@ -42,13 +42,36 @@ module.private = {
     --- @param projects core.gtd.queries.project[]
     --- @return core.ui.selection
     generate_display_flags = function(selection, tasks, projects)
+        local unclarified_tasks = vim.tbl_filter(
+            neorg.lib.wrap_cond_not(module.required["core.gtd.helpers"].is_processed),
+            tasks
+        )
+        local unclarified_projects = vim.tbl_filter(
+            neorg.lib.wrap_cond_not(module.required["core.gtd.helpers"].is_processed, tasks),
+            projects
+        )
+        neorg.lib.wrap_cond_not(function (v, ...)
+            
+        end, )
+
+        projects = vim.tbl_filter(
+            neorg.lib.wrap_cond(module.required["core.gtd.helpers"].is_processed, tasks),
+            projects
+        )
+
+        tasks = vim.tbl_filter(neorg.lib.wrap_cond(module.required["core.gtd.helpers"].is_processed), tasks)
+
         selection
             :text("Unclarified")
-            :flag("u", "Unclarified tasks", neorg.lib.wrap(module.public.display_unclarified, "task", tasks))
+            :flag(
+                "u",
+                "Unclarified tasks",
+                neorg.lib.wrap(module.public.display_unclarified, "task", unclarified_tasks)
+            )
             :flag(
                 "<C-u>",
                 "Unclarified projects",
-                neorg.lib.wrap(module.public.display_unclarified, "project", projects, tasks)
+                neorg.lib.wrap(module.public.display_unclarified, "project", unclarified_projects)
             )
             :blank()
             :text("Top priorities")

--- a/lua/neorg/modules/core/gtd/ui/views_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/views_popup.lua
@@ -42,21 +42,13 @@ module.private = {
     --- @param projects core.gtd.queries.project[]
     --- @return core.ui.selection
     generate_display_flags = function(selection, tasks, projects)
-        local unclarified_tasks = vim.tbl_filter(
-            neorg.lib.wrap_cond_not(module.required["core.gtd.helpers"].is_processed),
-            tasks
-        )
-        local unclarified_projects = vim.tbl_filter(
-            neorg.lib.wrap_cond_not(module.required["core.gtd.helpers"].is_processed, tasks),
-            projects
-        )
+        local is_processed_cb = module.public.get_callback("is_processed")
+        local unclarified_tasks = vim.tbl_filter(neorg.lib.wrap_cond_not(is_processed_cb), tasks)
+        local unclarified_projects = vim.tbl_filter(neorg.lib.wrap_cond_not(is_processed_cb, tasks), projects)
 
-        projects = vim.tbl_filter(
-            neorg.lib.wrap_cond(module.required["core.gtd.helpers"].is_processed, tasks),
-            projects
-        )
+        projects = vim.tbl_filter(neorg.lib.wrap_cond(is_processed_cb, tasks), projects)
 
-        tasks = vim.tbl_filter(neorg.lib.wrap_cond(module.required["core.gtd.helpers"].is_processed), tasks)
+        tasks = vim.tbl_filter(neorg.lib.wrap_cond(is_processed_cb), tasks)
 
         selection
             :text("Unclarified")

--- a/lua/neorg/modules/core/gtd/ui/views_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/views_popup.lua
@@ -103,18 +103,18 @@ module.private = {
                 selection
                     :title("GTD informations")
                     :blank()
-                    :text("Files used for GTD")
-                    :concat(neorg.lib.wrap(files_text, selection, files))
-                    :blank()
-                    :text("Files excluded")
-                    :concat(neorg.lib.wrap(files_text, selection, excluded_files))
-                    :blank()
-                    :flag("<CR>", "Return to main page", {
+                    :flag("<BS>", "Return to main page", {
                         callback = function()
                             selection:pop_page()
                         end,
                         destroy = false,
                     })
+                    :blank()
+                    :text("Files used for GTD")
+                    :concat(neorg.lib.wrap(files_text, selection, files))
+                    :blank()
+                    :text("Files excluded")
+                    :concat(neorg.lib.wrap(files_text, selection, excluded_files))
             end,
             destroy = false,
         })

--- a/lua/neorg/modules/core/gtd/ui/views_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/views_popup.lua
@@ -43,12 +43,12 @@ module.private = {
     --- @return core.ui.selection
     generate_display_flags = function(selection, tasks, projects)
         selection
-            :text("Unprocessed")
-            :flag("u", "Unprocessed tasks", neorg.lib.wrap(module.public.display_unprocessed, "task", tasks))
+            :text("Unclarified")
+            :flag("u", "Unclarified tasks", neorg.lib.wrap(module.public.display_unclarified, "task", tasks))
             :flag(
                 "<C-u>",
-                "Unprocessed projects",
-                neorg.lib.wrap(module.public.display_unprocessed, "project", projects, tasks)
+                "Unclarified projects",
+                neorg.lib.wrap(module.public.display_unclarified, "project", projects, tasks)
             )
             :blank()
             :text("Top priorities")

--- a/lua/neorg/modules/core/gtd/ui/views_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/views_popup.lua
@@ -50,9 +50,6 @@ module.private = {
             neorg.lib.wrap_cond_not(module.required["core.gtd.helpers"].is_processed, tasks),
             projects
         )
-        neorg.lib.wrap_cond_not(function (v, ...)
-            
-        end, )
 
         projects = vim.tbl_filter(
             neorg.lib.wrap_cond(module.required["core.gtd.helpers"].is_processed, tasks),

--- a/lua/neorg/modules/core/gtd/ui/views_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/views_popup.lua
@@ -43,31 +43,27 @@ module.private = {
     --- @return core.ui.selection
     generate_display_flags = function(selection, tasks, projects)
         selection
-            :text("Top priorities")
-            :flag("s", "Weekly Summary", function()
-                module.public.display_weekly_summary(tasks)
-            end)
+            :text("Unprocessed")
+            :flag("u", "Unprocessed tasks", neorg.lib.wrap(module.public.display_unprocessed, "task", tasks))
+            :flag(
+                "<C-u>",
+                "Unprocessed projects",
+                neorg.lib.wrap(module.public.display_unprocessed, "project", projects, tasks)
+            )
             :blank()
-            :text("Tasks")
-            :flag("t", "Today's tasks", function()
-                module.public.display_today_tasks(tasks)
-            end)
+            :text("Top priorities")
+            :flag("s", "Weekly Summary", neorg.lib.wrap(module.public.display_weekly_summary, tasks))
+            :flag("t", "Today's tasks", neorg.lib.wrap(module.public.display_today_tasks, tasks))
+            :flag("p", "Show projects", neorg.lib.wrap(module.public.display_projects, tasks, projects))
             :blank()
             :text("Sort and filter tasks")
-            :flag("c", "Contexts", function()
-                module.public.display_contexts(tasks, { exclude = { "someday" }, priority = { "_" } })
-            end)
-            :flag("w", "Waiting For", function()
-                module.public.display_waiting_for(tasks)
-            end)
-            :flag("d", "Someday Tasks", function()
-                module.public.display_someday(tasks)
-            end)
-            :blank()
-            :text("Projects")
-            :flag("p", "Show projects", function()
-                module.public.display_projects(tasks, projects)
-            end)
+            :flag(
+                "c",
+                "Contexts",
+                neorg.lib.wrap(module.public.display_contexts, tasks, { exclude = { "someday" }, priority = { "_" } })
+            )
+            :flag("w", "Waiting For", neorg.lib.wrap(module.public.display_waiting_for, tasks))
+            :flag("d", "Someday Tasks", neorg.lib.wrap(module.public.display_someday, tasks))
             :blank()
             :concat(module.private.generate_informations)
         return selection

--- a/lua/neorg/modules/core/presenter/module.lua
+++ b/lua/neorg/modules/core/presenter/module.lua
@@ -124,9 +124,6 @@ module.public = {
             nil,
             { keybinds = false }
         )
-        vim.api.nvim_buf_call(buffer, function()
-            vim.cmd("set scrolloff=999")
-        end)
 
         vim.api.nvim_buf_set_option(buffer, "modifiable", true)
         vim.api.nvim_buf_set_lines(buffer, 0, -1, false, results[1])

--- a/lua/neorg/modules/core/ui/module.lua
+++ b/lua/neorg/modules/core/ui/module.lua
@@ -201,6 +201,10 @@ module.public = {
         vim.api.nvim_buf_set_name(buf, bufname)
         vim.api.nvim_win_set_buf(0, buf)
 
+        vim.api.nvim_buf_call(buf, function()
+            vim.cmd("set scrolloff=999")
+        end)
+
         vim.api.nvim_win_set_option(0, "number", false)
         vim.api.nvim_win_set_option(0, "relativenumber", false)
 


### PR DESCRIPTION
Hello ! 🥳

This is part of the discussion I had with @molleweide in #307.

The idea is summarized below:

> Because we can improve the views a little bit by: Adding a new view called Unprocessed.

It'll group every task or project that is not entirely processed. 
For a task to be entirely processed, it has to be visible. 
- If it's a task: by having one or more contexts 
- If it's a project: by having one or more tasks associated.
In this way, we can remove the inbox file because we could view our unprocessed tasks, and we will not lose any tasks from the views.
In fact, I'm sure it'll be a better feature, because the inbox file is quite difficult to grasp for new users, and still not very usable by advanced users (because moving tasks and projects is not yet implemented in GTD actions).

I will track here every thing I still need to do in order to mark this feature as completed:

~- [x] Remove any allusion of `INBOX`~
- [x] Create two views: `unclarified tasks` and `unclarified projects`
- [x] Remove unclarified tasks and projects from other views

EDIT:

After a very enlightening discord conversation, we made the conclusion to still keep the inbox file, and the `unclarified` tasks and projects should be the mix of inbox PLUS previously unclarified tasks.