### PR TITLE
fix(export.markdown): properly format markdown links

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -406,7 +406,7 @@ module.public = {
                 table.insert(output, #output - 1, "#")
 
                 last_parsed_link_location = output[#output - 1]
-                output[#output - 1] = output[#output - 1]:lower():gsub("[^%s%w]+", ""):gsub("%s+", "-")
+                output[#output - 1] = output[#output - 1]:lower():gsub("-", " "):gsub("%p+", ""):gsub("%s+", "-")
 
                 return output
             end,


### PR DESCRIPTION
Hi! If you export a link using non-ASCII characters, you will get an empty link.

<details>
<summary>Neorg file</summary>

```norg
* что-то, на. русском!!

  {* что-то на русском}
```

</details>

<details>
<summary>Before</summary>

```md
# что-то, на. русском!!

[что-то на русском](#-)
```

</details>

<details>
<summary>After</summary>

```md
# что-то, на. русском!!

[что-то на русском](#что-то-на-русском)
```

</details>
