### PR TITLE
fix: `folke/todo-comments.nvim` comment highlighting in `.norg` files

### DIFF
--- a/queries/norg/highlights.scm
+++ b/queries/norg/highlights.scm
@@ -328,6 +328,9 @@
 (superscript (subscript) @neorg.error (#set! priority 300))
 (subscript (superscript) @neorg.error (#set! priority 300))
 
+; Comments
+(inline_comment) @comment
+
 ; Conceals
 (
     [


### PR DESCRIPTION
- Fixes https://github.com/nvim-neorg/neorg/issues/642  ; https://github.com/folke/todo-comments.nvim/issues/106
- Original commit: https://github.com/nvim-neorg/neorg/commit/887dc41f508aea1d1c9f195dba18a3aac0a2e1c8