### PR TITLE
feat(hop): open external links asynchronously

### DIFF
--- a/lua/neorg/modules/core/norg/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/hop/module.lua
@@ -9,6 +9,7 @@ require("neorg.modules.base")
 require("neorg.external.helpers")
 
 local module = neorg.modules.create("core.norg.esupports.hop")
+local job = require("plenary.job")
 
 module.setup = function()
     return {
@@ -401,14 +402,21 @@ module.public = {
         return neorg.lib.match(parsed_link_information.link_type)({
             -- If we're dealing with a URL, simply open the URL in the user's preferred method
             url = function()
-                local destination = parsed_link_information.link_location_text
+                local function open_with(command)
+                    job
+                        :new({
+                            command = command,
+                            args = { parsed_link_information.link_location_text },
+                        })
+                        :start()
+                end
 
                 if neorg.configuration.os_info == "linux" then
-                    vim.cmd('silent !xdg-open "' .. vim.fn.fnameescape(destination) .. '"')
+                    open_with("xdg-open")
                 elseif neorg.configuration.os_info == "mac" then
-                    vim.cmd('silent !open "' .. vim.fn.fnameescape(destination) .. '"')
+                    open_with("open")
                 else
-                    vim.cmd('silent !start "' .. vim.fn.fnameescape(destination) .. '"')
+                    open_with("start")
                 end
 
                 return {}
@@ -422,24 +430,21 @@ module.public = {
                     ) .. destination
 
                 local function open_in_external_app()
+                    local function open_with(command)
+                        job
+                            :new({
+                                command = command,
+                                args = { vim.uri_from_fname(vim.fn.expand(destination)) },
+                            })
+                            :start()
+                    end
+
                     if neorg.configuration.os_info == "linux" then
-                        vim.cmd(
-                            'silent !xdg-open "'
-                                .. vim.fn.fnameescape(vim.uri_from_fname(vim.fn.expand(destination)))
-                                .. '"'
-                        )
+                        open_with("xdg-open")
                     elseif neorg.configuration.os_info == "mac" then
-                        vim.cmd(
-                            'silent !open "'
-                                .. vim.fn.fnameescape(vim.uri_from_fname(vim.fn.expand(destination)))
-                                .. '"'
-                        )
+                        open_with("open")
                     else
-                        vim.cmd(
-                            'silent !start "'
-                                .. vim.fn.fnameescape(vim.uri_from_fname(vim.fn.expand(destination)))
-                                .. '"'
-                        )
+                        open_with("start")
                     end
                 end
 


### PR DESCRIPTION
First, thank you for your efforts in this project, `neorg` works great for me so far!

However, a major pain point I encountered while using `neorg` is that external links are currently opened synchronously via a simple call to `vim.cmd("xdg-open [...]")`; so when I follow a link to a website inside `neorg`, it will open my browser and then block until the browser is closed. I see a lot of potential in `neorg` for organizing references to websites and local files, but I think this behaviour makes it frankly unusable for this purpose and I don't think this behaviour is what most users would expect or want.

This PR proposes to instead spawn the processes used to open external links via `luvit` in an asynchronous manner; since `neorg` already uses/depends on `plenary.nvim`, this change comes pretty much for free by simply using `plenary.nvim`'s existing functionality.
