### PR TITLE
feat(highlights): add multiline comments highlight

### DIFF
--- a/lua/neorg/modules/core/highlights/module.lua
+++ b/lua/neorg/modules/core/highlights/module.lua
@@ -79,6 +79,10 @@ module.config.public = {
 
                 parameters = "+@string",
             },
+
+            comment = {
+                content = "+@comment"
+            }
         },
 
         headings = {

--- a/queries/norg/highlights.scm
+++ b/queries/norg/highlights.scm
@@ -4,7 +4,9 @@
 	content: (ranged_tag_content)?
 	(ranged_tag_end ("_prefix") @neorg.tags.ranged_verbatim.end ("_name") @neorg.tags.ranged_verbatim.name.word))
 
-; TODO: Make the content of @comment darker
+(ranged_tag ("_prefix")
+	name: (tag_name) @neorg.tags.ranged_verbatim.name (#eq? @neorg.tags.ranged_verbatim.name "comment")
+	content: (ranged_tag_content)? @neorg.tags.comment.content)
 
 (carryover_tag_set
     (carryover_tag


### PR DESCRIPTION
### Before
<img width="909" alt="before" src="https://user-images.githubusercontent.com/57654917/187423405-a5b5bb77-2262-42e3-b353-c8eedf0b1d24.png">

### After
<img width="857" alt="after" src="https://user-images.githubusercontent.com/57654917/187423416-e4b84783-5a54-4f1b-99a5-911595e06a35.png">
