### PR TITLE
docs: minor typo

### DIFF
--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -264,7 +264,7 @@ consective new lines.
     | some marker
 
  ** Definitions
-    There are two kinds of defintions:
+    There are two kinds of definitions:
 
   *** Single-paragraph definitions
       @code norg


### PR DESCRIPTION
Just found a minor typo in the documented presented by :h neorg.
I hope that such formally lacking PRs are welcome.

Note: No code changes