### PR TITLE
docs: update link to specification file

### DIFF
--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -10,7 +10,7 @@
 = TOC
 
 * The `.norg` file-format
-  If you find the {https://github.com/vhyrro/neorg/blob/main/docs/NFF-0.1-spec.md}[spec]
+  If you find the {https://github.com/nvim-neorg/norg-specs/blob/main/1.0-specification.norg}[spec]
   too long and want to jump-start your Neorg skills, you've come to the right place!
 
  ** Basic Markup


### PR DESCRIPTION
Commit c5345e72ebdd84585eec6272755aa26233431317 removed the specification file from this repository so the link at the start of `:h neorg` 404s. This commit changes to link to point to the specification directory.