### PR TITLE
fix: do not skip anchors when jumping to next/prev link

### DIFF
--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -13,6 +13,8 @@ module.private = {
     ts_utils = nil,
     link_query = [[
                 (link) @next-segment
+                (anchor_declaration) @next-segment
+                (anchor_definition) @next-segment
              ]],
     heading_query = [[
                  [


### PR DESCRIPTION
Anchor definitions and anchor declarations were skipped when jumping to the next or previous link. This was a bit surprising as you could jump to links with a custom text for example. Since anchors serve a similar purpose as links, it makes sense to be able to jump to them.

To test this, use the same Neorg setup as described in issue #609, then create a new norg file with the following contents:

```
{:link1:}
{:link2:}[description]
[anchor]
[anchor]{:link3:}
{:link4:}
```

With the cursor on the first line, repeatedly press `Tab`.