### PR TITLE
fix(gtd): nil query

### DIFF
--- a/lua/neorg/modules/core/norg/esupports/indent/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/indent/module.lua
@@ -18,11 +18,7 @@ end
 module.public = {
     indentexpr = function(buf)
         local node = module.required["core.integrations.treesitter"].get_first_node_on_line(buf, vim.v.lnum - 1)
-            or module.required["core.integrations.treesitter"].get_first_node_on_line(
-                buf,
-                vim.v.lnum - 1,
-                true
-            )
+            or module.required["core.integrations.treesitter"].get_first_node_on_line(buf, vim.v.lnum - 1, true)
             or module.required["core.integrations.treesitter"].get_first_node_on_line(buf, vim.v.lnum - 1, true, true)
 
         if not node then

--- a/lua/neorg/modules/core/queries/native/module.lua
+++ b/lua/neorg/modules/core/queries/native/module.lua
@@ -113,7 +113,7 @@ module.public = {
         local temp_buf = module.public.get_temp_buf(bufnr)
         local root_node = module.required["core.integrations.treesitter"].get_document_root(temp_buf)
         if not root_node then
-            return
+            return {}
         end
 
         local res = module.public.query_from_tree(root_node, tree, bufnr)


### PR DESCRIPTION
Prior to this pull request, `query_nodes_from_buf` could return `{}` or `nil`. When it was the latter, this block in `retrievers.lua` in the `get` function would fail:

```lua
        for _, bufnr in pairs(bufnrs) do
            ---@type core.queries.native
            local queries = module.required["core.queries.native"]
            local nodes = queries.query_nodes_from_buf(tree, bufnr)
            vim.list_extend(res, nodes)  -- fails here because nodes is nil
        end
```

The backtrace is 

```
Error executing vim.schedule lua callback: vim/shared.lua:0: src: expected table, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'list_extend'
        .../neorg/lua/neorg/modules/core/gtd/queries/retrievers.lua:104: in function 'get'
```