### PR TITLE
feat(meta): add a new updated field to document metadata

### DIFF
--- a/lua/neorg/modules/core/highlights/module.lua
+++ b/lua/neorg/modules/core/highlights/module.lua
@@ -55,6 +55,7 @@ module.config.public = {
                     authors = "+@annotation",
                     categories = "+@keyword",
                     created = "+@float",
+                    updated = "+@float",
                     version = "+@float",
 
                     object = {

--- a/lua/neorg/modules/core/norg/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/metagen/module.lua
@@ -20,6 +20,9 @@ module.config.public = {
     -- - Empty generates metadata only for new files/buffers.
     type = "none",
 
+    -- Whether updated date field should be automatically updated on save if required
+    update_date = true,
+
     -- How to generate a tabulation inside the `@document.meta` tag
     tab = "",
 
@@ -186,13 +189,15 @@ module.load = function()
         module.private.listen_event = "bufnewfile"
     end
 
-    vim.api.nvim_create_autocmd("BufWritePre", {
-        pattern = "*.norg",
-        callback = function()
-            module.public.update_metadata(vim.api.nvim_get_current_buf())
-        end,
-        desc = "Update updated date metadata field in norg documents",
-    })
+    if module.config.public.update_date then
+        vim.api.nvim_create_autocmd("BufWritePre", {
+            pattern = "*.norg",
+            callback = function()
+                module.public.update_metadata(vim.api.nvim_get_current_buf())
+            end,
+            desc = "Update updated date metadata field in norg documents",
+        })
+    end
 end
 
 module.on_event = function(event)

--- a/queries/norg_meta/highlights.scm
+++ b/queries/norg_meta/highlights.scm
@@ -57,6 +57,12 @@
 
 (pair
     (key) @_key
+    (value) @neorg.tags.ranged_verbatim.document_meta.updated
+    (#eq? @_key "updated")
+)
+
+(pair
+    (key) @_key
     (value) @neorg.tags.ranged_verbatim.document_meta.version
     (#eq? @_key "version")
 )


### PR DESCRIPTION
This PR aims to add a new field to default document metadata template called `updated` that serves as a last updated field for norg documents.

That field gets automatically updated on `BufWritePre` event if current date is different from last updated date from said field.

Edit: also updated `neorg.modules.core.norg.esupports.metagen.module` to use `module.required["core.neorgcmd"].add_commands_from_table()` for creating `:Neorg` commands as discussed on discord server.