### PR TITLE
fix: fix state_to_text translation for gtd

### DIFF
--- a/lua/neorg/modules/core/gtd/helpers/module.lua
+++ b/lua/neorg/modules/core/gtd/helpers/module.lua
@@ -152,7 +152,7 @@ module.public = {
             uncertain = "- [?]",
             urgent = "- [!]",
             recurring = "- [+]",
-            onhold = "- [=]",
+            on_hold = "- [=]",
             cancelled = "- [_]",
         })
     end,


### PR DESCRIPTION
I noticed a bug when trying to view the project view in GTD. It seems that the helper was improperly mapping state to `onhold` rather than `on_hold`, as it's seen everywhere else in the codebase.