### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ will also be updated to the correct revision.
 
 ### Troubleshooting Treesitter
 - Not using packer? Make sure that Neorg's `setup()` gets called after `nvim-treesitter`'s setup.
+- If you don't use the latest Neovim nightly, you might want to use an older Neorg version by doing `tag = '0.0.12'`. Version `0.0.13` adapts to a breaking change in Treesitter highlighting.
 - If on MacOS, ensure that the `CC` environment variable points to a compiler that has C++14 support.
   You can run Neovim like so: `CC=/path/to/newer/compiler nvim -c
   "TSInstallSync norg"` in your shell of choice


### PR DESCRIPTION
I'm using NVIM v0.8.0-dev+177-gcf68f0a51 and got the same errors as in https://github.com/nvim-neorg/neorg/issues/559. It's nice that that issue is pinned, so that I found the issue relatively quickly. Stating this in the README is still a bit easier to discover.