### PR TITLE
Expand paths relative to current file, not CWD

### DIFF
--- a/lua/neorg/modules/core/norg/dirman/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/module.lua
@@ -483,7 +483,15 @@ module.public = {
             path = module.public.get_current_workspace()[2] .. path:sub(workspace:len() + 1)
         end
 
-        return vim.fn.fnamemodify(path .. ".norg", ":p")
+        -- temporarily set current directory to current file's directory
+        local cwd = vim.fn.getcwd()
+        vim.api.nvim_set_current_dir(vim.fn.expand("%:h"))
+
+        local expanded = vim.fn.fnamemodify(path .. ".norg", ":p")
+
+        -- restore cwd
+        vim.api.nvim_set_current_dir(cwd)
+        return expanded
     end,
 
     --- Touches a file in workspace


### PR DESCRIPTION
According to the spec, "Filepaths are relative to the norg file they're contained in by default". However, when following links with `hop-link`, filepaths were being expanded relative to vim's `cwd`, not relative to the file being edited.

To reproduce: 
- `:e /tmp/test.norg`
- `:cd ~`
- Insert `{:testfile:}`
- Place cursor on `{:testfile:}` and `<CR>`
- The opened file is `~/testfile.norg`, not `/tmp/test.norg`

This updates the `expand_path` function to expand paths relative to the current file by temporarily switching `cwd` to the directory of the current file. I couldn't come up with any better way to do path expansion relative to a directory other than the current directory, but I'm a nvim plugin noob. In any case, I figured a PR showing exactly where the issue is would be more useful than a bug report. I won't be offended if it's closed for a better solution 😄 