### PR TITLE
feat: rewrite `core.neorgcmd` module

### DIFF
--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -38,6 +38,7 @@ module.load = function()
         neorgcmd.add_commands_from_table({
             export = {
                 args = 1,
+                condition = "norg",
 
                 subcommands = {
                     ["to-file"] = {

--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -36,27 +36,19 @@ end
 module.load = function()
     neorg.modules.await("core.neorgcmd", function(neorgcmd)
         neorgcmd.add_commands_from_table({
-            definitions = {
-                export = {
-                    ["to-file"] = {},
-                    ["directory"] = {},
-                },
-            },
-            data = {
-                export = {
-                    args = 1,
+            export = {
+                args = 1,
 
-                    subcommands = {
-                        ["to-file"] = {
-                            min_args = 1,
-                            max_args = 2,
-                            name = "export.to-file",
-                        },
-                        ["directory"] = {
-                            min_args = 2,
-                            max_args = 3,
-                            name = "export.directory",
-                        },
+                subcommands = {
+                    ["to-file"] = {
+                        min_args = 1,
+                        max_args = 2,
+                        name = "export.to-file",
+                    },
+                    ["directory"] = {
+                        min_args = 2,
+                        max_args = 3,
+                        name = "export.directory",
                     },
                 },
             },

--- a/lua/neorg/modules/core/gtd/base/module.lua
+++ b/lua/neorg/modules/core/gtd/base/module.lua
@@ -142,21 +142,12 @@ module.load = function()
     -- Add neorgcmd capabilities
     -- All gtd commands start with :Neorg gtd ...
     module.required["core.neorgcmd"].add_commands_from_table({
-        definitions = {
-            gtd = {
-                views = {},
-                edit = {},
-                capture = {},
-            },
-        },
-        data = {
-            gtd = {
-                args = 1,
-                subcommands = {
-                    views = { args = 0, name = "gtd.views" },
-                    edit = { args = 0, name = "gtd.edit" },
-                    capture = { args = 0, name = "gtd.capture" },
-                },
+        gtd = {
+            args = 1,
+            subcommands = {
+                views = { args = 0, name = "gtd.views" },
+                edit = { args = 0, name = "gtd.edit" },
+                capture = { args = 0, name = "gtd.capture" },
             },
         },
     })

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -61,14 +61,9 @@ module.load = function()
         }
 
         module.required["core.neorgcmd"].add_commands_from_table({
-            definitions = {
-                ["sync-parsers"] = {},
-            },
-            data = {
-                ["sync-parsers"] = {
-                    args = 0,
-                    name = "sync-parsers",
-                },
+            ["sync-parsers"] = {
+                args = 0,
+                name = "sync-parsers",
             },
         })
 

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -100,13 +100,14 @@ module.public = {
             min_args = 2,
             name = "core.keybinds.trigger",
 
-            subcommands = {},
+            complete = {
+                {},
+                {},
+            },
         },
     },
 
     version = "0.0.9",
-
-    keybinds = {},
 
     -- Adds a new keybind to the database of known keybinds
     -- @param module_name string #the name of the module that owns the keybind. Make sure it's an absolute path.
@@ -120,7 +121,7 @@ module.public = {
             module.events.defined[keybind_name] = neorg.events.define(module, keybind_name)
 
             -- Define autocompletion for core.neorgcmd
-            module.public.keybinds[keybind_name] = {}
+            table.insert(module.public.neorg_commands.keybind.complete[2], keybind_name)
         end
 
         -- Update core.neorgcmd's internal tables
@@ -141,7 +142,7 @@ module.public = {
                 module.events.defined[keybind_name] = neorg.events.define(module, keybind_name)
 
                 -- Define autocompletion for core.neorgcmd
-                module.public.keybinds[keybind_name] = {}
+                table.insert(module.public.neorg_commands.keybind.complete[2], keybind_name)
             end
         end
 
@@ -397,22 +398,13 @@ module.public = {
 
     --- Updates the list of known modes and keybinds for easy autocompletion. Invoked automatically during neorg_post_load().
     sync = function()
-        -- -- Reset all the autocompletions
-        -- module.public.neorg_commands.keybind.subcommands = {}
+        -- Update the first parameter with the new list of modes
+        -- NOTE(vhyrro): Is there a way to prevent copying? Can you "unbind" a reference to a table?
+        module.public.neorg_commands.keybind.complete[1] = vim.deepcopy(module.required["core.mode"].get_modes())
+        table.insert(module.public.neorg_commands.keybind.complete[1], "all")
 
-        -- -- Grab all the modes
-        -- local modes = module.required["core.mode"].get_modes()
-
-        -- -- Set autocompletion for the "all" mode
-        -- module.public.neorg_commands.keybind.all.subcommands = module.public.keybinds
-
-        -- -- Convert the list of modes into completion entries for core.neorgcmd
-        -- for _, mode in ipairs(modes) do
-        --     module.public.neorg_commands.keybind.subcommands[mode] = module.public.keybinds
-        -- end
-
-        -- -- Update core.neorgcmd's internal tables
-        -- module.required["core.neorgcmd"].add_commands_from_table(module.public.neorg_commands)
+        -- Update core.neorgcmd's internal tables
+        module.required["core.neorgcmd"].add_commands_from_table(module.public.neorg_commands)
     end,
 
     request_keys = function(module_name, callback)

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -96,14 +96,11 @@ module.public = {
 
     -- Define neorgcmd autocompletions and commands
     neorg_commands = {
-        definitions = {
-            keybind = {},
-        },
-        data = {
-            keybind = {
-                min_args = 2,
-                name = "core.keybinds.trigger",
-            },
+        keybind = {
+            min_args = 2,
+            name = "core.keybinds.trigger",
+
+            subcommands = {},
         },
     },
 
@@ -400,22 +397,22 @@ module.public = {
 
     --- Updates the list of known modes and keybinds for easy autocompletion. Invoked automatically during neorg_post_load().
     sync = function()
-        -- Reset all the autocompletions
-        module.public.neorg_commands.definitions.keybind = {}
+        -- -- Reset all the autocompletions
+        -- module.public.neorg_commands.keybind.subcommands = {}
 
-        -- Grab all the modes
-        local modes = module.required["core.mode"].get_modes()
+        -- -- Grab all the modes
+        -- local modes = module.required["core.mode"].get_modes()
 
-        -- Set autocompletion for the "all" mode
-        module.public.neorg_commands.definitions.keybind.all = module.public.keybinds
+        -- -- Set autocompletion for the "all" mode
+        -- module.public.neorg_commands.keybind.all.subcommands = module.public.keybinds
 
-        -- Convert the list of modes into completion entries for core.neorgcmd
-        for _, mode in ipairs(modes) do
-            module.public.neorg_commands.definitions.keybind[mode] = module.public.keybinds
-        end
+        -- -- Convert the list of modes into completion entries for core.neorgcmd
+        -- for _, mode in ipairs(modes) do
+        --     module.public.neorg_commands.keybind.subcommands[mode] = module.public.keybinds
+        -- end
 
-        -- Update core.neorgcmd's internal tables
-        module.required["core.neorgcmd"].add_commands_from_table(module.public.neorg_commands)
+        -- -- Update core.neorgcmd's internal tables
+        -- module.required["core.neorgcmd"].add_commands_from_table(module.public.neorg_commands)
     end,
 
     request_keys = function(module_name, callback)

--- a/lua/neorg/modules/core/mode/module.lua
+++ b/lua/neorg/modules/core/mode/module.lua
@@ -43,7 +43,7 @@ module.public = {
             max_args = 1,
             name = "mode",
             condition = "norg",
-            subcommands = {},
+            complete = { { "norg" } },
         },
     },
 
@@ -69,7 +69,7 @@ module.public = {
         )
 
         -- Define the autocompletion tables and make them include the current mode
-        module.public.neorg_commands["mode"].subcommands[mode_name] = {}
+        table.insert(module.public.neorg_commands["mode"].complete[1], mode_name)
 
         -- If core.neorgcmd is loaded then update all autocompletions
         local neorgcmd = neorg.modules.get_module("core.neorgcmd")

--- a/lua/neorg/modules/core/mode/module.lua
+++ b/lua/neorg/modules/core/mode/module.lua
@@ -39,17 +39,10 @@ module.public = {
 
     -- Define command for :Neorg
     neorg_commands = {
-        definitions = {
-            ["mode"] = {
-                norg = {},
-            },
-        },
-
-        data = {
-            ["mode"] = {
-                max_args = 1,
-                name = "mode",
-            },
+        ["mode"] = {
+            max_args = 1,
+            name = "mode",
+            subcommands = {},
         },
     },
 
@@ -75,7 +68,7 @@ module.public = {
         )
 
         -- Define the autocompletion tables and make them include the current mode
-        module.public.neorg_commands.definitions["mode"][mode_name] = {}
+        module.public.neorg_commands["mode"].subcommands[mode_name] = {}
 
         -- If core.neorgcmd is loaded then update all autocompletions
         local neorgcmd = neorg.modules.get_module("core.neorgcmd")

--- a/lua/neorg/modules/core/mode/module.lua
+++ b/lua/neorg/modules/core/mode/module.lua
@@ -42,6 +42,7 @@ module.public = {
         ["mode"] = {
             max_args = 1,
             name = "mode",
+            condition = "norg",
             subcommands = {},
         },
     },

--- a/lua/neorg/modules/core/neorgcmd/commands/module/list/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/commands/module/list/module.lua
@@ -21,7 +21,6 @@ module.public = {
             args = 1,
 
             subcommands = {
-
                 list = {
                     args = 0,
                     name = "module.list",

--- a/lua/neorg/modules/core/neorgcmd/commands/module/list/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/commands/module/list/module.lua
@@ -16,23 +16,15 @@ module.setup = function()
 end
 
 module.public = {
-
     neorg_commands = {
-        definitions = {
-            module = {
-                list = {},
-            },
-        },
-        data = {
-            module = {
-                args = 1,
+        module = {
+            args = 1,
 
-                subcommands = {
+            subcommands = {
 
-                    list = {
-                        args = 0,
-                        name = "module.list",
-                    },
+                list = {
+                    args = 0,
+                    name = "module.list",
                 },
             },
         },

--- a/lua/neorg/modules/core/neorgcmd/commands/module/load/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/commands/module/load/module.lua
@@ -18,20 +18,13 @@ end
 module.public = {
 
     neorg_commands = {
-        definitions = {
-            module = {
-                load = {},
-            },
-        },
-        data = {
-            module = {
-                args = 1,
+        module = {
+            args = 1,
 
-                subcommands = {
-                    load = {
-                        args = 1,
-                        name = "module.load",
-                    },
+            subcommands = {
+                load = {
+                    args = 1,
+                    name = "module.load",
                 },
             },
         },

--- a/lua/neorg/modules/core/neorgcmd/commands/return/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/commands/return/module.lua
@@ -17,16 +17,10 @@ module.setup = function()
 end
 
 module.public = {
-
     neorg_commands = {
-        definitions = {
-            ["return"] = {},
-        },
-        data = {
-            ["return"] = {
-                args = 0,
-                name = "return",
-            },
+        ["return"] = {
+            args = 0,
+            name = "return",
         },
     },
 }

--- a/lua/neorg/modules/core/neorgcmd/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/module.lua
@@ -20,27 +20,21 @@ module.examples = {
 
         module.load = function()
             module.required["core.neorgcmd"].add_commands_from_table({
-                definitions = { -- Used for completion
-                    my_command = { -- Define a command called my_command
-                        my_subcommand = {}, -- Define a subcommand called my_subcommand
-                    },
-                },
-                data = { -- Metadata about our commands, should follow the same structure as the definitions table
-                    my_command = {
-                        min_args = 1, -- Tells neorgcmd that we want at least one argument for this command
-                        max_args = 1, -- Tells neorgcmd we want no more than one argument
-                        args = 1, -- Setting this variable instead would be the equivalent of min_args = 1 and max_args = 1
+                -- The name of our subcommand
+                my_command = {
+                    min_args = 1, -- Tells neorgcmd that we want at least one argument for this command
+                    max_args = 1, -- Tells neorgcmd we want no more than one argument
+                    args = 1, -- Setting this variable instead would be the equivalent of min_args = 1 and max_args = 1
+                    norg = false, -- When true, will only be available in .norg files. When false, will only be available outside .norg files.
 
-                        subcommands = { -- Defines subcommands
+                    subcommands = { -- Defines subcommands
+                        -- Repeat the definition cycle again
+                        my_subcommand = {
+                            args = 0, -- We don't want any arguments
+                            name = "my.command", -- The identifying name of this command
 
-                            -- Repeat the definition cycle again
-                            my_subcommand = {
-                                args = 0, -- We don't want any arguments
-                                name = "my.command", -- The identifying name of this command
-
-                                -- We do not define a subcommands table here because we don't have any more subcommands
-                                -- Creating an empty subcommands table will cause errors so don't bother
-                            },
+                            -- We do not define a subcommands table here because we don't have any more subcommands
+                            -- Creating an empty subcommands table will cause errors so don't bother
                         },
                     },
                 },
@@ -74,7 +68,7 @@ module.examples = {
         })
 
         -- And that's it! You're good to go.
-        -- Want to find out more? Read the wiki entry! https://github.com/vhyrro/neorg/wiki/Neorg-Command
+        -- Want to find out more? Read the wiki entry! https://github.com/nvim-neorg/neorg/wiki/Neorg-Command
     end,
 }
 
@@ -111,7 +105,6 @@ module.config.public = {
 
 ---@class core.neorgcmd
 module.public = {
-
     -- The table containing all the functions. This can get a tad complex so I recommend you read the wiki entry
     neorg_commands = {},
 
@@ -173,195 +166,25 @@ module.public = {
 
 module.private = {
     --- Handles the calling of the appropriate function based on the command the user entered
-    -- @Param  ... (varargs) - the contents of <f-args> provided by nvim itself
     command_callback = function(data)
         local args = data.fargs
-
-        --[[
-		--	Ok, this is where things get messy. Read the comments from the generate_completions()
-		--	function to get a decent grasp of the code below. Before you ask, yes, all these variables
-		--	here are necessary in order for the function to work. Time to explain them one by one:
-		--		ref_definitions - a reference to the module.config.public.neorg_commands.definitions table, recursive reference assignment is done here.
-		--			It's used to track where we are recursively in the table. It's also used to build a valid event string and to test whether the supplied
-		--			commands and subcommands actually exist.
-		--		ref_data - a reference to the module.config.public.neorg_commands.data table. It's used to recursively enter the "subcommands" tables and
-		--			tell the for loop below when to bail out and stop parsing further.
-		--		ref_data_one_above - the same as ref_data, except used for a different purpose. As the name suggests, this variable is a reference to one level above ref_data.
-		--			You still with me? This variable is used to read the metadata present in the neorg_commands.data table, it doesn't instantly enter the "subcommands" table like ref_data
-		--			does.
-		--		event_name - the current event string. Tracks the tail of the command we're executing.
-		--		current_depth - the current recursion depth. Used to track what is a command/subcommand and what are arguments.
-		--]]
-        local ref_definitions = module.public.neorg_commands.definitions
-        local ref_data = module.public.neorg_commands.data
-        local ref_data_one_above = module.public.neorg_commands.data
-        local event_name = ""
-        local current_depth = 0
-
-        -- For every argument we have received do
-        for _, cmd in ipairs(args) do
-            -- If we can recursively enter the definitions table then
-            if ref_definitions[cmd] then
-                -- If we can recursively enter the data table then
-                if ref_data[cmd] then
-                    -- Assign ref_data_one_above to the correct value
-                    ref_data_one_above = ref_data[cmd]
-
-                    -- Recursively assign the ref_definitions reference (equivalent of entering the table)
-                    ref_definitions = ref_definitions[cmd]
-
-                    -- Set the event_name string
-                    event_name = ref_data_one_above.name
-
-                    -- Increase the current recursion depth
-                    current_depth = current_depth + 1
-
-                    -- If we have another subcommands table to enter then enter it, otherwise there's no more recursion to do and we can bail out
-                    if ref_data[cmd].subcommands then
-                        ref_data = ref_data[cmd].subcommands
-                    else
-                        break
-                    end
-                else -- If we can't enter the data table then that means it's inconsistent with the definitions table
-                    log.error(
-                        "Unable to execute command :Neorg",
-                        table.concat(args, " "),
-                        cmd,
-                        "- the command exists but doesn't hold any valid metadata. Metadata is required for neorg to parse the command correctly, please consult the neorg wiki if you're confused."
-                    )
-                    return
-                end
-            else -- If we can't enter the definitions table further then that means the command we entered does not exist
-                log.error(
-                    "Unable to execute command :Neorg",
-                    table.concat(args, " "),
-                    cmd,
-                    "- such a command does not exist."
-                )
-                return
-            end
-        end
-
-        -- PARSE COMMAND METADATA (read wiki for metadata info)
-
-        -- If we have not specified the min_args value default to 0
-        ref_data_one_above.min_args = ref_data_one_above.min_args or 0
-
-        -- If we've defined an args variable then set both the min_args and max_args to that value
-        if ref_data_one_above.args then
-            ref_data_one_above.min_args = ref_data_one_above.args
-            ref_data_one_above.max_args = ref_data_one_above.args
-        end
-
-        -- If our recursion depth is smaller than the minimum argument count then that means the user has not supplied enough arguments
-        -- We'll therefore query the user for the remainder
-        if #args == 0 or #args - current_depth < ref_data_one_above.min_args then
-            -- When an insufficient amount of arguments are provided Neorg will query for the next mandatory
-            -- argument - this may not be done with the `ref_definitions` table however, as `ref_definitions`
-            -- performs a recursion on the data of each keybind versus the completions of each keybind. This means
-            -- that keybinds with many arguments wouldn't be registered and would instead cause this function to
-            -- loop. The only solution is to query completions for the next item here.
-            local completions =
-                module.private.generate_completions(_, string.format("Neorg %s ", table.concat(args, " ")))
-            module.private.select_next_cmd_arg(args, completions)
-            return
-        end
-
-        -- If our event name is nil then that means the command did not have a `name` field defined
-        if not event_name then
-            log.error("Unable to execute neorg command. The command does not have a 'name' field to identify it.")
-            return
-        end
-
-        -- If our recursion depth is larger than the maximum argument count then that means we have supplied too many arguments
-        if ref_data_one_above.max_args and #args - current_depth > ref_data_one_above.max_args then
-            if ref_data_one_above.max_args == 0 then
-                log.error(
-                    "Unable to execute neorg command under name",
-                    event_name,
-                    "- exceeded maximum argument count. The command does not take any arguments."
-                )
-            else
-                log.error(
-                    "Unable to execute neorg command under name",
-                    event_name,
-                    "- exceeded maximum argument count. The command does not allow more than",
-                    ref_data_one_above.max_args,
-                    "arguments."
-                )
-            end
-
-            return
-        end
-
-        -- If not already defined define our event
-        if not module.events.defined[event_name] then
-            module.events.defined[event_name] = neorg.events.define(module, event_name)
-        end
-
-        -- Broadcast the event with all the correct data and the arguments passed to our command as the contents
-        neorg.events.broadcast_event(
-            neorg.events.create(
-                module,
-                "core.neorgcmd.events." .. event_name,
-                vim.list_slice(args, #args - (#args - current_depth) + 1)
-            )
-        )
     end,
 
     --- This function returns all available commands to be used for the :Neorg command
     ---@param _ nil #Placeholder variable
     ---@param command string #Supplied by nvim itself; the full typed out command
     generate_completions = function(_, command)
-        -- If core.neorgcmd is not loaded do not provide completion
-        if not neorg.modules.is_module_loaded("core.neorgcmd") then
-            return { "Unable to provide completions: core.neorgcmd is not loaded." }
-        end
+        local current_buf = vim.api.nvim_get_current_buf()
+        local is_norg = vim.api.nvim_buf_get_option(current_buf, "filetype") == "norg"
 
-        -- Trim any leading whitespace that may be present in the command
         command = command:gsub("^%s*", "")
+        
+        local splitcmd = vim.list_slice(vim.split(command, " ", {
+            plain = true,
+            trimempty = true,
+        }), 2)
 
-        -- Split the command into several smaller ones for easy parsing
-        local split_command = vim.split(command, " ")
-
-        -- Create a reference to the definitions table
-        local ref = module.public.neorg_commands.definitions
-
-        -- If the split command contains only 2 values then don't bother with
-        -- the code below, just return all the available completions and exit
-        if #split_command == 2 then
-            return vim.tbl_filter(function(key)
-                return key ~= "__any__" and key:find(split_command[#split_command])
-            end, vim.tbl_keys(ref))
-        end
-
-        -- Splice the command to omit the beginning :Neorg bit
-        local sliced_split_command = vim.list_slice(split_command, 2)
-
-        -- If the last element is not an empty string then add it, it serves as a terminator for neorgcmd's completion
-        if sliced_split_command[#sliced_split_command] ~= "" then
-            sliced_split_command[#sliced_split_command] = ""
-        end
-
-        -- This is where the magic begins - recursive reference assignment
-        -- What we do here is we recursively traverse down the module.public.neorg_commands.definitions
-        -- table and provide autocompletion based on how many commands we have typed into the :Neorg command.
-        -- If we e.g. type ":Neorg list " and then press Tab we want to traverse once down the table
-        -- and return all the contents at the first recursion level of that table.
-        for _, cmd in ipairs(sliced_split_command) do
-            if ref[cmd] then
-                ref = ref[cmd]
-            elseif cmd:len() > 0 and ref.__any__ then
-                ref = ref.__any__
-            else
-                break
-            end
-        end
-
-        -- Return everything from ref that is a potential match
-        return vim.tbl_filter(function(key)
-            return key ~= "__any__" and key:find(split_command[#split_command])
-        end, vim.tbl_keys(ref))
+        -- TODO
     end,
 
     --- Queries the user to select next argument

--- a/lua/neorg/modules/core/neorgcmd/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/module.lua
@@ -213,12 +213,17 @@ module.private = {
 
             ref = ref.subcommands[cmd]
 
-            -- TODO(vhyrro): Make error message more clear
-            -- The user should know if they executed a command that simply is disabled
-            if not ref or not check_condition(ref.condition) then
+            if not ref then
+                log.error(
+                    ("Error when executing `:Neorg %s` - such a command does not exist!"):format(
+                        table.concat(vim.list_slice(args, 1, i), " ")
+                    )
+                )
+                return
+            elseif not check_condition(ref.condition) then
                 log.error(
                     (
-                        "Error when executing `:Neorg %s` - such a command does not exist! Are you sure you're in the correct context?"
+                        "Error when executing `:Neorg %s` - the command is currently disabled. Some commands will only become available under certain conditions!"
                     ):format(table.concat(vim.list_slice(args, 1, i), " "))
                 )
                 return
@@ -244,12 +249,22 @@ module.private = {
             module.private.select_next_cmd_arg(data.args, completions)
             return
         elseif argument_count > ref.max_args then
-            log.error("Too many")
+            log.error(
+                ("Error when executing `:Neorg %s` - too many arguments supplied! The command expects %s argument%s."):format(
+                    data.args,
+                    ref.max_args == 0 and "no" or ref.max_args,
+                    ref.max_args == 1 and "" or "s"
+                )
+            )
             return
         end
 
         if not ref.name then
-            log.error("Unable to execute command - something something no name")
+            log.error(
+                (
+                    "Error when executing `:Neorg %s` - the ending command didn't have a `name` variable associated with it! This is an implementation error on the developer's side, so file a report to the author of the module."
+                ):format(data.args)
+            )
             return
         end
 

--- a/lua/neorg/modules/core/neorgcmd/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/module.lua
@@ -288,6 +288,7 @@ module.private = {
             subcommands = module.public.neorg_commands,
         }
         local last_valid_ref = ref
+        local last_completion_level = 0
 
         for _, cmd in ipairs(splitcmd) do
             if not ref or not check_condition(ref.condition) then
@@ -299,7 +300,17 @@ module.private = {
 
             if ref then
                 last_valid_ref = ref
+                last_completion_level = last_completion_level + 1
             end
+        end
+
+        if not last_valid_ref.subcommands and last_valid_ref.complete then
+            return vim.endswith(command, " ") and (last_valid_ref.complete[#splitcmd - last_completion_level + 1] or {})
+                or (
+                    vim.tbl_filter(function(key)
+                        return key:find(splitcmd[#splitcmd])
+                    end, last_valid_ref.complete[#splitcmd - last_completion_level])
+                )
         end
 
         -- TODO: Fix `:Neorg m <tab>` giving invalid completions

--- a/lua/neorg/modules/core/neorgcmd/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/module.lua
@@ -219,6 +219,8 @@ module.private = {
         if ref.args then
             ref.min_args = ref.args
             ref.max_args = ref.args
+        elseif ref.min_args and not ref.max_args then
+            ref.max_args = math.huge
         else
             ref.min_args = ref.min_args or 0
             ref.max_args = ref.max_args or 0
@@ -309,7 +311,7 @@ module.private = {
                 or (
                     vim.tbl_filter(function(key)
                         return key:find(splitcmd[#splitcmd])
-                    end, last_valid_ref.complete[#splitcmd - last_completion_level])
+                    end, last_valid_ref.complete[#splitcmd - last_completion_level] or {})
                 )
         end
 

--- a/lua/neorg/modules/core/neorgcmd/module.lua
+++ b/lua/neorg/modules/core/neorgcmd/module.lua
@@ -20,18 +20,31 @@ module.examples = {
 
         module.load = function()
             module.required["core.neorgcmd"].add_commands_from_table({
-                -- The name of our subcommand
+                -- The name of our command
                 my_command = {
                     min_args = 1, -- Tells neorgcmd that we want at least one argument for this command
                     max_args = 1, -- Tells neorgcmd we want no more than one argument
                     args = 1, -- Setting this variable instead would be the equivalent of min_args = 1 and max_args = 1
-                    condition = "norg", -- This command is only avaiable within `.norg` files
+                    -- This command is only avaiable within `.norg` files.
+                    -- This can also be a function(bufnr, is_in_an_norg_file)
+                    condition = "norg",
 
                     subcommands = { -- Defines subcommands
                         -- Repeat the definition cycle again
                         my_subcommand = {
-                            args = 0, -- We don't want any arguments
-                            name = "my.command", -- The identifying name of this command
+                            args = 2, -- Force two arguments to be supplied
+                            -- The identifying name of this command
+                            -- Every "endpoint" must have a name associated with it
+                            name = "my.command",
+
+                            -- If your command takes in arguments versus
+                            -- subcommands you can make a table of tables with
+                            -- completion for those arguments here.
+                            -- This table is optional.
+                            complete = {
+                                { "first_completion1", "first_completion2" },
+                                { "second_completion1", "second_completion2" },
+                            },
 
                             -- We do not define a subcommands table here because we don't have any more subcommands
                             -- Creating an empty subcommands table will cause errors so don't bother

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -1856,14 +1856,9 @@ module.load = function()
 
     neorg.modules.await("core.neorgcmd", function(neorgcmd)
         neorgcmd.add_commands_from_table({
-            definitions = {
-                ["toggle-concealer"] = {},
-            },
-            data = {
-                ["toggle-concealer"] = {
-                    name = "core.norg.concealer.toggle",
-                    args = 0,
-                },
+            ["toggle-concealer"] = {
+                name = "core.norg.concealer.toggle",
+                args = 0,
             },
         })
     end)

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -1859,6 +1859,7 @@ module.load = function()
             ["toggle-concealer"] = {
                 name = "core.norg.concealer.toggle",
                 args = 0,
+                condition = "norg",
             },
         })
     end)

--- a/lua/neorg/modules/core/norg/dirman/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/module.lua
@@ -256,14 +256,9 @@ module.public = {
 
         -- Add the command to core.neorgcmd so it can be used by the user!
         module.required["core.neorgcmd"].add_commands_from_table({
-            definitions = {
-                workspace = workspace_autocomplete,
-            },
-            data = {
-                workspace = {
-                    max_args = 1,
-                    name = "dirman.workspace",
-                },
+            workspace = {
+                max_args = 1,
+                name = "dirman.workspace",
             },
         })
     end,

--- a/lua/neorg/modules/core/norg/dirman/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/module.lua
@@ -243,22 +243,12 @@ module.public = {
         -- Get all the workspace names
         local workspace_names = module.public.get_workspace_names()
 
-        -- Construct a table to be used by core.neorgcmd for autocompletion
-        local workspace_autocomplete = (function()
-            local result = {}
-
-            for _, ws_name in ipairs(workspace_names) do
-                result[ws_name] = {}
-            end
-
-            return result
-        end)()
-
         -- Add the command to core.neorgcmd so it can be used by the user!
         module.required["core.neorgcmd"].add_commands_from_table({
             workspace = {
                 max_args = 1,
                 name = "dirman.workspace",
+                complete = { workspace_names },
             },
         })
     end,

--- a/lua/neorg/modules/core/norg/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/metagen/module.lua
@@ -164,19 +164,13 @@ module.public = {
 module.load = function()
     neorg.modules.await("core.neorgcmd", function(neorgcmd)
         neorgcmd.add_commands_from_table({
-            definitions = {
-                ["inject-metadata"] = {},
-                ["update-metadata"] = {},
+            ["inject-metadata"] = {
+                args = 0,
+                name = "inject-metadata",
             },
-            data = {
-                ["inject-metadata"] = {
-                    args = 0,
-                    name = "inject-metadata",
-                },
-                ["update-metadata"] = {
-                    args = 0,
-                    name = "update-metadata",
-                },
+            ["update-metadata"] = {
+                args = 0,
+                name = "update-metadata",
             },
         })
     end)

--- a/lua/neorg/modules/core/norg/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/metagen/module.lua
@@ -167,10 +167,12 @@ module.load = function()
             ["inject-metadata"] = {
                 args = 0,
                 name = "inject-metadata",
+                condition = "norg",
             },
             ["update-metadata"] = {
                 args = 0,
                 name = "update-metadata",
+                condition = "norg",
             },
         })
     end)

--- a/lua/neorg/modules/core/norg/journal/module.lua
+++ b/lua/neorg/modules/core/norg/journal/module.lua
@@ -433,6 +433,7 @@ module.load = function()
                 toc = {
                     args = 1,
                     name = "journal.toc",
+                    condition = "norg",
                     subcommands = {
                         open = { args = 0, name = "journal.toc.open" },
                         update = { args = 0, name = "journal.toc.update" },

--- a/lua/neorg/modules/core/norg/journal/module.lua
+++ b/lua/neorg/modules/core/norg/journal/module.lua
@@ -421,36 +421,21 @@ module.load = function()
     end
 
     module.required["core.neorgcmd"].add_commands_from_table({
-        definitions = {
-            journal = {
-                tomorrow = {},
-                yesterday = {},
-                today = {},
-                custom = {},
-                template = {},
+        journal = {
+            min_args = 1,
+            max_args = 2,
+            subcommands = {
+                tomorrow = { args = 0, name = "journal.tomorrow" },
+                yesterday = { args = 0, name = "journal.yesterday" },
+                today = { args = 0, name = "journal.today" },
+                custom = { args = 1, name = "journal.custom" }, -- format :yyyy-mm-dd
+                template = { args = 0, name = "journal.template" },
                 toc = {
-                    open = {},
-                    update = {},
-                },
-            },
-        },
-        data = {
-            journal = {
-                min_args = 1,
-                max_args = 2,
-                subcommands = {
-                    tomorrow = { args = 0, name = "journal.tomorrow" },
-                    yesterday = { args = 0, name = "journal.yesterday" },
-                    today = { args = 0, name = "journal.today" },
-                    custom = { args = 1, name = "journal.custom" }, -- format :yyyy-mm-dd
-                    template = { args = 0, name = "journal.template" },
-                    toc = {
-                        args = 1,
-                        name = "journal.toc",
-                        subcommands = {
-                            open = { args = 0, name = "journal.toc.open" },
-                            update = { args = 0, name = "journal.toc.update" },
-                        },
+                    args = 1,
+                    name = "journal.toc",
+                    subcommands = {
+                        open = { args = 0, name = "journal.toc.open" },
+                        update = { args = 0, name = "journal.toc.update" },
                     },
                 },
             },

--- a/lua/neorg/modules/core/norg/news/module.lua
+++ b/lua/neorg/modules/core/norg/news/module.lua
@@ -75,41 +75,32 @@ module.load = function()
         local old_keys, new_keys = vim.tbl_keys(module.private.old_news), vim.tbl_keys(module.private.new_news)
 
         local commands_table = {
-            definitions = {
-                news = {
-                    new = lib.to_keys(new_keys),
-                    old = lib.to_keys(old_keys),
-                    all = {},
-                },
-            },
-            data = {
-                news = {
-                    args = 1,
-                    subcommands = {
-                        old = {
-                            name = "news.old",
-                            max_args = 1,
-                            subcommands = lib.construct(old_keys, function(key)
-                                return {
-                                    args = 0,
-                                    name = "news.old." .. key,
-                                }
-                            end),
-                        },
-                        new = {
-                            name = "news.new",
-                            max_args = 1,
-                            subcommands = lib.construct(new_keys, function(key)
-                                return {
-                                    args = 0,
-                                    name = "news.new." .. key,
-                                }
-                            end),
-                        },
-                        all = {
-                            name = "news.all",
-                            args = 0,
-                        },
+            news = {
+                args = 1,
+                subcommands = {
+                    old = {
+                        name = "news.old",
+                        max_args = 1,
+                        subcommands = lib.construct(old_keys, function(key)
+                            return {
+                                args = 0,
+                                name = "news.old." .. key,
+                            }
+                        end),
+                    },
+                    new = {
+                        name = "news.new",
+                        max_args = 1,
+                        subcommands = lib.construct(new_keys, function(key)
+                            return {
+                                args = 0,
+                                name = "news.new." .. key,
+                            }
+                        end),
+                    },
+                    all = {
+                        name = "news.all",
+                        args = 0,
                     },
                 },
             },
@@ -118,7 +109,7 @@ module.load = function()
         module.required["core.neorgcmd"].add_commands_from_table(commands_table)
 
         module.events.subscribed = {
-            ["core.neorgcmd"] = lib.to_keys(lib.extract(commands_table.data.news.subcommands, "name"), true),
+            ["core.neorgcmd"] = lib.to_keys(lib.extract(commands_table.news.subcommands, "name"), true),
         }
 
         if not vim.tbl_isempty(module.private.new_news) then

--- a/lua/neorg/modules/core/norg/qol/toc/module.lua
+++ b/lua/neorg/modules/core/norg/qol/toc/module.lua
@@ -43,23 +43,13 @@ module.load = function()
     -- Add neorgcmd capabilities
     -- All toc commands start with :Neorg toc ...
     module.required["core.neorgcmd"].add_commands_from_table({
-        definitions = {
-            toc = {
-                split = {},
-                inline = {},
-                toqflist = {},
-                close = {},
-            },
-        },
-        data = {
-            toc = {
-                args = 1,
-                subcommands = {
-                    split = { args = 0, name = "toc.split" },
-                    inline = { args = 0, name = "toc.inline" },
-                    toqflist = { args = 0, name = "toc.toqflist" },
-                    close = { args = 0, name = "toc.close" },
-                },
+        toc = {
+            args = 1,
+            subcommands = {
+                split = { args = 0, name = "toc.split" },
+                inline = { args = 0, name = "toc.inline" },
+                toqflist = { args = 0, name = "toc.toqflist" },
+                close = { args = 0, name = "toc.close" },
             },
         },
     })

--- a/lua/neorg/modules/core/norg/qol/toc/module.lua
+++ b/lua/neorg/modules/core/norg/qol/toc/module.lua
@@ -45,6 +45,7 @@ module.load = function()
     module.required["core.neorgcmd"].add_commands_from_table({
         toc = {
             args = 1,
+            condition = "norg",
             subcommands = {
                 split = { args = 0, name = "toc.split" },
                 inline = { args = 0, name = "toc.inline" },

--- a/lua/neorg/modules/core/presenter/module.lua
+++ b/lua/neorg/modules/core/presenter/module.lua
@@ -46,19 +46,11 @@ module.load = function()
     keybinds.register_keybinds(module.name, { "next_page", "previous_page", "close" })
     -- Add neorgcmd capabilities
     module.required["core.neorgcmd"].add_commands_from_table({
-        definitions = {
-            presenter = {
-                start = {},
-                close = {},
-            },
-        },
-        data = {
-            presenter = {
-                args = 1,
-                subcommands = {
-                    start = { args = 0, name = "presenter.start" },
-                    close = { args = 0, name = "presenter.close" },
-                },
+        presenter = {
+            args = 1,
+            subcommands = {
+                start = { args = 0, name = "presenter.start" },
+                close = { args = 0, name = "presenter.close" },
             },
         },
     })

--- a/lua/neorg/modules/core/presenter/module.lua
+++ b/lua/neorg/modules/core/presenter/module.lua
@@ -48,6 +48,7 @@ module.load = function()
     module.required["core.neorgcmd"].add_commands_from_table({
         presenter = {
             args = 1,
+            condition = "norg",
             subcommands = {
                 start = { args = 0, name = "presenter.start" },
                 close = { args = 0, name = "presenter.close" },

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -156,27 +156,18 @@ end
 
 module.load = function()
     module.required["core.neorgcmd"].add_commands_from_table({
-        definitions = {
-            tangle = {
-                ["current-file"] = {},
-                -- directory = {},
-            },
-        },
+        tangle = {
+            args = 1,
 
-        data = {
-            tangle = {
-                args = 1,
-
-                subcommands = {
-                    ["current-file"] = {
-                        args = 0,
-                        name = "core.tangle.current-file",
-                    },
-                    -- directory = {
-                    --     max_args = 1,
-                    --     name = "core.tangle.directory",
-                    -- }
+            subcommands = {
+                ["current-file"] = {
+                    args = 0,
+                    name = "core.tangle.current-file",
                 },
+                -- directory = {
+                --     max_args = 1,
+                --     name = "core.tangle.directory",
+                -- }
             },
         },
     })

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -158,6 +158,7 @@ module.load = function()
     module.required["core.neorgcmd"].add_commands_from_table({
         tangle = {
             args = 1,
+            condition = "norg",
 
             subcommands = {
                 ["current-file"] = {


### PR DESCRIPTION
After a long wait, I decided it was time to rewrite this module to open up some more possibilities.
Here are some things that this improves:

- Uses Lua APIs to define commands. There's a noticeable speed difference when executing commands, it's much snappier.
- The table used to define commands has been changed to something much simpler. No more `definitions` and `data` tables!
- Added a `complete` argument for commands that want more complex completion for parameters
- **Added a `condition` command that can allow for conditional command execution**.
  This is the big one - now that Neorg is no longer lazy loaded by default it would be great to have more commands related to workflow, but nobody wants to see a load of commands in their completion popup! If you're in a `.norg` file, then you'll see completions for commands that operate on `.norg` files. If you're outside of a `.norg` file, you'll see completions for workflow commands. If your cursor is hovering over a code block, you'll get a `magnify-code-block` command. The options are limitless here! Expect many follow-ups to this PR.