### PR TITLE
fix(export): using `vim.fn.expand` for path (fixes #540)

### DIFF
--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -210,26 +210,27 @@ module.on_event = function(event)
         -- Syntax: Neorg export to-file file.extension forced-filetype?
         -- Example: Neorg export to-file my-custom-file markdown
 
-        local filetype = neorg.utils.get_filetype(event.content[1], event.content[2])
+        local path = vim.fn.expand(event.content[1])
+        local filetype = neorg.utils.get_filetype(path, event.content[2])
         local exported = module.public.export(event.buffer, filetype)
 
-        vim.loop.fs_open(event.content[1], "w", 438, function(err, fd)
+        vim.loop.fs_open(path, "w", 438, function(err, fd)
             assert(
                 not err,
-                neorg.lib.lazy_string_concat("Failed to open file '", event.content[1], "' for export: ", err)
+                neorg.lib.lazy_string_concat("Failed to open file '", path, "' for export: ", err)
             )
 
             vim.loop.fs_write(fd, exported, 0, function(werr)
                 assert(
                     not werr,
-                    neorg.lib.lazy_string_concat("Failed to write to file '", event.content[1], "' for export: ", werr)
+                    neorg.lib.lazy_string_concat("Failed to write to file '", path, "' for export: ", werr)
                 )
             end)
 
             vim.schedule(neorg.lib.wrap(vim.notify, "Successfully exported 1 file!"))
         end)
     elseif event.type == "core.neorgcmd.events.export.directory" then
-        local path = event.content[3]
+        local path = vim.fn.expand(event.content[3])
             or module.config.public.export_dir
                 :gsub("<language>", event.content[2])
                 :gsub("<export%-dir>", event.content[1])

--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -230,7 +230,7 @@ module.on_event = function(event)
             vim.schedule(neorg.lib.wrap(vim.notify, "Successfully exported 1 file!"))
         end)
     elseif event.type == "core.neorgcmd.events.export.directory" then
-        local path = vim.fn.expand(event.content[3])
+        local path = event.content[3] and vim.fn.expand(event.content[3])
             or module.config.public.export_dir
                 :gsub("<language>", event.content[2])
                 :gsub("<export%-dir>", event.content[1])

--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -210,20 +210,20 @@ module.on_event = function(event)
         -- Syntax: Neorg export to-file file.extension forced-filetype?
         -- Example: Neorg export to-file my-custom-file markdown
 
-        local path = vim.fn.expand(event.content[1])
-        local filetype = neorg.utils.get_filetype(path, event.content[2])
+        local filepath = vim.fn.expand(event.content[1])
+        local filetype = neorg.utils.get_filetype(filepath, event.content[2])
         local exported = module.public.export(event.buffer, filetype)
 
-        vim.loop.fs_open(path, "w", 438, function(err, fd)
+        vim.loop.fs_open(filepath, "w", 438, function(err, fd)
             assert(
                 not err,
-                neorg.lib.lazy_string_concat("Failed to open file '", path, "' for export: ", err)
+                neorg.lib.lazy_string_concat("Failed to open file '", filepath, "' for export: ", err)
             )
 
             vim.loop.fs_write(fd, exported, 0, function(werr)
                 assert(
                     not werr,
-                    neorg.lib.lazy_string_concat("Failed to write to file '", path, "' for export: ", werr)
+                    neorg.lib.lazy_string_concat("Failed to write to file '", filepath, "' for export: ", werr)
                 )
             end)
 
@@ -270,7 +270,7 @@ module.on_event = function(event)
                     end
 
                     vim.schedule(function()
-                        local filepath = event.content[1] .. "/" .. name
+                        local filepath = vim.fn.expand(event.content[1]) .. "/" .. name
 
                         vim.opt.eventignore = "BufEnter"
 


### PR DESCRIPTION
This patch fixes issue #540