### PR TITLE
fix(export.markdown): always save last parsed link

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -417,6 +417,8 @@ module.public = {
 
         recollectors = {
             ["link_location"] = function(output, state)
+                last_parsed_link_location = output[#output - 1]
+
                 if state.is_url then
                     state.is_url = false
                     output[#output - 1] = vim.uri_from_fname(output[#output - 1]):sub(string.len("file://") + 1)
@@ -424,8 +426,6 @@ module.public = {
                 end
 
                 table.insert(output, #output - 1, "#")
-
-                last_parsed_link_location = output[#output - 1]
                 output[#output - 1] = output[#output - 1]:lower():gsub("-", " "):gsub("%p+", ""):gsub("%s+", "-")
 
                 return output


### PR DESCRIPTION
Part of #508

Neorg:
```norg
A link without description: {www.wikipedia.org}
```

Before:
```markdown
A link without description: [](www.wikipedia.org)
```

After:
```markdown
A link without description: [www.wikipedia.org](www.wikipedia.org)
```