### PR TITLE
fix(concealer): don't update `content_only` variable if `conceal` is false and `adaptive` is true

### DIFF
--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -331,7 +331,7 @@ module.public = {
                             )
                         end
 
-                        if module.config.public.dim_code_blocks.adaptive then
+                        if module.config.public.dim_code_blocks.conceal and module.config.public.dim_code_blocks.adaptive then
                             module.config.public.dim_code_blocks.content_only = has_conceal
                         end
 
@@ -1879,7 +1879,7 @@ module.load = function()
                     module.private.icon_namespace
                 )
 
-                if module.config.public.dim_code_blocks.adaptive then
+                if module.config.public.dim_code_blocks.conceal and module.config.public.dim_code_blocks.adaptive then
                     module.public.trigger_code_block_highlights(current_buffer, has_conceal)
                 end
             end,


### PR DESCRIPTION
I think adaptive should be disable when conceal not enable.
Otherwise the behavior when { adaptive = true, conceal = false } kinda weird (only background adaptive).