### PR TITLE
Treesitter Based Concealing

### DIFF
--- a/lua/neorg/modules/core/norg/concealer/preset_brave.lua
+++ b/lua/neorg/modules/core/norg/concealer/preset_brave.lua
@@ -1,9 +1,0 @@
-local module = neorg.modules.extend("core.norg.concealer.preset_brave", "core.norg.concealer")
-
-module.config.private.markup_preset_brave = {
-    icon = "⁠", -- not an empty string but the word joiner unicode (U+2060)
-    -- NOTE: if you're experiencing issues with this concealing, try using the
-    -- safe preset instead.
-}
-
-return module

--- a/lua/neorg/modules/core/norg/concealer/preset_dimmed.lua
+++ b/lua/neorg/modules/core/norg/concealer/preset_dimmed.lua
@@ -2,6 +2,8 @@ local module = neorg.modules.extend("core.norg.concealer.preset_dimmed", "core.n
 
 module.config.private.markup_preset_dimmed = {
     enabled = true,
+    icon = " ",
+    conceal = nil,
 
     bold = {
         enabled = false,

--- a/lua/neorg/modules/core/norg/concealer/preset_safe.lua
+++ b/lua/neorg/modules/core/norg/concealer/preset_safe.lua
@@ -1,7 +1,0 @@
-local module = neorg.modules.extend("core.norg.concealer.preset_safe", "core.norg.concealer")
-
-module.config.private.markup_preset_safe = {
-    icon = " ",
-}
-
-return module


### PR DESCRIPTION
This PR is a temporary workaround for treesitter based concealing not working (see https://github.com/nvim-neorg/neorg/issues/292#issuecomment-1073023644). The "brave" preset will now actually physically conceal the text thanks to a discovery I made recently with `matchaddpos()` :P

It may be a little less performant with this update, but it's a tradeoff I'm willing to make until we get the real thing.