### PR TITLE
feat: add `core.itero` module

### DIFF
--- a/lua/neorg/modules/core/defaults/module.lua
+++ b/lua/neorg/modules/core/defaults/module.lua
@@ -13,6 +13,7 @@ return neorg.modules.create_meta(
     "core.defaults",
     "core.autocommands",
     "core.integrations.treesitter",
+    "core.itero",
     "core.keybinds",
     "core.looking-glass",
     "core.mode",

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -529,8 +529,13 @@ module.public = {
     ---@param buf number #The buffer to search in (0 for current)
     ---@param line number #The line number (0-indexed) to get the node from
     -- the same line as `line`.
+    ---@param string|table? #Don't recurse to the provided type(s)
     ---@return userdata|nil #The first node on `line`
-    get_first_node_on_line = function(buf, line)
+    get_first_node_on_line = function(buf, line, stop_type)
+        if type(stop_type) == "string" then
+            stop_type = { stop_type }
+        end
+
         local document_root = module.public.get_document_root(buf)
 
         if not document_root then
@@ -551,7 +556,13 @@ module.public = {
             and (descendant:parent():start()) == line
             and descendant:parent():symbol() ~= document_root:symbol()
         do
-            descendant = descendant:parent()
+            local parent = descendant:parent()
+
+            if parent and stop_type and vim.tbl_contains(stop_type, parent:type()) then
+                break
+            end
+
+            descendant = parent
         end
 
         return descendant

--- a/lua/neorg/modules/core/itero/module.lua
+++ b/lua/neorg/modules/core/itero/module.lua
@@ -14,14 +14,24 @@ module.setup = function()
 end
 
 module.config.public = {
+    -- If true, will automatically continue list items and the like when `<CR>`
+    -- is pressed, and will stop when `<M-CR>` is pressed or `<CR>` is pressed
+    -- twice.
+    --
+    -- When false, will do the opposite - list items will not be continued unless
+    -- `<M-CR>` is pressed.
+    trigger_by_default = true,
+
     iterables = {
         "unordered_list%d",
         "ordered_list%d",
-        -- "quote%d",
+        "heading%d",
+        "quote%d",
     },
 
     stop_types = {
         "generic_list",
+        "quote",
     },
 }
 
@@ -31,32 +41,39 @@ end
 
 module.on_event = function(event)
     if event.split_type[2] == (module.name .. ".next-iteration") then
+        local ts = module.required["core.integrations.treesitter"]
         local cursor_pos = event.cursor_position[1] - 1
 
-        local node_on_line = module.required["core.integrations.treesitter"].get_first_node_on_line(event.buffer, cursor_pos, module.config.public.stop_types)
-        local text_to_repeat = nil
+        local current = ts.get_first_node_on_line(event.buffer, cursor_pos, module.config.public.stop_types)
 
-        for _, iterable in ipairs(module.config.public.iterables) do
-            if node_on_line:type():match(iterable) then
-                text_to_repeat = module.required["core.integrations.treesitter"].get_node_text(node_on_line:named_child(0))
-                vim.api.nvim_buf_set_lines(event.buffer, cursor_pos + 1, cursor_pos + 1, true, { text_to_repeat })
+        if not current then
+            log.error(
+                "Treesitter seems to be high and can't properly grab the node under the cursor. Perhaps try again?"
+            )
+            return
+        end
+
+        while current:parent() do
+            if
+                neorg.lib.filter(module.config.public.iterables, function(_, iterable)
+                    return current:type():match(table.concat({ "^", iterable, "$" })) and iterable or nil
+                end)
+            then
                 break
             end
+
+            current = current:parent()
         end
 
-        if node_on_line:has_error() then
-            vim.api.nvim_buf_set_lines(event.buffer, cursor_pos, cursor_pos + 1, true, { "" })
+        if not current or current:type() == "document" then
+            vim.notify("No object to continue! Make sure you're under a list item.")
             return
         end
 
-        if not text_to_repeat then
-            vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, true, true), "n", false)
-            return
-        end
+        local text_to_repeat = ts.get_node_text(current:named_child(0), event.buffer)
 
+        vim.api.nvim_buf_set_lines(event.buffer, cursor_pos + 1, cursor_pos + 1, true, { text_to_repeat })
         vim.api.nvim_win_set_cursor(event.window, { cursor_pos + 2, text_to_repeat:len() })
-    elseif event.split_type[2] == (module.name .. ".stop-iteration") then
-        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, true, true), "n", false)
     end
 end
 

--- a/lua/neorg/modules/core/itero/module.lua
+++ b/lua/neorg/modules/core/itero/module.lua
@@ -14,21 +14,18 @@ module.setup = function()
 end
 
 module.config.public = {
-    -- If true, will automatically continue list items and the like when `<CR>`
-    -- is pressed, and will stop when `<M-CR>` is pressed or `<CR>` is pressed
-    -- twice.
-    --
-    -- When false, will do the opposite - list items will not be continued unless
-    -- `<M-CR>` is pressed.
-    trigger_by_default = true,
-
+    -- A list of strings detailing what nodes can be "iterated".
+    -- Usually doesn't need to be changed, unless you want to disable some
+    -- items from being iterable.
     iterables = {
         "unordered_list%d",
         "ordered_list%d",
         "heading%d",
         "quote%d",
     },
+}
 
+module.config.private = {
     stop_types = {
         "generic_list",
         "quote",
@@ -44,7 +41,7 @@ module.on_event = function(event)
         local ts = module.required["core.integrations.treesitter"]
         local cursor_pos = event.cursor_position[1] - 1
 
-        local current = ts.get_first_node_on_line(event.buffer, cursor_pos, module.config.public.stop_types)
+        local current = ts.get_first_node_on_line(event.buffer, cursor_pos, module.config.private.stop_types)
 
         if not current then
             log.error(

--- a/lua/neorg/modules/core/itero/module.lua
+++ b/lua/neorg/modules/core/itero/module.lua
@@ -1,0 +1,70 @@
+--[[
+--
+--]]
+
+local module = neorg.modules.create("core.itero")
+
+module.setup = function()
+    return {
+        requires = {
+            "core.keybinds",
+            "core.integrations.treesitter",
+        },
+    }
+end
+
+module.config.public = {
+    iterables = {
+        "unordered_list%d",
+        "ordered_list%d",
+        -- "quote%d",
+    },
+
+    stop_types = {
+        "generic_list",
+    },
+}
+
+module.load = function()
+    module.required["core.keybinds"].register_keybinds(module.name, { "next-iteration", "stop-iteration" })
+end
+
+module.on_event = function(event)
+    if event.split_type[2] == (module.name .. ".next-iteration") then
+        local cursor_pos = event.cursor_position[1] - 1
+
+        local node_on_line = module.required["core.integrations.treesitter"].get_first_node_on_line(event.buffer, cursor_pos, module.config.public.stop_types)
+        local text_to_repeat = nil
+
+        for _, iterable in ipairs(module.config.public.iterables) do
+            if node_on_line:type():match(iterable) then
+                text_to_repeat = module.required["core.integrations.treesitter"].get_node_text(node_on_line:named_child(0))
+                vim.api.nvim_buf_set_lines(event.buffer, cursor_pos + 1, cursor_pos + 1, true, { text_to_repeat })
+                break
+            end
+        end
+
+        if node_on_line:has_error() then
+            vim.api.nvim_buf_set_lines(event.buffer, cursor_pos, cursor_pos + 1, true, { "" })
+            return
+        end
+
+        if not text_to_repeat then
+            vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, true, true), "n", false)
+            return
+        end
+
+        vim.api.nvim_win_set_cursor(event.window, { cursor_pos + 2, text_to_repeat:len() })
+    elseif event.split_type[2] == (module.name .. ".stop-iteration") then
+        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<CR>", true, true, true), "n", false)
+    end
+end
+
+module.events.subscribed = {
+    ["core.keybinds"] = {
+        [module.name .. ".next-iteration"] = true,
+        [module.name .. ".stop-iteration"] = true,
+    },
+}
+
+return module

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -73,9 +73,7 @@ module.config.public = {
                 },
 
                 i = {
-                    { "<CR>", "core.itero.next-iteration", },
-                    { "<C-j>", "core.itero.next-iteration", },
-                    { "<M-CR>", "core.itero.stop-iteration", },
+                    { "<M-CR>", "core.itero.next-iteration" },
                 },
 
                 -- v = {

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -72,6 +72,12 @@ module.config.public = {
                     { "<<", "core.promo.demote", "nested" },
                 },
 
+                i = {
+                    { "<CR>", "core.itero.next-iteration", },
+                    { "<C-j>", "core.itero.next-iteration", },
+                    { "<M-CR>", "core.itero.stop-iteration", },
+                },
+
                 -- v = {
                 --     { ">>", ":<cr><cmd>Neorg keybind all core.promo.promote_range<cr>" },
                 --     { "<<", ":<cr><cmd>Neorg keybind all core.promo.demote_range<cr>" },


### PR DESCRIPTION
This module handles item continuation, like continuation of lists, quotes, headings etc.

`<CR>` in insert mode will *not* continue the current line, like you would expect it to. By default, `<M-CR>` (Alt + `<CR>`) continues the current item. This is a big contrast to the "traditional way", as the Neorg behaviour is *opt in* vs *opt out*. I have a few reasons as to why this is a much better solution, including less fighting with the editor, no ambiguous behaviours on when to continue and item and when not to, etc.

Let me know what you think of it and optionally submit bug reports or feature requests! :)