### PR TITLE
fix: broken link following when using hop

### DIFF
--- a/lua/neorg/modules/core/norg/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/hop/module.lua
@@ -434,7 +434,7 @@ module.public = {
                     png = open_in_external_app,
                     [{ "jpg", "jpeg" }] = open_in_external_app,
                     [module.config.public.external_filetypes] = open_in_external_app,
-                    _ = vim.cmd("e " .. vim.fn.fnamemodify(destination, ":p")),
+                    _ = neorg.lib.wrap(vim.api.nvim_exec, "e " .. vim.fn.fnamemodify(destination, ":p"), false),
                 })
 
                 return {}

--- a/lua/neorg/modules/core/norg/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/hop/module.lua
@@ -429,12 +429,12 @@ module.public = {
                     os_open_link(vim.uri_from_fname(vim.fn.expand(destination)))
                 end
 
-                neorg.lib.match(destination:match("%.(.+)$"))({
+                neorg.lib.match(vim.fn.fnamemodify(destination, ":e"))({
                     pdf = open_in_external_app,
                     png = open_in_external_app,
                     [{ "jpg", "jpeg" }] = open_in_external_app,
                     [module.config.public.external_filetypes] = open_in_external_app,
-                    _ = neorg.lib.wrap(vim.cmd, "e " .. destination),
+                    _ = vim.cmd("e " .. vim.fn.fnamemodify(destination, ":p")),
                 })
 
                 return {}


### PR DESCRIPTION
Noticed that non-norg file links were completely broken. The issue was a bad string match when trying to find the file type, as well as `vim.cmd` not working correctly

This fixes it by using `vim.fn.fnamemodify` to directly get the file paths desired as well as replacing `vim.cmd` with `vim.api.nvim_exec` for the hop file edit call