### PR TITLE
fix(tangle): show correct tangled count

### DIFF
--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -288,8 +288,12 @@ module.on_event = function(event)
             return
         end
 
+        local file_count = vim.tbl_count(tangles)
+        local tangled_count = 0
+
         for file, content in pairs(tangles) do
             vim.loop.fs_open(vim.fn.expand(file), "w", 438, function(err, fd)
+                file_count = file_count - 1
                 assert(not err, neorg.lib.lazy_string_concat("Failed to open file '", file, "' for tangling: ", err))
 
                 vim.loop.fs_write(fd, table.concat(content, "\n"), 0, function(werr)
@@ -299,7 +303,12 @@ module.on_event = function(event)
                     )
                 end)
 
-                vim.schedule(neorg.lib.wrap(vim.notify, "Successfully tangled 1 file!"))
+                tangled_count = tangled_count + 1
+                if file_count == 0 then
+                    vim.schedule(
+                        neorg.lib.wrap(vim.notify, string.format("Successfully tangled %d file!", tangled_count))
+                    )
+                end
             end)
         end
     end

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -306,7 +306,7 @@ module.on_event = function(event)
                 tangled_count = tangled_count + 1
                 if file_count == 0 then
                     vim.schedule(
-                        neorg.lib.wrap(vim.notify, string.format("Successfully tangled %d file!", tangled_count))
+                        neorg.lib.wrap(vim.notify, string.format("Successfully tangled %d file%s!", tangled_count, tangled_count == 1 and "" or "s"))
                     )
                 end
             end)


### PR DESCRIPTION
For example, I want to tangle two files

Before:
```
Successfully tangled 1 file!
Successfully tangled 1 file!
```

After:
```
Successfully tangled 2 file!
```