### PR TITLE
docs: update anchor links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ Your New Life Organization Tool - All in Lua
 
 [Summary](#summary)
 •
-[Showcase](#🌟-showcase)
+[Showcase](#-showcase)
 •
-[Installation](#🔧-installation)
+[Installation](#-installation)
 •
-[Setup](#📦-setup)
+[Setup](#-setup)
 •
-[Usage](#⚙-usage)
+[Usage](#-usage)
 <br>
-[Modules](#🥡-modules)
+[Modules](#-modules)
 •
-[Roadmap](#🗺-roadmap)
+[Roadmap](#-roadmap)
 •
-[Philosophy](#❓-philosophy)
+[Philosophy](#-philosophy)
 •
-[FAQ](#📚-faq)
+[FAQ](#-faq)
 
 </div>
 


### PR DESCRIPTION
👋 

I was checking out this great project and wanted to jump to various parts of the README but the anchor links are broken. Looks like the markdown parser strips emojis. So this removes the emojis from the links at the top of the README.

Example: https://github.com/nvim-neorg/neorg#-showcase

Thanks 💖 