### PR TITLE
docs(README): update Neovim icon to 0.8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Neorg - An Organized Future
 
-<a href="https://neovim.io"> ![Neovim](https://img.shields.io/badge/Neovim%200.7+-brightgreen?style=for-the-badge) </a>
+<a href="https://neovim.io"> ![Neovim](https://img.shields.io/badge/Neovim%200.8+-brightgreen?style=for-the-badge) </a>
 <a href="https://discord.gg/T6EgTAX7ht"> ![Discord](https://img.shields.io/badge/discord-join-7289da?style=for-the-badge&logo=discord) </a>
 <a href="/LICENSE"> ![License](https://img.shields.io/badge/license-GPL%20v3-brightgreen?style=for-the-badge)</a>
 <a href="#wip"> ![Status](https://img.shields.io/badge/status-WIP-informational?style=for-the-badge) </a>


### PR DESCRIPTION
Under the installation instructions, it says Neovim 0.8+ is required to operate, but the link at the top of the README is still showing 0.7+.