### PR TITLE
feat: disable lazy loading by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,12 @@ You can install it through your favorite plugin manager:
   
 - [Packer (with lazyloading)](https://github.com/wbthomason/packer.nvim):
 
-  Want to lazy load? Know that you'll have to jump through some hoops and hurdles to get
-  it to work perfectly.
-  You can use the `ft` key to load Neorg only upon entering a `.norg` file:
+  Want to lazy load? You can use the `ft` key to load Neorg only upon entering a `.norg` file:
 
   ```lua
   use {
       "nvim-neorg/neorg",
-      -- tag = "latest",
+      -- tag = "*",
       ft = "norg",
       after = "nvim-treesitter", -- You may want to specify Telescope here as well
       config = function()
@@ -161,12 +159,9 @@ You can install it through your favorite plugin manager:
   }
   ```
 
-  Although it's proven to work for a lot of people, you might need additional setups depending on how your lazyloading system is configured.
-
-  One important thing to ask yourself is: "is it really worth it?".
-  Neorg practically lazy loads itself: only a few lines of code are run on startup, these lines check whether the current
-  extension is `.norg`, if it's not then nothing else loads. You shouldn't have to worry about performance issues when it comes to startup, but
-  hey, you do you :)
+  Although it's proven to work for a lot of people, you might need to take some
+  additional steps depending on how your lazyloading system and/or Neovim
+  config is set up.
 
 - [vim-plug](https://github.com/junegunn/vim-plug):
 
@@ -190,21 +185,23 @@ You can install it through your favorite plugin manager:
 Neorg will automatically attempt to install the parsers for you upon entering a `.norg` file if you have `core.defaults` loaded.
 A command is also exposed to reinstall and/or update these parsers: `:Neorg sync-parsers`.
 
-Note that the `:Neorg sync-parsers` command is only available when in a `.norg` file, and the installation isn't reproducible.
-To make it permanent, you want to alter your treesitter configuration a little:
-
+It is important to note that installation via this command isn't reproducible.
+There are a few ways to make it reproducible, but the recommended way is to set up an **update flag** for your plugin
+manager of choice. In packer, your configuration may look something like this:
 ```lua
-require('nvim-treesitter.configs').setup {
-    ensure_installed = { "norg", --[[ other parsers you would wish to have ]] },
-    highlight = { -- Be sure to enable highlights if you haven't!
-        enable = true,
-    }
+use {
+    "nvim-neorg/neorg",
+    run = ":Neorg sync-parsers", -- This is the important bit!
+    config = function()
+        require("neorg").setup {
+            -- configuration here
+        }
+    end,
 }
 ```
 
-NOTE: Putting `"norg_meta"` into your `ensure_installed` table may trigger unintended errors.
-This is because `norg_meta` isn't in the native `nvim-treesitter` repositories, and the parser is
-only defined while using Neorg. This is why using `:Neorg sync-parsers` is recommended.
+With the above `run` key set, every time you update Neorg the internal parsers
+will also be updated to the correct revision.
 
 ### Troubleshooting Treesitter
 - Not using packer? Make sure that Neorg's `setup()` gets called after `nvim-treesitter`'s setup.
@@ -267,11 +264,7 @@ require('neorg').setup {
 ```
 
 Changing workspaces is easy, just do `:Neorg workspace work`, where `work` is the name of your workspace.
-Note that `:Neorg` is only available when the Neorg environment is loaded, i.e. when you're
-in a `.norg` file or have loaded a `.norg` file already in your Neovim session.
-
-If the Neorg environment isn't loaded you'll find a `:NeorgStart` command which will launch Neorg and pop
-you in to your last (or only) workspace.
+Voila!
 
 #### It works, cool! What are the next steps?
 

--- a/lua/neorg/config.lua
+++ b/lua/neorg/config.lua
@@ -2,7 +2,7 @@
 neorg.configuration = {
 
     user_configuration = {
-        lazy_loading = true,
+        lazy_loading = false,
         load = {
             --[[
 				["name"] = { config = { ... } }

--- a/lua/neorg/config.lua
+++ b/lua/neorg/config.lua
@@ -14,7 +14,7 @@ neorg.configuration = {
     manual = nil,
     arguments = {},
 
-    version = "0.0.13",
+    version = "0.0.14",
     neovim_version = (function()
         require("neorg.external.helpers")
 

--- a/lua/neorg/modules.lua
+++ b/lua/neorg/modules.lua
@@ -215,10 +215,17 @@ function neorg.modules.load_module_from_table(module, parent)
     -- Keep track of the number of loaded modules
     neorg.modules.loaded_module_count = neorg.modules.loaded_module_count + 1
 
+    -- NOTE(vhyrro): Left here for debugging.
+    -- Maybe make controllable with a switch in the future.
+    -- local start = vim.loop.hrtime()
+
     -- Call the load function
     if module.load then
         module.load()
     end
+
+    -- local msg = ("%fms"):format((vim.loop.hrtime() - start) / 1e6)
+    -- vim.notify(msg .. " " .. module.name)
 
     neorg.events.broadcast_event({
         type = "core.module_loaded",

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -362,7 +362,8 @@ module.public = {
                 elseif
                     text == "embed"
                     and node:next_sibling()
-                    and module.required["core.integrations.treesitter"].get_node_text(node:next_sibling()) == "markdown"
+                    and module.required["core.integrations.treesitter"].get_node_text(node:next_sibling())
+                        == "markdown"
                 then
                     return {
                         state = {

--- a/lua/neorg/modules/core/highlights/module.lua
+++ b/lua/neorg/modules/core/highlights/module.lua
@@ -82,8 +82,8 @@ module.config.public = {
             },
 
             comment = {
-                content = "+@comment"
-            }
+                content = "+@comment",
+            },
         },
 
         headings = {
@@ -511,6 +511,12 @@ module.load = function()
             todo_items.cancelled[index].content = todo_items.cancelled[index][""]
         end
     end
+
+    module.public.trigger_highlights()
+
+    vim.api.nvim_create_autocmd("ColorScheme", {
+        callback = module.public.trigger_highlights,
+    })
 end
 
 ---@class core.highlights
@@ -686,12 +692,6 @@ module.public = {
 
     -- END of shamelessly ripped off akinsho code
 }
-
-module.on_event = function(event)
-    if event.type == "core.autocommands.events.bufenter" or event.type == "core.autocommands.events.colorscheme" then
-        module.public.trigger_highlights()
-    end
-end
 
 module.events.subscribed = {
     ["core.autocommands"] = {

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -79,7 +79,6 @@ module.load = function()
             once = true,
             callback = function()
                 -- HACK(vhyrro): Using internal Neovim APIs.
-                -- -- HACK(vhyrro): Using internal Neovim APIs.
                 -- It be like that sometimes.
                 if not vim._ts_has_language("norg") then
                     if module.config.public.install_parsers then

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -259,7 +259,7 @@ module.public = {
         local old_extmarks = {}
 
         -- The next block of code will be responsible for dimming code blocks accordingly
-        local tree = vim.treesitter.get_parser(buf, "norg"):parse()[1]
+        local tree = module.required["core.integrations.treesitter"].get_document_root(buf)
 
         -- If the tree is valid then attempt to perform the query
         if tree then

--- a/lua/neorg/modules/core/norg/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/metagen/module.lua
@@ -153,7 +153,7 @@ module.public = {
                     local updated_date = updated_field:match("%d+%-%d+-%d+")
                     if updated_date ~= current_date then
                         local new_date = updated_field:gsub("%d+%-%d+-%d+", current_date)
-                        vim.api.nvim_buf_set_lines(buf, idx-1, idx, false, {new_date})
+                        vim.api.nvim_buf_set_lines(buf, idx - 1, idx, false, { new_date })
                     end
                 end
             end

--- a/lua/neorg/modules/core/syntax/module.lua
+++ b/lua/neorg/modules/core/syntax/module.lua
@@ -102,7 +102,8 @@ module.public = {
         end
 
         -- If the tree is valid then attempt to perform the query
-        local tree = vim.treesitter.get_parser(buf, "norg"):parse()[1]
+        local tree = module.required["core.integrations.treesitter"].get_document_root(buf)
+
         if tree then
             -- get the language node used by the code block
             local code_lang = vim.treesitter.parse_query(


### PR DESCRIPTION
It's time for some changes. Yes, they are breaking changes, I know nobody likes them, but here they are definitely for the better.
If you don't like the change, feel free to use this configuration:
```lua
require("neorg").setup {
	lazy_loading = true,
	load = { ... },
}
```

# Overview
- `:NeorgStart` no longer exists and you always have access to a `:Neorg` command
- Highlights are always active, which means that e.g. highlights in telescope previews work now

# Side effects
- Some commands will error out if you use them outside of a `.norg` file
- Your config's startup time will be increased by just under 30 milliseconds (on my hardware at least)

# Notes
- Apart from reenabling the `lazy_loading` flag, you can also lazy load using your plugin manager via e.g. the `ft = "norg"` flag in packer.
- Work will be done to optimize existing modules for faster startup
