### PR TITLE
feat(ui): add filetype to create_(v)split

### DIFF
--- a/lua/neorg/modules/core/ui/module.lua
+++ b/lua/neorg/modules/core/ui/module.lua
@@ -196,6 +196,7 @@ module.public = {
             bufhidden = "hide",
             buftype = "nofile",
             buflisted = false,
+            filetype = "neorg",
         }
 
         vim.api.nvim_buf_set_name(buf, bufname)
@@ -247,6 +248,7 @@ module.public = {
             bufhidden = "hide",
             buftype = "nofile",
             buflisted = false,
+            filetype = "neorg",
         }
 
         vim.api.nvim_buf_set_name(buf, "neorg://" .. name)


### PR DESCRIPTION
This allows autocommands to be specified like this
```
au FileType neorg ...
```
Note that this is for neorg, not norg, buffers
