### PR TITLE
fix(export): export correct yaml metadata

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -310,7 +310,7 @@ module.public = {
                         }
                 elseif text == "document.meta" and module.config.public.extensions["metadata"] then
                     return module.config.public.metadata["start"],
-                        true,
+                        false,
                         {
                             tag_indent = tag_start_column - 1,
                             tag_close = module.config.public.metadata["end"],
@@ -526,6 +526,11 @@ module.public = {
             ["heading4"] = handle_heading_newlines(),
             ["heading5"] = handle_heading_newlines(),
             ["heading6"] = handle_heading_newlines(),
+
+            ["pair"] = function(output)
+                table.insert(output, "\n")
+                return output
+            end,
         },
 
         cleanup = function()

--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -155,6 +155,14 @@ module.public = {
                         end
 
                         if keep_descending then
+                            if state.parse_as then
+                                node = module.required["core.integrations.treesitter"].get_document_root(
+                                    "\n" .. vim.treesitter.get_node_text(node, buffer),
+                                    state.parse_as
+                                )
+                                state.parse_as = nil
+                            end
+
                             local ret = descend(node)
 
                             if ret then
@@ -215,10 +223,7 @@ module.on_event = function(event)
         local exported = module.public.export(event.buffer, filetype)
 
         vim.loop.fs_open(filepath, "w", 438, function(err, fd)
-            assert(
-                not err,
-                neorg.lib.lazy_string_concat("Failed to open file '", filepath, "' for export: ", err)
-            )
+            assert(not err, neorg.lib.lazy_string_concat("Failed to open file '", filepath, "' for export: ", err))
 
             vim.loop.fs_write(fd, exported, 0, function(werr)
                 assert(

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -483,18 +483,28 @@ module.public = {
         }
     end,
 
-    --- Extracts the document root from the current document
-    ---@param buf number The number of the buffer to extract (can be nil)
+    --- Extracts the document root from the current document or from the string
+    ---@param src number|string The number of the buffer to extract or string with code (can be nil)
+    ---@param filetype The filetype of the buffer or the string with code
     ---@return userdata #The root node of the document
-    get_document_root = function(buf)
-        local tree = vim.treesitter.get_parser(buf or 0, "norg"):parse()[1]
+    get_document_root = function(src, filetype)
+        filetype = filetype or "norg"
 
-        if not tree or not tree:root() then
+        local parser
+        if type(src) == "string" then
+            parser = vim.treesitter.get_string_parser(src, filetype)
+        else
+            parser = vim.treesitter.get_parser(src or 0, filetype)
+        end
+
+        local tree = parser:parse()[1]
+
+        if not tree or not tree:root() or tree:root():type() == "ERROR" then
             log.warn("Unable to parse the current document's syntax tree :(")
             return
         end
 
-        return tree:root():type() ~= "ERROR" and tree:root()
+        return tree:root()
     end,
 
     --- Attempts to find a parent of a node recursively


### PR DESCRIPTION
Part of #508

<details>
<summary>Neorg</summary>

```norg
@document.meta
title: test
description:
categories: [
  this
  that
]
created: 2022-07-10
version: 0.0.11
@end
```

</details>

<details>
<summary>Before</summary>

```markdown
---

title: test
description:
categories: [
  this
  that
]
created: 2022-07-10
version: 0.0.11
---
```

</details>

<details>
<summary>After</summary>

```markdown
---
title: test
description:
categories:
  - this
  - that
created: 2022-07-10
version: 0.0.11
---
```

</details>
