### PR TITLE
fix(export.markdown): paragraph breaks

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -169,7 +169,7 @@ module.public = {
             end,
 
             ["_paragraph_break"] = function(newlines, _, state)
-                return string.rep("\n", newlines:len()) .. string.rep(" ", state.indent),
+                return string.rep("\n\n", newlines:len()) .. string.rep(" ", state.indent),
                     false,
                     {
                         weak_indent = 0,


### PR DESCRIPTION
If you export a `.norg` file with multiple paragraphs to markdown, you will get incorrect paragraph breaks.

<details>
<summary>Neorg file</summary>

```norg
123

456


789
```

</details>

<details>
<summary>Before</summary>

```md
123
456

789
```

</details>

<details>
<summary>After</summary>

```md
123

456


789
```

</details>
