### PR TITLE
fix(concealer): set win local fold options

### DIFF
--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -1914,19 +1914,22 @@ module.on_event = function(event)
 
     local has_conceal = (
         vim.api.nvim_win_is_valid(event.window) and (vim.api.nvim_win_get_option(event.window, "conceallevel") > 0)
-            or false
-        )
+        or false
+    )
 
     if event.type == "core.autocommands.events.bufenter" and event.content.norg then
         if module.config.public.folds and vim.api.nvim_win_is_valid(event.window) then
             local opts = {
                 scope = "local",
-                win = event.window
+                win = event.window,
             }
             vim.api.nvim_set_option_value("foldmethod", "expr", opts)
             vim.api.nvim_set_option_value("foldexpr", "nvim_treesitter#foldexpr()", opts)
-            vim.api.nvim_set_option_value("foldtext",
-                "v:lua.neorg.modules.get_module('core.norg.concealer').foldtext()", opts)
+            vim.api.nvim_set_option_value(
+                "foldtext",
+                "v:lua.neorg.modules.get_module('core.norg.concealer').foldtext()",
+                opts
+            )
         end
 
         local buf = event.buffer

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -1914,18 +1914,19 @@ module.on_event = function(event)
 
     local has_conceal = (
         vim.api.nvim_win_is_valid(event.window) and (vim.api.nvim_win_get_option(event.window, "conceallevel") > 0)
-        or false
-    )
+            or false
+        )
 
     if event.type == "core.autocommands.events.bufenter" and event.content.norg then
         if module.config.public.folds and vim.api.nvim_win_is_valid(event.window) then
-            vim.api.nvim_win_set_option(event.window, "foldmethod", "expr")
-            vim.api.nvim_win_set_option(event.window, "foldexpr", "nvim_treesitter#foldexpr()")
-            vim.api.nvim_win_set_option(
-                event.window,
-                "foldtext",
-                "v:lua.neorg.modules.get_module('core.norg.concealer').foldtext()"
-            )
+            local opts = {
+                scope = "local",
+                win = event.window
+            }
+            vim.api.nvim_set_option_value("foldmethod", "expr", opts)
+            vim.api.nvim_set_option_value("foldexpr", "nvim_treesitter#foldexpr()", opts)
+            vim.api.nvim_set_option_value("foldtext",
+                "v:lua.neorg.modules.get_module('core.norg.concealer').foldtext()", opts)
         end
 
         local buf = event.buffer


### PR DESCRIPTION
Currently if you open a `norg` file first and folding is enabled, fold options will be set on the window globally. So any buffer you open afterwards will apply folding even if it's not a norg file.

If we use `nvim_set_option_value` and use `scope = local` the fold options will only apply locally to the buffer
```
                                                     *nvim_set_option_value()*
nvim_set_option_value({name}, {value}, {*opts})
    Sets the value of an option. The behavior of this function matches that of
    |:set|: for global-local options, both the global and local value are set
    unless otherwise specified with {scope}.

    Note the options {win} and {buf} cannot be used together.

    Parameters: ~
        {name}   Option name
        {value}  New option value
        {opts}   Optional parameters
                 • scope: One of 'global' or 'local'. Analogous to
                   |:setglobal| and |:setlocal|, respectively.
                 • win: |window-ID|. Used for setting window local option.
                 • buf: Buffer number. Used for setting buffer local option.
```

### Testing
##### _open to a beter way to test this!_
A bit crude 😅  but swapped out my `plugged/neorg` dir with this repo and  did the following:
1. open neorg workspace
2. check that concealing and folding is applied
3. open a new tab and open code file like `main.go`
4. there should be no folding
