### PR TITLE
feat: add `core.tangle`

### DIFF
--- a/lua/neorg/external/helpers.lua
+++ b/lua/neorg/external/helpers.lua
@@ -135,6 +135,23 @@ neorg.utils = {
 
         return ret
     end,
+
+    get_filetype = function(file, force_filetype)
+        local filetype = force_filetype
+
+        -- Getting a filetype properly is... difficult
+        -- This is why we leverage Neovim instead.
+        -- We create a dummy buffer with the filepath the user wanted to export to
+        -- and query the filetype from there.
+        if not filetype then
+            local dummy_buffer = vim.uri_to_bufnr("file://" .. file)
+            vim.fn.bufload(dummy_buffer)
+            filetype = vim.api.nvim_buf_get_option(dummy_buffer, "filetype")
+            vim.api.nvim_buf_delete(dummy_buffer, { force = true })
+        end
+
+        return filetype
+    end,
 }
 
 neorg.lib = {

--- a/lua/neorg/external/helpers.lua
+++ b/lua/neorg/external/helpers.lua
@@ -371,7 +371,7 @@ neorg.lib = {
 
             -- luacheck: push ignore
             function_pointer = function(...)
-                return prev
+                return prev, unpack(params)
             end
             -- luacheck: pop
         end

--- a/lua/neorg/modules/core/defaults/module.lua
+++ b/lua/neorg/modules/core/defaults/module.lua
@@ -22,5 +22,6 @@ return neorg.modules.create_meta(
     "core.norg.esupports.hop",
     "core.integrations.treesitter",
     "core.storage",
-    "core.norg.news"
+    "core.norg.news",
+    "core.tangle"
 )

--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -85,27 +85,6 @@ module.public = {
             neorg.modules.get_module_config("core.export." .. ftype)
     end,
 
-    --- Queries the filetype for a certain file extension
-    ---@param file string #A filepath with an extension
-    ---@param force_filetype string #Force a specific filetype instead of querying
-    ---@return string #The filetype as extracted from the filename
-    get_filetype = function(file, force_filetype)
-        local filetype = force_filetype
-
-        -- Getting an extension properly is... difficult
-        -- This is why we leverage Neovim instead.
-        -- We create a dummy buffer with the filepath the user wanted to export to
-        -- and query the filetype from there.
-        if not filetype then
-            local dummy_buffer = vim.uri_to_bufnr("file://" .. file)
-            vim.fn.bufload(dummy_buffer)
-            filetype = vim.api.nvim_buf_get_option(dummy_buffer, "filetype")
-            vim.api.nvim_buf_delete(dummy_buffer, { force = true })
-        end
-
-        return filetype
-    end,
-
     --- Takes a buffer and exports it to a specific file
     ---@param buffer number #The buffer ID to read the contents from
     ---@param filetype string #A Neovim filetype to specify which language to export to
@@ -235,7 +214,7 @@ module.on_event = function(event)
         -- Syntax: Neorg export to-file file.extension forced-filetype?
         -- Example: Neorg export to-file my-custom-file markdown
 
-        local filetype = module.public.get_filetype(event.content[1], event.content[2])
+        local filetype = neorg.utils.get_filetype(event.content[1], event.content[2])
         local exported = module.public.export(event.buffer, filetype)
 
         vim.loop.fs_open(event.content[1], "w", 438, function(err, fd)

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -340,20 +340,6 @@ module.public = {
         }
     end,
 
-    --- Used to extract data from e.g. document.meta
-    -- @Param  tag_content (string) - the content of the tag (without the beginning and end declarations)
-    parse_tag = function(tag_content)
-        local result = {}
-
-        tag_content = tag_content:gsub("([^%s])~\n%s*", "%1 ")
-
-        for name, content in tag_content:gmatch("%s*(%w+):%s+([^\n]*)") do
-            result[name] = content
-        end
-
-        return result
-    end,
-
     --- Gets the range of a given node
     ---@param node userdata #The node to get the range of
     ---@return table #A table of `row_start`, `column_start`, `row_end` and `column_end` values
@@ -499,6 +485,98 @@ module.public = {
         end
 
         return find_closest_unnamed_node(result)
+    end,
+
+    get_document_metadata = function(buf)
+        buf = buf or 0
+
+        local languagetree = vim.treesitter.get_parser(buf, "norg")
+
+        if not languagetree then
+            return
+        end
+
+        local result = {}
+
+        languagetree:for_each_child(function(tree)
+            if tree:lang() ~= "norg_meta" then
+                return
+            end
+
+            local meta_language_tree = tree:parse()[1]
+
+            if not meta_language_tree then
+                return
+            end
+
+            local query = vim.treesitter.parse_query(
+                "norg_meta",
+                [[
+                (metadata
+                    (pair
+                        (key) @key
+                    )
+                )
+            ]]
+            )
+
+            local function parse_data(node)
+                return neorg.lib.match(node:type())({
+                    value = neorg.lib.wrap(module.public.get_node_text, node, buf),
+                    array = function()
+                        local resulting_array = {}
+
+                        for child in node:iter_children() do
+                            if child:named() then
+                                local parsed_data = parse_data(child)
+
+                                if parsed_data then
+                                    table.insert(resulting_array, parsed_data)
+                                end
+                            end
+                        end
+
+                        return resulting_array
+                    end,
+                    object = function()
+                        local resulting_object = {}
+
+                        for child in node:iter_children() do
+                            if not child:named() or child:type() ~= "pair" then
+                                goto continue
+                            end
+
+                            local key = child:named_child(0)
+                            local value = child:named_child(1)
+
+                            if not key then
+                                goto continue
+                            end
+
+                            local key_content = module.public.get_node_text(key, buf)
+
+                            resulting_object[key_content] = (value and parse_data(value) or vim.NIL)
+
+                            ::continue::
+                        end
+
+                        return resulting_object
+                    end,
+                })
+            end
+
+            for id, node in query:iter_captures(meta_language_tree:root(), buf) do
+                if query.captures[id] == "key" then
+                    local key_content = module.public.get_node_text(node, buf)
+
+                    result[key_content] = (
+                            node:next_named_sibling() and parse_data(node:next_named_sibling()) or vim.NIL
+                        )
+                end
+            end
+        end)
+
+        return result
     end,
 }
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -15,8 +15,8 @@ module.load = function()
     module.required["core.neorgcmd"].add_commands_from_table({
         definitions = {
             tangle = {
-                file= {},
-                directory = {},
+                file = {},
+                -- directory = {},
             }
         },
 
@@ -29,10 +29,10 @@ module.load = function()
                         max_args = 1,
                         name = "core.tangle.file",
                     },
-                    directory = {
-                        max_args = 1,
-                        name = "core.tangle.directory",
-                    }
+                    -- directory = {
+                    --     max_args = 1,
+                    --     name = "core.tangle.directory",
+                    -- }
                 }
             }
         }
@@ -63,34 +63,98 @@ module.on_event = function(event)
         local document_root = module.required["core.integrations.treesitter"].get_document_root(buffer)
 
         local options = {
-            files = { "" },
-            languages = {},
-            scope = "all", -- "all" | "tagged" (unimplemented)
+            files = parsed_document_metadata.tangle.files or { "" },
+            languages = parsed_document_metadata.tangle.languages or "all",
+            scope = parsed_document_metadata.tangle.scope or "all", -- "all" | "tagged" (unimplemented)
         }
+
+        local bound_files = {}
 
         if type(parsed_document_metadata.tangle) == "string" then
             options.files[1] = parsed_document_metadata.tangle
-        end
+            options.languages[1] = neorg.utils.get_filetype(parsed_document_metadata.tangle)
+            bound_files[options.languages[1]] = options.files[1]
+        else
+            for _, file in ipairs(options.files) do
+                local filetype = neorg.utils.get_filetype(file)
 
-        local filetype = neorg.utils.get_filetype(parsed_document_metadata.tangle)
-
-        local query = vim.treesitter.parse_query("norg", ([[
-                (ranged_tag
-                    (tag_name) @_name
-                    (tag_parameters
-                        parameter: (tag_param) @_language
-                        .
-                    )
-                    (#eq? @_name "code")
-                    (#eq? @_language "%s")
-                ) @code
-            ]]):format(filetype))
-
-        for id, node in query:iter_captures(document_root, buffer) do
-            if query.captures[id] == "code" then
-
+                if options.languages == "all" or vim.tbl_contains(options.languages, filetype) then
+                    bound_files[filetype] = file
+                end
             end
         end
+
+        local tangles = {}
+
+        for _, filetype in type(options.languages) ~= "table"
+            and (function() -- This is fine
+                local mem = { "" }
+                local prev = nil
+
+                return function()
+                    prev = next(mem, prev)
+                    return prev, ".*"
+                end
+            end)()
+            or ipairs(options.languages) -- FIX: This errors out for some reason
+            do
+
+            local query = vim.treesitter.parse_query("norg", ([[
+                    (ranged_tag
+                        (tag_name) @_name
+                        (tag_parameters
+                            parameter: (tag_param) @_language
+                            .
+                        )
+                        (#eq? @_name "code")
+                        (#match? @_language "^%s$")
+                    ) @code
+                ]]):format(filetype))
+
+            for id, node in query:iter_captures(document_root, buffer) do
+                if query.captures[id] == "code" then
+                    if node:parent():type() == "carryover_tag_set" then
+                        for tag in node:parent():iter_children() do
+                            if tag:type() == "carryover_tag" then
+                                local carryover_tag_name = tag:named_child(0)
+                                local carryover_tag_params = tag:named_child(1)
+
+                                if vim.treesitter.get_node_text(carryover_tag_name, buffer) == "tangle" then
+                                    log.warn('ok')
+                                    if carryover_tag_params then
+                                        local filepath = vim.trim(vim.treesitter.get_node_text(carryover_tag_params, buffer))
+
+                                        tangles[filepath] = tangles[filepath] or {}
+                                        table.insert(tangles[filepath], node)
+                                    elseif bound_files[filetype] then
+                                        -- Figure out which file to tangle to
+                                        local file_to_tangle_to = bound_files[filetype]
+                                        tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
+                                        table.insert(tangles[file_to_tangle_to], node)
+                                    end
+                                end
+                            end
+                        end
+                    elseif bound_files[filetype] then
+                        -- Figure out which file to tangle to
+                        local file_to_tangle_to = bound_files[filetype]
+                        tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
+                        table.insert(tangles[file_to_tangle_to], node)
+                    elseif filetype == ".*" then
+                        local language = vim.trim(vim.treesitter.get_node_text(node:named_child(1):named_child(0), buffer))
+
+                        local file_to_tangle_to = bound_files[language]
+
+                        if file_to_tangle_to then
+                            tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
+                            table.insert(tangles[file_to_tangle_to], node)
+                        end
+                    end
+                end
+            end
+        end
+
+        log.warn(tangles)
     end
 end
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -43,14 +43,10 @@ module.public = {
     tangle = function(buffer)
         local parsed_document_metadata = module.required["core.integrations.treesitter"].get_document_metadata(buffer)
 
-        if vim.tbl_isempty(parsed_document_metadata) then
-            log.error("Unable to tangle document - no document metadata present!")
-            return
-        end
-
-        if not parsed_document_metadata.tangle then
-            log.error("Unable to tangle document - no tangling information provided within metadata!")
-            return
+        if vim.tbl_isempty(parsed_document_metadata) or not parsed_document_metadata.tangle then
+            parsed_document_metadata = {
+                tangle = {},
+            }
         end
 
         local document_root = module.required["core.integrations.treesitter"].get_document_root(buffer)
@@ -70,6 +66,8 @@ module.public = {
                     options.languages[language] = file
                 end
             end
+        elseif type(parsed_document_metadata.tangle) == "string" then
+            options.languages[neorg.utils.get_filetype(parsed_document_metadata.tangle)] = parsed_document_metadata.tangle
         end
 
         local tangles = {
@@ -77,31 +75,29 @@ module.public = {
         }
 
         local query_str = neorg.lib.match(options.scope) {
-            all = [[
+            _ = [[
                 (ranged_tag
                     name: (tag_name) @_name
                     (#eq? @_name "code")
                     (tag_parameters
                         .
-                        parameter: (tag_param) @_language)
-                        (#any-of? @_language "%s")) @tag
+                        parameter: (tag_param) @_language)) @tag
             ]],
             tagged = [[
-                (carryover_tag
-                    name: (tag_name) @_carryover_tag_name
-                    (#eq? @_carryover_tag_name "tangle"))
-                .
-                (ranged_tag
-                    name: (tag_name) @_name
-                    (#eq? @_name "code")
-                    (tag_parameters
-                        .
-                        parameter: (tag_param) @_language)
-                        (#any-of? @_language "%s")) @tag
+                (carryover_tag_set
+                    (carryover_tag
+                        name: (tag_name) @_carryover_tag_name
+                        (#eq? @_carryover_tag_name "tangle"))
+                    (ranged_tag
+                        name: (tag_name) @_name
+                        (#eq? @_name "code")
+                        (tag_parameters
+                            .
+                            parameter: (tag_param) @_language)) @tag)
             ]],
         }
 
-        local query = vim.treesitter.parse_query("norg", string.format(query_str, table.concat(vim.tbl_keys(options.languages), "\" \"")))
+        local query = vim.treesitter.parse_query("norg", query_str)
 
         for id, node in query:iter_captures(document_root, buffer, 0, -1) do
             local capture = query.captures[id]
@@ -116,12 +112,18 @@ module.public = {
                         if attribute.name == "tangle.none" then
                             goto skip_tag
                         elseif attribute.name == "tangle" and attribute.parameters[1] then
+                            if options.scope == "main" then
+                                goto skip_tag
+                            end
+
                             file_to_tangle_to = table.concat(attribute.parameters)
                         end
                     end
 
-                    tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
-                    vim.list_extend(tangles[file_to_tangle_to], parsed_tag.content)
+                    if file_to_tangle_to then
+                        tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
+                        vim.list_extend(tangles[file_to_tangle_to], parsed_tag.content)
+                    end
 
                     ::skip_tag::
                 end
@@ -135,7 +137,29 @@ module.public = {
 module.on_event = function(event)
     if event.type == "core.neorgcmd.events.core.tangle.current-file" then
         local tangles = module.public.tangle(event.buffer)
-        log.warn(tangles)
+
+        if not tangles or vim.tbl_isempty(tangles) then
+            vim.notify("Nothing to tangle!")
+            return
+        end
+
+        for file, content in pairs(tangles) do
+            vim.loop.fs_open(file, "w", 438, function(err, fd)
+                assert(
+                    not err,
+                    neorg.lib.lazy_string_concat("Failed to open file '", file, "' for tangling: ", err)
+                )
+
+                vim.loop.fs_write(fd, table.concat(content, "\n"), 0, function(werr)
+                    assert(
+                        not werr,
+                        neorg.lib.lazy_string_concat("Failed to write to file '", file, "' for tangling: ", werr)
+                    )
+                end)
+
+                vim.schedule(neorg.lib.wrap(vim.notify, "Successfully tangled 1 file!"))
+            end)
+        end
     end
 end
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -113,13 +113,17 @@ module.public = {
                     local file_to_tangle_to = options.languages[parsed_tag.parameters[1]]
 
                     for _, attribute in ipairs(parsed_tag.attributes) do
-                        if attribute.name == "tangle" and attribute.parameters[1] then
+                        if attribute.name == "tangle.none" then
+                            goto skip_tag
+                        elseif attribute.name == "tangle" and attribute.parameters[1] then
                             file_to_tangle_to = table.concat(attribute.parameters)
                         end
                     end
 
                     tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
                     vim.list_extend(tangles[file_to_tangle_to], parsed_tag.content)
+
+                    ::skip_tag::
                 end
             end
         end

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -63,98 +63,27 @@ module.on_event = function(event)
         local document_root = module.required["core.integrations.treesitter"].get_document_root(buffer)
 
         local options = {
-            files = parsed_document_metadata.tangle.files or { "" },
-            languages = parsed_document_metadata.tangle.languages or "all",
-            scope = parsed_document_metadata.tangle.scope or "all", -- "all" | "tagged" (unimplemented)
+            languages = {},
+            scope = parsed_document_metadata.tangle.scope or "all", -- "all" | "tagged"
         }
 
-        local bound_files = {}
-
-        if type(parsed_document_metadata.tangle) == "string" then
-            options.files[1] = parsed_document_metadata.tangle
-            options.languages[1] = neorg.utils.get_filetype(parsed_document_metadata.tangle)
-            bound_files[options.languages[1]] = options.files[1]
-        else
-            for _, file in ipairs(options.files) do
-                local filetype = neorg.utils.get_filetype(file)
-
-                if options.languages == "all" or vim.tbl_contains(options.languages, filetype) then
-                    bound_files[filetype] = file
+        if type(parsed_document_metadata.tangle) == "table" then
+            if vim.tbl_islist(parsed_document_metadata.tangle) then
+                for _, file in ipairs(parsed_document_metadata.tangle) do
+                    options.languages[neorg.utils.get_filetype(file)] = file
+                end
+            elseif parsed_document_metadata.tangle.languages then
+                for language, file in pairs(parsed_document_metadata.tangle.languages) do
+                    options.languages[language] = file
                 end
             end
         end
 
-        local tangles = {}
+        log.warn(options)
 
-        for _, filetype in type(options.languages) ~= "table"
-            and (function() -- This is fine
-                local mem = { "" }
-                local prev = nil
+        -- local tangles = {}
 
-                return function()
-                    prev = next(mem, prev)
-                    return prev, ".*"
-                end
-            end)()
-            or ipairs(options.languages) -- FIX: This errors out for some reason
-            do
-
-            local query = vim.treesitter.parse_query("norg", ([[
-                    (ranged_tag
-                        (tag_name) @_name
-                        (tag_parameters
-                            parameter: (tag_param) @_language
-                            .
-                        )
-                        (#eq? @_name "code")
-                        (#match? @_language "^%s$")
-                    ) @code
-                ]]):format(filetype))
-
-            for id, node in query:iter_captures(document_root, buffer) do
-                if query.captures[id] == "code" then
-                    if node:parent():type() == "carryover_tag_set" then
-                        for tag in node:parent():iter_children() do
-                            if tag:type() == "carryover_tag" then
-                                local carryover_tag_name = tag:named_child(0)
-                                local carryover_tag_params = tag:named_child(1)
-
-                                if vim.treesitter.get_node_text(carryover_tag_name, buffer) == "tangle" then
-                                    log.warn('ok')
-                                    if carryover_tag_params then
-                                        local filepath = vim.trim(vim.treesitter.get_node_text(carryover_tag_params, buffer))
-
-                                        tangles[filepath] = tangles[filepath] or {}
-                                        table.insert(tangles[filepath], node)
-                                    elseif bound_files[filetype] then
-                                        -- Figure out which file to tangle to
-                                        local file_to_tangle_to = bound_files[filetype]
-                                        tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
-                                        table.insert(tangles[file_to_tangle_to], node)
-                                    end
-                                end
-                            end
-                        end
-                    elseif bound_files[filetype] then
-                        -- Figure out which file to tangle to
-                        local file_to_tangle_to = bound_files[filetype]
-                        tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
-                        table.insert(tangles[file_to_tangle_to], node)
-                    elseif filetype == ".*" then
-                        local language = vim.trim(vim.treesitter.get_node_text(node:named_child(1):named_child(0), buffer))
-
-                        local file_to_tangle_to = bound_files[language]
-
-                        if file_to_tangle_to then
-                            tangles[file_to_tangle_to] = tangles[file_to_tangle_to] or {}
-                            table.insert(tangles[file_to_tangle_to], node)
-                        end
-                    end
-                end
-            end
-        end
-
-        log.warn(tangles)
+        -- log.warn(tangles)
     end
 end
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -15,7 +15,7 @@ module.load = function()
     module.required["core.neorgcmd"].add_commands_from_table({
         definitions = {
             tangle = {
-                file = {},
+                ["current-file"] = {},
                 -- directory = {},
             }
         },
@@ -25,9 +25,9 @@ module.load = function()
                 args = 1,
 
                 subcommands = {
-                    file = {
-                        max_args = 1,
-                        name = "core.tangle.file",
+                    ["current-file"] = {
+                        args = 0,
+                        name = "core.tangle.current-file",
                     },
                     -- directory = {
                     --     max_args = 1,
@@ -133,7 +133,7 @@ module.public = {
 }
 
 module.on_event = function(event)
-    if event.type == "core.neorgcmd.events.core.tangle.file" then
+    if event.type == "core.neorgcmd.events.core.tangle.current-file" then
         local tangles = module.public.tangle(event.buffer)
         log.warn(tangles)
     end
@@ -141,7 +141,7 @@ end
 
 module.events.subscribed = {
     ["core.neorgcmd"] = {
-        ["core.tangle.file"] = true,
+        ["core.tangle.current-file"] = true,
         ["core.tangle.directory"] = true,
     }
 }

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -1,0 +1,104 @@
+--[[ TODO ]]
+
+local module = neorg.modules.create("core.tangle")
+
+module.setup = function()
+    return {
+        requires = {
+            "core.integrations.treesitter",
+            "core.neorgcmd"
+        }
+    }
+end
+
+module.load = function()
+    module.required["core.neorgcmd"].add_commands_from_table({
+        definitions = {
+            tangle = {
+                file= {},
+                directory = {},
+            }
+        },
+
+        data = {
+            tangle = {
+                args = 1,
+
+                subcommands = {
+                    file = {
+                        max_args = 1,
+                        name = "core.tangle.file",
+                    },
+                    directory = {
+                        max_args = 1,
+                        name = "core.tangle.directory",
+                    }
+                }
+            }
+        }
+    })
+end
+
+module.on_event = function(event)
+    if event.type == "core.neorgcmd.events.core.tangle.file" then
+        local buffer = event.buffer
+
+        if event.content[1] then
+            buffer = vim.fn.bufadd(event.content[1])
+            vim.fn.bufload(buffer)
+        end
+
+        local parsed_document_metadata = module.required["core.integrations.treesitter"].get_document_metadata(event.buffer)
+
+        if vim.tbl_isempty(parsed_document_metadata) then
+            log.error("Unable to tangle document - no document metadata present!")
+            return
+        end
+
+        if not parsed_document_metadata.tangle then
+            log.error("Unable to tangle document - no tangling information provided within metadata!")
+            return
+        end
+
+        local document_root = module.required["core.integrations.treesitter"].get_document_root(buffer)
+
+        local options = {
+            files = { "" },
+            languages = {},
+            scope = "all", -- "all" | "tagged" (unimplemented)
+        }
+
+        if type(parsed_document_metadata.tangle) == "string" then
+            options.files[1] = parsed_document_metadata.tangle
+        end
+
+        local filetype = neorg.utils.get_filetype(parsed_document_metadata.tangle)
+
+        local query = vim.treesitter.parse_query("norg", ([[
+                (ranged_tag
+                    (tag_name) @_name
+                    (tag_parameters
+                        parameter: (tag_param) @_language
+                        .
+                    )
+                    (#eq? @_name "code")
+                    (#eq? @_language "%s")
+                ) @code
+            ]]):format(filetype))
+
+        for id, node in query:iter_captures(document_root, buffer) do
+            if query.captures[id] == "code" then
+
+            end
+        end
+    end
+end
+
+module.events.subscribed = {
+    ["core.neorgcmd"] = {
+        ["core.tangle.file"] = true,
+        ["core.tangle.directory"] = true,
+    }
+}
+
+return module


### PR DESCRIPTION
It is time :D

This PR adds basic tangling support for Neorg (only for the currently open file). For proper documentation I recommend you consult the wiki entry. I'll copy paste it here for reference:

The goal of this module is to allow users to spit out the contents of code blocks into
many different files. This is the primary component required for a literate configuration in Neorg.

## Commands
- `:Neorg tangle current-file` - performs all possible tangling operations on the current file

## Mini-Tutorial
By default, *zero* code blocks are tangled. You must provide where you'd like to tangle each code block manually (we'll get to global configuration later).
To do so, add a `#tangle <output-file>` tag above the code block you'd wish to export. For example:

```norg
#tangle init.lua
@code lua
print("Hello World!")
@end
```
The above snippet will *only* tangle that single code block to the desired output file: `init.lua`.

### Global Tangling for Single Files
Apart from tangling a single or a set of code blocks, you can declare a global output file in the document's metadata:
```norg
@document.meta
tangle: ./init.lua
@end
```

This will tangle all `lua` code blocks to `init.lua`, *unless* the code block has an explicit `#tangle` tag associated with it, in which case
the `#tangle` tag takes precedence.

### Global Tangling for Multiple Files
Apart from a single filepath, you can provide many in an array:
```norg
@document.meta
tangle: [
    ./init.lua
    ./output.hs
]
@end
```

The above snippet tells the Neorg tangling engine to tangle all `lua` code blocks to `./init.lua` and all `haskell` code blocks to `./output.hs`.
As always if any of the code blocks have a `#tangle` tag then that takes precedence.

### Ignoring Code Blocks
Sometimes when tangling you may want to omit some code blocks. For this you may use the `#tangle.none` tag:
```norg
#tangle.none
@code lua
print("I won't be tangled!")
@end
```

### Global Tangling with Extra Options
But wait, it doesn't stop there! You can supply a string to `tangle`, an array to `tangle`, but also an object!
It looks like this:
```norg
@document.meta
tangle: {
    languages: {
        lua: ./output.lua
        haskell: my-haskell-file
    }
    scope: all
}
@end
```

The `scope` option is discussed in a [later section](#tangling-scopes), what we want to focus on is the `languages` object.
It's a simple language-filepath mapping, but it's especially useful when the output file's language type cannot be inferred from the name.
So far we've been using `init.lua`, `output.hs` - but what if we wanted to export all `haskell` code blocks into `my-file-without-an-extension`?
The only way to do that is through the `languages` object, where we explicitly define the language to tangle. Neat!

### Tangling Scopes
What you've seen so far is the tangler operating in `all` mode. This means it captures all code blocks of a certain type unless that code block is tagged
with `#tangle.none`. There are two other types: `tagged` and `main`.

#### The `tagged` Scope
When in this mode, the tangler will only tangle code blocks that have been `tagged` with a `#tangle` tag.
Note that you don't have to always provide a filetype, and that:
```norg
#tangle
@code lua
@end
```
Will use the global output file for that language as defined in the metadata. I.e., if I do:
```norg
@document.meta
tangle: {
    languages: {
        lua: ./output.lua
    }
    scope: tagged
}
@end

@code lua
print("Hello")
@end

#tangle
@code lua
print("Sup")
@end

#tangle other-file.lua
@code lua
print("Ayo")
@end
```
The first code block will not be touched, the second code block will be tangled to `./output.lua` and the third code block will be tangled to `other-file.lua. You
can probably see that this system can get expressive pretty quick.

#### The `main` scope
This mode is the opposite of the `tagged` one in that it will only tangle code blocks to files that are defined in the document metadata. I.e. in this case:
```norg
@document.meta
tangle: {
    languages: {
        lua: ./output.lua
    }
    scope: main
}
@end

@code lua
print("Hello")
@end

#tangle
@code lua
print("Sup")
@end

#tangle other-file.lua
@code lua
print("Ayo")
@end
```
The first code block will be tangled to `./output.lua`, the second code block will also be tangled to `./output.lua` and the third code block will be ignored.
