### PR TITLE
[GTD] Rewrite capture core

### DIFF
--- a/lua/neorg/modules/core/gtd/queries/creators.lua
+++ b/lua/neorg/modules/core/gtd/queries/creators.lua
@@ -2,22 +2,13 @@ local module = neorg.modules.extend("core.gtd.queries.creators")
 
 ---@class core.gtd.queries
 module.public = {
-    --- Creates a new project/task (depending of `type`) from the `node` table and insert it in `bufnr` at `location`
-    --- supported `string`: project|task
-    --- @param type string
+    --- Creates a new project/task from the `node` table and insert it at `location`
     --- @param node core.gtd.queries.task|core.gtd.queries.project
     --- @param location table
     --- @param opts table|nil opts
     ---   - opts.no_save(boolean)    if true, don't save the buffer
-    create = function(type, node, location, opts)
+    create = function(node, location, opts)
         vim.validate({
-            type = {
-                type,
-                function(t)
-                    return vim.tbl_contains({ "project", "task" }, t)
-                end,
-                "project|task",
-            },
             node = { node, "table" },
             location = { location, "table" },
             opts = { opts, "table", true },
@@ -38,13 +29,13 @@ module.public = {
         local bufnr = node.internal.bufnr
 
         local indendation = string.rep(" ", location[2])
-        local prefix = type == "project" and "* " or "- [ ] "
+        local prefix = node.type == "project" and "* " or "- [ ] "
         table.insert(inserter, indendation .. prefix .. node.content)
 
         local temp_buf = module.required["core.queries.native"].get_temp_buf(bufnr)
         vim.api.nvim_buf_set_lines(temp_buf, location[1], location[1], false, inserter)
 
-        local nodes = module.public.get(type .. "s", { bufnr = bufnr })
+        local nodes = module.public.get(node.type .. "s", { bufnr = bufnr })
         local ts_utils = module.required["core.integrations.treesitter"].get_ts_utils()
 
         local inserted_line = location[1] + #inserter

--- a/lua/neorg/modules/core/gtd/ui/capture_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/capture_popup.lua
@@ -43,6 +43,7 @@ module.private = {
                 ---@type core.gtd.queries.task
                 local task = {
                     content = text,
+                    type = "task",
                     internal = {},
                 }
 
@@ -77,7 +78,7 @@ module.private = {
                         local cursor = vim.api.nvim_win_get_cursor(0)
                         local location = { cursor[1] - 1, 0 }
                         task.internal.bufnr = 0
-                        module.required["core.gtd.queries"].create("task", task, location)
+                        module.required["core.gtd.queries"].create(task, location)
                     end)
                     :flag("<CR>", "Add to inbox", function()
                         local workspace = neorg.modules.get_module_config("core.gtd.base").workspace
@@ -98,7 +99,7 @@ module.private = {
                         task.internal.bufnr = buf
                         local end_row, projectAtEnd = module.required["core.gtd.queries"].get_end_document_content(buf)
 
-                        module.required["core.gtd.queries"].create("task", task, { end_row, 0 }, projectAtEnd)
+                        module.required["core.gtd.queries"].create(task, { end_row, 0 }, projectAtEnd)
                     end)
 
                 return selection
@@ -285,6 +286,7 @@ module.private = {
                                 --- @type core.gtd.queries.project
                                 local project = {
                                     content = text,
+                                    type = "project",
                                     internal = {},
                                 }
 
@@ -358,8 +360,8 @@ module.private = {
                 return
             end
             selection:destroy()
-            module.required["core.gtd.queries"].create("project", project, { location, 0 })
-            module.required["core.gtd.queries"].create("task", task, { location + 1, 2 })
+            module.required["core.gtd.queries"].create(project, { location, 0 })
+            module.required["core.gtd.queries"].create(task, { location + 1, 2 })
         else
             selection:push_page()
             selection:title("Create a new project"):blank():text("Project name: " .. project.content):blank()
@@ -374,8 +376,8 @@ module.private = {
                 selection:flag(f, extracted_nodes[i]:sub(3), function()
                     local ts_utils = module.required["core.integrations.treesitter"].get_ts_utils()
                     local _, _, er, _ = ts_utils.get_node_range(marker_node[1])
-                    module.required["core.gtd.queries"].create("project", project, { er, 0 })
-                    module.required["core.gtd.queries"].create("task", task, { er + 1, 2 })
+                    module.required["core.gtd.queries"].create(project, { er, 0 })
+                    module.required["core.gtd.queries"].create(task, { er + 1, 2 })
                 end)
             end
 
@@ -387,8 +389,8 @@ module.private = {
                 end
                 selection:destroy()
 
-                module.required["core.gtd.queries"].create("project", project, { location, 0 })
-                module.required["core.gtd.queries"].create("task", task, { location + 2, 2 })
+                module.required["core.gtd.queries"].create(project, { location, 0 })
+                module.required["core.gtd.queries"].create(task, { location + 2, 2 })
             end)
         end
     end,
@@ -467,7 +469,7 @@ module.private = {
         selection:flag("<CR>", description, {
             callback = function()
                 location = module.required["core.gtd.queries"].get_end_project(node, bufnr)
-                module.required["core.gtd.queries"].create("task", task, location)
+                module.required["core.gtd.queries"].create(task, location)
                 vim.cmd(string.format([[echom '%s']], 'Task added to "' .. project_title .. '".'))
             end,
             destroy = true,


### PR DESCRIPTION
Hello everyone, 

Right now GTD seems very stable, with the exception of GTD capture methods.
Why though ?

-  First of all, I was still a newbie when I started out creating this integration. 😁
- But most importantly, capture methods for Neorg gtd feels kinda complicated, let me show you:

Imagine you want to create a task inside a project, and this is the type of task that you want to create:

```lua
- [ ] Wash dishes
``` 

If you want to add to a very simple project, like this one:

```
* Home things
```

It's possible to add it like this:

```
* Home things 
- [ ] Wash dishes 
```

But now imagine you already had a task before, with a context:

```
* Home things 
  #contexts sister
  - [ ] ask her to wash dishes 
```

You can't simply put your task afterwards, because Neorg (and therefore gtd) treats things inside tags as groups, so this:

```
* Home things 
  #contexts sister
  - [ ] ask her to wash dishes 
  - [ ] Wash dishes   
```

Will mean that our task will have `sister` context.

OKAY THEN, what will be done here ? Basically, follow this workflow:

1 . Ask for every information for a task
2. Adds the task to the buffer
3. After the task has been added, verify the location of new task: does it require some operations ?
4. modify the buffer accordingly, and add more information (like new contexts for example)