### PR TITLE
feat(neorgcmd): select next unspecified command argument

### DIFF
--- a/lua/neorg/modules/core/neorgcmd/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/module.lua
@@ -137,21 +137,25 @@ end
 ---@param args table #previous arguments of the command Neorg
 ---@param choices table #all possible choices for the next argument
 local _select_next_cmd_arg = function(args, choices)
-    local current = string.format('Neorg %s', table.concat(args, ' '))
+    local current = string.format("Neorg %s", table.concat(args, " "))
 
     local query
 
     if vim.tbl_isempty(choices) then
-        query = function(...) vim.ui.input(...) end
+        query = function(...)
+            vim.ui.input(...)
+        end
     else
-        query = function(...) vim.ui.select(choices, ...) end
+        query = function(...)
+            vim.ui.select(choices, ...)
+        end
     end
 
     query({
         prompt = current,
     }, function(choice)
         if choice ~= nil then
-            vim.cmd(string.format('%s %s', current, choice))
+            vim.cmd(string.format("%s %s", current, choice))
         end
     end)
 end
@@ -329,7 +333,7 @@ module.public = {
             -- performs a recursion on the data of each keybind versus the completions of each keybind. This means
             -- that keybinds with many arguments wouldn't be registered and would instead cause this function to
             -- loop. The only solution is to query completions for the next item here.
-            local completions = _neorgcmd_generate_completions(_, string.format("Neorg %s ", table.concat(args, " "))
+            local completions = _neorgcmd_generate_completions(_, string.format("Neorg %s ", table.concat(args, " ")))
             _select_next_cmd_arg(args, completions)
             return
         end

--- a/lua/neorg/modules/core/neorgcmd/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/module.lua
@@ -139,12 +139,20 @@ local _select_next_cmd_arg = function(args, ref_definitions)
     local current = string.format('Neorg %s', table.concat(args, ' '))
     local choices = {}
     for choice, _ in pairs(ref_definitions) do
-      table.insert(choices, choice)
+        table.insert(choices, choice)
     end
-    vim.ui.select(choices, {
+    local query
+    if vim.tbl_isempty(ref_definitions) then
+        query = function(...) vim.ui.input(...) end
+    else
+        query = function(...) vim.ui.select(choices, ...) end
+    end
+    query({
         prompt = current,
     }, function(choice)
-      vim.cmd(string.format('%s %s', current, choice))
+        if choice ~= nil then
+            vim.cmd(string.format('%s %s', current, choice))
+        end
     end)
 end
 


### PR DESCRIPTION
First of, I realised that I should maybe have first reach out and checked if this makes sense with the current vision. But you can see this more as a draft/suggestion and if you don't like it no problem :)

I started trying out `neorg` a few days ago and already loving it. When starting out one thing that bothered me a bit was when I was trying to run a command, let's say `:Neorg news` just to see what it does, I get an error with something like:
```
Unable to execute neorg command under name event_name - minimum argument count not satisfied. The command requires at least
```
of course I can then try again using `<Tab>` so see what the options are. But to reduce that little bit of friction I thought it would be great if instead of giving the error, `neorg` would instead query the user for the next argument using `vim.ui.select` (which can for example be call out to eg `telescope` based on the users config). This is what this MR attempts to achieve.

See the following gif for how the current MR can work:

![neorgcmd](https://user-images.githubusercontent.com/23341710/168492072-e5732eb3-d71a-4579-ac07-28f0c526e4fa.gif)

Feel free to let me know what you think and if this makes sense :)

Thanks for the awesome work :tada:
