### PR TITLE
Adding `core.tutor` module

### DIFF
--- a/lua/neorg/modules/core/tutor/module.lua
+++ b/lua/neorg/modules/core/tutor/module.lua
@@ -1,0 +1,5 @@
+--[[
+    File: Tutor
+    Title: Tutor module for Neorg.
+    Summary: This module provides tutorial functionality for Neorg.
+--]]


### PR DESCRIPTION
Basically this module is somekind alternative of `:Tutor`, but only for neorg format.
This lets user discover useful features via interactive guide besides specs.