### PR TITLE
fix(core.ui): filetype `neorg` -> `norg`

### DIFF
--- a/lua/neorg/modules/core/ui/module.lua
+++ b/lua/neorg/modules/core/ui/module.lua
@@ -131,7 +131,7 @@ module.public = {
             bufhidden = "hide",
             buftype = "nofile",
             buflisted = false,
-            filetype = "neorg",
+            filetype = "norg",
         }
 
         vim.api.nvim_buf_set_name(buf, bufname)
@@ -188,7 +188,7 @@ module.public = {
             bufhidden = "hide",
             buftype = "nofile",
             buflisted = false,
-            filetype = "neorg",
+            filetype = "norg",
         }
 
         vim.api.nvim_buf_set_name(buf, "neorg://" .. name)


### PR DESCRIPTION
Fixed the error that occurred when following a link in toc:
```
Error executing vim.schedule lua callback: ...org/lua/neorg/modules/core/norg/esupports/hop/module.lua:206: attempt to index local 'node_under_cursor' (a nil value)
```