### PR TITLE
fix: concealer breakage on carryover tag set when calculating todo items

### DIFF
--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -473,41 +473,39 @@ module.public = {
             local total = 0
 
             for child_node in start_node:iter_children() do
-              if child_node:type() == "generic_list" then
-                  for todo_item_node in child_node:iter_children() do
-                      if vim.startswith(todo_item_node:type(), "todo_item") then
-                          local type_node = todo_item_node:named_child(1)
+                if child_node:type() == "generic_list" then
+                    for todo_item_node in child_node:iter_children() do
+                        if vim.startswith(todo_item_node:type(), "todo_item") then
+                            local type_node = todo_item_node:named_child(1)
 
-                          if type_node then
-                              local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
-                              local resulting_todo_item = results[todo_item_type] or 0
+                            if type_node then
+                                local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
+                                local resulting_todo_item = results[todo_item_type] or 0
 
-                              results[todo_item_type] = resulting_todo_item + 1
-                              total = total + (todo_item_type == "cancelled" and 0 or 1)
-                          end
-                      end
-                  end
-              elseif child_node:type() == "carryover_tag_set" then
+                                results[todo_item_type] = resulting_todo_item + 1
+                                total = total + (todo_item_type == "cancelled" and 0 or 1)
+                            end
+                        end
+                    end
+                elseif child_node:type() == "carryover_tag_set" then
+                    for carryover_child_node in child_node:iter_children() do
+                        if carryover_child_node:type() == "generic_list" then
+                            for todo_item_node in carryover_child_node:iter_children() do
+                                if vim.startswith(todo_item_node:type(), "todo_item") then
+                                    local type_node = todo_item_node:named_child(1)
 
-                for carryover_child_node in child_node:iter_children() do
-                  if carryover_child_node:type() == "generic_list" then
-                      for todo_item_node in carryover_child_node:iter_children() do
-                          if vim.startswith(todo_item_node:type(), "todo_item") then
-                              local type_node = todo_item_node:named_child(1)
+                                    if type_node then
+                                        local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
+                                        local resulting_todo_item = results[todo_item_type] or 0
 
-                              if type_node then
-                                  local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
-                                  local resulting_todo_item = results[todo_item_type] or 0
-
-                                  results[todo_item_type] = resulting_todo_item + 1
-                                  total = total + (todo_item_type == "cancelled" and 0 or 1)
-                              end
-                          end
-                      end
-                  end
+                                        results[todo_item_type] = resulting_todo_item + 1
+                                        total = total + (todo_item_type == "cancelled" and 0 or 1)
+                                    end
+                                end
+                            end
+                        end
+                    end
                 end
-
-              end
             end
 
             results.total = total

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -473,21 +473,41 @@ module.public = {
             local total = 0
 
             for child_node in start_node:iter_children() do
-                if child_node:type() == "generic_list" then
-                    for todo_item_node in child_node:iter_children() do
-                        if vim.startswith(todo_item_node:type(), "todo_item") then
-                            local type_node = todo_item_node:named_child(1)
+              if child_node:type() == "generic_list" then
+                  for todo_item_node in child_node:iter_children() do
+                      if vim.startswith(todo_item_node:type(), "todo_item") then
+                          local type_node = todo_item_node:named_child(1)
 
-                            if type_node then
-                                local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
-                                local resulting_todo_item = results[todo_item_type] or 0
+                          if type_node then
+                              local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
+                              local resulting_todo_item = results[todo_item_type] or 0
 
-                                results[todo_item_type] = resulting_todo_item + 1
-                                total = total + (todo_item_type == "cancelled" and 0 or 1)
-                            end
-                        end
-                    end
+                              results[todo_item_type] = resulting_todo_item + 1
+                              total = total + (todo_item_type == "cancelled" and 0 or 1)
+                          end
+                      end
+                  end
+              elseif child_node:type() == "carryover_tag_set" then
+
+                for carryover_child_node in child_node:iter_children() do
+                  if carryover_child_node:type() == "generic_list" then
+                      for todo_item_node in carryover_child_node:iter_children() do
+                          if vim.startswith(todo_item_node:type(), "todo_item") then
+                              local type_node = todo_item_node:named_child(1)
+
+                              if type_node then
+                                  local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
+                                  local resulting_todo_item = results[todo_item_type] or 0
+
+                                  results[todo_item_type] = resulting_todo_item + 1
+                                  total = total + (todo_item_type == "cancelled" and 0 or 1)
+                              end
+                          end
+                      end
+                  end
                 end
+
+              end
             end
 
             results.total = total

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -80,10 +80,10 @@ local function add_to_counters_if_todo_node(node, results)
     end
 end
 
-local function traverse_nodes(root_node, results, func)
-    func(root_node, results)
+local function count_todo_nodes_under_node(root_node, results)
+    add_to_counters_if_todo_node(root_node, results)
     for child_node in root_node:iter_children() do
-        traverse_nodes(child_node, results, func)
+        count_todo_nodes_under_node(child_node, results)
     end
 end
 
@@ -490,7 +490,7 @@ module.public = {
 
         get_todo_item_counts = function(start_node)
             local results = { total = 0 }
-            traverse_nodes(start_node, results, add_to_counters_if_todo_node)
+            count_todo_nodes_under_node(start_node, results)
             return results
         end,
 

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -66,6 +66,27 @@ local function schedule(func)
     end)
 end
 
+local function add_to_counters_if_todo_node(node, results)
+    if vim.startswith(node:type(), "todo_item") then
+        local type_node = node:named_child(1)
+
+        if type_node then
+            local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
+            local resulting_todo_item = results[todo_item_type] or 0
+
+            results[todo_item_type] = resulting_todo_item + 1
+            results.total = results.total + (todo_item_type == "cancelled" and 0 or 1)
+        end
+    end
+end
+
+local function traverse_nodes(root_node, results, func)
+    func(root_node, results)
+    for child_node in root_node:iter_children() do
+        traverse_nodes(child_node, results, func)
+    end
+end
+
 module.setup = function()
     return {
         success = true,
@@ -468,48 +489,8 @@ module.public = {
         end,
 
         get_todo_item_counts = function(start_node)
-            local results = {}
-
-            local total = 0
-
-            for child_node in start_node:iter_children() do
-                if child_node:type() == "generic_list" then
-                    for todo_item_node in child_node:iter_children() do
-                        if vim.startswith(todo_item_node:type(), "todo_item") then
-                            local type_node = todo_item_node:named_child(1)
-
-                            if type_node then
-                                local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
-                                local resulting_todo_item = results[todo_item_type] or 0
-
-                                results[todo_item_type] = resulting_todo_item + 1
-                                total = total + (todo_item_type == "cancelled" and 0 or 1)
-                            end
-                        end
-                    end
-                elseif child_node:type() == "carryover_tag_set" then
-                    for carryover_child_node in child_node:iter_children() do
-                        if carryover_child_node:type() == "generic_list" then
-                            for todo_item_node in carryover_child_node:iter_children() do
-                                if vim.startswith(todo_item_node:type(), "todo_item") then
-                                    local type_node = todo_item_node:named_child(1)
-
-                                    if type_node then
-                                        local todo_item_type = type_node:type():sub(string.len("todo_item_") + 1)
-                                        local resulting_todo_item = results[todo_item_type] or 0
-
-                                        results[todo_item_type] = resulting_todo_item + 1
-                                        total = total + (todo_item_type == "cancelled" and 0 or 1)
-                                    end
-                                end
-                            end
-                        end
-                    end
-                end
-            end
-
-            results.total = total
-
+            local results = { total = 0 }
+            traverse_nodes(start_node, results, add_to_counters_if_todo_node)
             return results
         end,
 


### PR DESCRIPTION
This PR actually fixes issue #432 by using recursion to iterate over all descendant nodes and counting all todo_items.


