### PR TITLE
fix: errors in fs_write on some systems when exporting a file

### DIFF
--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -147,7 +147,7 @@ module.on_event = function(event)
                 neorg.lib.lazy_string_concat("Failed to open file '", event.content[1], "' for export: ", err)
             )
 
-            vim.loop.fs_write(fd, exported, function(werr)
+            vim.loop.fs_write(fd, exported, 0, function(werr)
                 assert(
                     not werr,
                     neorg.lib.lazy_string_concat("Failed to write to file '", event.content[1], "' for export: ", err)


### PR DESCRIPTION
My Pop OS machine would fail to run the export function, complaining that arg 3 of vim.loop.fs_write is nil instead of a number. Using 0 instead seems to remedy this. My Arch machine works fine