### PR TITLE
feat(export): export code blocks

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -323,7 +323,7 @@ module.public = {
                             tag_close = module.config.public.metadata["end"],
                             is_meta = true,
                         }
-                elseif text == "export"
+                elseif text == "embed"
                     and node:next_sibling()
                     and ts_utils.get_node_text(node:next_sibling())[1] == "markdown"
                 then

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -283,8 +283,8 @@ module.public = {
             ["ordered_list6_prefix"] = ordered_list_prefix(6),
 
             ["tag_parameters"] = function(text, _, state)
-                if state.is_export then
-                    state.is_export = nil
+                if state.ignore_tag_parameters then
+                    state.ignore_tag_parameters = nil
                     return "", false, state
                 end
 
@@ -332,12 +332,14 @@ module.public = {
                         {
                             tag_indent = tag_start_column - 1,
                             tag_close = "",
-                            is_export = true,
+                            ignore_tag_parameters = true,
                         }
                 end
 
                 state.tag_close = nil
-                return nil, false, state
+                return nil, false, {
+                    ignore_tag_parameters = true,
+                }
             end,
 
             ["ranged_tag_content"] = function(text, node, state)

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -282,9 +282,16 @@ module.public = {
             ["ordered_list5_prefix"] = ordered_list_prefix(5),
             ["ordered_list6_prefix"] = ordered_list_prefix(6),
 
-            ["tag_parameters"] = true,
+            ["tag_parameters"] = function(text, _, state)
+                if state.is_export then
+                    state.is_export = nil
+                    return "", false, state
+                end
 
-            ["tag_name"] = function(text, node, state)
+                return text
+            end,
+
+            ["tag_name"] = function(text, node, state, ts_utils)
                 local _, tag_start_column = node:range()
 
                 if text == "code" then
@@ -315,6 +322,17 @@ module.public = {
                             tag_indent = tag_start_column - 1,
                             tag_close = module.config.public.metadata["end"],
                             is_meta = true,
+                        }
+                elseif text == "export"
+                    and node:next_sibling()
+                    and ts_utils.get_node_text(node:next_sibling())[1] == "markdown"
+                then
+                    return "",
+                        false,
+                        {
+                            tag_indent = tag_start_column - 1,
+                            tag_close = "",
+                            is_export = true,
                         }
                 end
 

--- a/lua/neorg/modules/core/looking-glass/module.lua
+++ b/lua/neorg/modules/core/looking-glass/module.lua
@@ -158,7 +158,7 @@ module.on_event = function(event)
             [[
             (ranged_tag
                 name: (tag_name) @_name
-                (#eq? @_name "code")) @tag
+                (#any-of? @_name "code" "export")) @tag
         ]]
         )
 

--- a/lua/neorg/modules/core/looking-glass/module.lua
+++ b/lua/neorg/modules/core/looking-glass/module.lua
@@ -158,7 +158,7 @@ module.on_event = function(event)
             [[
             (ranged_tag
                 name: (tag_name) @_name
-                (#any-of? @_name "code" "export")) @tag
+                (#any-of? @_name "code" "embed")) @tag
         ]]
         )
 

--- a/lua/neorg/modules/core/norg/completion/module.lua
+++ b/lua/neorg/modules/core/norg/completion/module.lua
@@ -86,6 +86,7 @@ module.public = {
             complete = {
                 "table",
                 "code",
+                "export",
                 "image",
                 "embed",
                 "document",
@@ -128,6 +129,17 @@ module.public = {
                     },
 
                     -- Don't descend any further, we've narrowed down our match
+                    descend = {},
+                },
+                {
+                    regex = "export%s+%w*",
+
+                    complete = require("neorg.external.helpers").get_language_list(true),
+
+                    options = {
+                        type = "Language",
+                    },
+
                     descend = {},
                 },
                 {

--- a/lua/neorg/modules/core/norg/completion/module.lua
+++ b/lua/neorg/modules/core/norg/completion/module.lua
@@ -86,7 +86,6 @@ module.public = {
             complete = {
                 "table",
                 "code",
-                "export",
                 "image",
                 "embed",
                 "document",

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -269,7 +269,7 @@ module.public = {
                 "norg",
                 [[(
                     (ranged_tag (tag_name) @_name) @tag
-                    (#eq? @_name "code")
+                    (#any-of? @_name "code" "export")
                 )]]
             )
 

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -269,7 +269,7 @@ module.public = {
                 "norg",
                 [[(
                     (ranged_tag (tag_name) @_name) @tag
-                    (#any-of? @_name "code" "export")
+                    (#any-of? @_name "code" "embed")
                 )]]
             )
 

--- a/lua/neorg/modules/core/syntax/module.lua
+++ b/lua/neorg/modules/core/syntax/module.lua
@@ -109,7 +109,7 @@ module.public = {
                 "norg",
                 [[(
                     (ranged_tag (tag_name) @_tagname (tag_parameters) @language)
-                    (#eq? @_tagname "code")
+                    (#any-of? @_tagname "code" "export")
                 )]]
             )
 

--- a/lua/neorg/modules/core/syntax/module.lua
+++ b/lua/neorg/modules/core/syntax/module.lua
@@ -109,7 +109,7 @@ module.public = {
                 "norg",
                 [[(
                     (ranged_tag (tag_name) @_tagname (tag_parameters) @language)
-                    (#any-of? @_tagname "code" "export")
+                    (#any-of? @_tagname "code" "embed")
                 )]]
             )
 

--- a/queries/norg/injections.scm
+++ b/queries/norg/injections.scm
@@ -1,5 +1,5 @@
 ; Injection for code blocks
-(ranged_tag (tag_name) @_tagname (tag_parameters parameter: (tag_param) @language) (ranged_tag_content) @content (#any-of? @_tagname "code" "export") (#not-eq? @language "norg"))
+(ranged_tag (tag_name) @_tagname (tag_parameters parameter: (tag_param) @language) (ranged_tag_content) @content (#any-of? @_tagname "code" "embed") (#not-eq? @language "norg"))
 (ranged_tag (tag_name) @_tagname (tag_parameters)? (ranged_tag_content) @latex (#eq? @_tagname "math"))
 
 (

--- a/queries/norg/injections.scm
+++ b/queries/norg/injections.scm
@@ -1,5 +1,5 @@
 ; Injection for code blocks
-(ranged_tag (tag_name) @_tagname (tag_parameters parameter: (tag_param) @language) (ranged_tag_content) @content (#eq? @_tagname "code") (#not-eq? @language "norg"))
+(ranged_tag (tag_name) @_tagname (tag_parameters parameter: (tag_param) @language) (ranged_tag_content) @content (#any-of? @_tagname "code" "export") (#not-eq? @language "norg"))
 (ranged_tag (tag_name) @_tagname (tag_parameters)? (ranged_tag_content) @latex (#eq? @_tagname "math"))
 
 (


### PR DESCRIPTION
New feature: export of code blocks. See example:

### Neorg
```norg
* Test title

  @export markdown
  ## Another title

  **bold** *italic*

  <h3>Test subtitle</h3>
  @end

  @export latex
  I don't want to export it to markdown
  @end

  *bold* /italic/
```

### Markdown
```markdown
# Test title



## Another title

**bold** *italic*

<h3>Test subtitle</h3>




**bold** _italic_
```
