### PR TITLE
fix(concealer): Don't attach to non-norg buffers.

### DIFF
--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -1869,6 +1869,7 @@ module.load = function()
             pattern = "conceallevel",
             callback = function()
                 local current_buffer = vim.api.nvim_get_current_buf()
+                if vim.bo[current_buffer].ft ~= "norg" then return end
                 local has_conceal = (tonumber(vim.v.option_new) > 0)
 
                 module.public.trigger_icons(


### PR DESCRIPTION
Fixes #600.

Are there other file types that the concealer should automatically attach to on the this auto command?