### PR TITLE
feat(gtd.ui): add keybind to add captured task and directly capture a new one

### DIFF
--- a/lua/neorg/modules/core/gtd/ui/capture_popup.lua
+++ b/lua/neorg/modules/core/gtd/ui/capture_popup.lua
@@ -84,24 +84,11 @@ module.private = {
                         )
                     end)
                     :flag("<CR>", "Add to inbox", function()
-                        local workspace = neorg.modules.get_module_config("core.gtd.base").workspace
-                        local workspace_path = module.required["core.norg.dirman"].get_workspace(workspace)
-
-                        local files = module.required["core.norg.dirman"].get_norg_files(workspace)
-                        local inbox = neorg.modules.get_module_config("core.gtd.base").default_lists.inbox
-                        if not vim.tbl_contains(files, inbox) then
-                            log.error([[ Inbox file is not from gtd workspace.
-                            Please verify if the file exists in your gtd workspace.
-                            Type :messages to show the full error report
-                            ]])
-                            return
-                        end
-
-                        local uri = vim.uri_from_fname(workspace_path .. "/" .. inbox)
-                        local buf = vim.uri_to_bufnr(uri)
-                        local end_row, projectAtEnd = module.required["core.gtd.queries"].get_end_document_content(buf)
-
-                        module.required["core.gtd.queries"].create("task", task, buf, { end_row, 0 }, projectAtEnd)
+                        module.private.add_to_inbox(task)
+                    end)
+                    :flag("n", "Add to inbox and new capture", function()
+                        module.private.add_to_inbox(task)
+                        vim.cmd('Neorg gtd capture')
                     end)
 
                 return selection
@@ -524,6 +511,28 @@ module.private = {
         end
 
         return alphabet:sub(index, index)
+    end,
+
+
+    add_to_inbox = function(task)
+        local workspace = neorg.modules.get_module_config("core.gtd.base").workspace
+        local workspace_path = module.required["core.norg.dirman"].get_workspace(workspace)
+
+        local files = module.required["core.norg.dirman"].get_norg_files(workspace)
+        local inbox = neorg.modules.get_module_config("core.gtd.base").default_lists.inbox
+        if not vim.tbl_contains(files, inbox) then
+            log.error([[ Inbox file is not from gtd workspace.
+            Please verify if the file exists in your gtd workspace.
+            Type :messages to show the full error report
+            ]])
+            return
+        end
+
+        local uri = vim.uri_from_fname(workspace_path .. "/" .. inbox)
+        local buf = vim.uri_to_bufnr(uri)
+        local end_row, projectAtEnd = module.required["core.gtd.queries"].get_end_document_content(buf)
+
+        module.required["core.gtd.queries"].create("task", task, buf, { end_row, 0 }, projectAtEnd)
     end,
 }
 


### PR DESCRIPTION
This adds a keybind `n` in the capture popup which adds the current one to the inbox and directly starts capturing a new one.

I was also thinking it could be nice to have one more option to capture another task with the same context as the current one, any thoughts? Although not fully sure how to do that in a nice way.