### PR TITLE
feat: add `core.clipboard` module

### DIFF
--- a/lua/neorg/modules/core/clipboard/code-blocks/module.lua
+++ b/lua/neorg/modules/core/clipboard/code-blocks/module.lua
@@ -1,0 +1,24 @@
+local module = neorg.modules.create("core.clipboard.code-blocks")
+
+module.load = function()
+    neorg.modules.await("core.clipboard", function(clipboard)
+        clipboard.add_callback("ranged_tag_content", function(node, content, position)
+            -- TODO: Handle visual/visual line/visual block modes
+
+            -- The end of "ranged_tag_content" spans one line too many
+            if position["end"][1] > node:end_() - 1 then
+                return
+            end
+
+            local _, indentation = node:start()
+
+            for i, line in ipairs(content) do
+                content[i] = line:sub(indentation + 1)
+            end
+
+            return content
+        end, true)
+    end)
+end
+
+return module

--- a/lua/neorg/modules/core/clipboard/module.lua
+++ b/lua/neorg/modules/core/clipboard/module.lua
@@ -1,0 +1,51 @@
+local module = neorg.modules.create("core.clipboard")
+
+module.setup = function()
+    return {
+        requires = {
+            "core.integrations.treesitter",
+        }
+    }
+end
+
+module.load = function()
+    neorg.modules.await("core.keybinds", function(keybinds)
+        keybinds.register_keybinds(module.name, { "yank" })
+    end)
+end
+
+module.private = {
+    callbacks = {},
+}
+
+module.public = {
+    set_callback = function(node_type, func)
+        module.private.callbacks[node_type] = func
+    end,
+}
+
+module.on_event = function(event)
+    if event.split_type[2] == "core.clipboard.yank" then
+        vim.api.nvim_feedkeys("y", "n", true)
+
+        local node = module.required["core.integrations.treesitter"].get_first_node_on_line(event.buffer, event.cursor_position[1] - 1)
+
+        while node:parent() do
+            if module.private.callbacks[node:type()] then
+                local register = vim.fn.getreg("\"")
+                vim.fn.setreg("\"", module.private.callbacks[node:type()](node, register) or register)
+                return
+            end
+
+            node = node:parent()
+        end
+    end
+end
+
+module.events.subscribed = {
+    ["core.keybinds"] = {
+        ["core.clipboard.yank"] = true,
+    },
+}
+
+return module

--- a/lua/neorg/modules/core/clipboard/module.lua
+++ b/lua/neorg/modules/core/clipboard/module.lua
@@ -11,24 +11,45 @@ end
 module.load = function()
     vim.api.nvim_create_autocmd("TextYankPost", {
         callback = function(data)
-            if vim.api.nvim_buf_get_option(data.buf, "filetype") ~= "norg" then
+            if vim.api.nvim_buf_get_option(data.buf, "filetype") ~= "norg" or vim.v.event.operator ~= "y" then
                 return
             end
 
             local range = { vim.api.nvim_buf_get_mark(data.buf, "["), vim.api.nvim_buf_get_mark(data.buf, "]") }
+            range[1][1] = range[1][1] - 1
+            range[2][1] = range[2][1] - 1
 
             for i = range[1][1], range[2][1] do
                 local node = module.required["core.integrations.treesitter"].get_first_node_on_line(data.buf, i)
 
                 while node:parent() do
                     if module.private.callbacks[node:type()] then
-                        local register = vim.fn.getreg(vim.v.event.regname)
+                        local register = vim.fn.getreg(vim.v.register)
 
                         vim.fn.setreg(
-                            vim.v.event.regname,
-                            neorg.lib.filter(module.private.callbacks[node:type()], function(_, cb)
-                                return cb(node, register, { i, range[2] })
-                            end)
+                            vim.v.register,
+                            neorg.lib.filter(module.private.callbacks[node:type()], function(_, callback)
+                                if callback.strict and (range[1][1] < i or range[2][1] > node:end_()) then
+                                    return
+                                end
+
+                                return callback.cb(
+                                    node,
+                                    vim.split(register, "\n", {
+                                        plain = true,
+                                        -- TODO: This causes problems in places
+                                        -- where you actually want to copy
+                                        -- newlines.
+                                        trimempty = true,
+                                    }),
+                                    {
+                                        start = range[1],
+                                        ["end"] = range[2],
+                                        current = { i, range[1][2] },
+                                    }
+                                )
+                            end) or register,
+                            "l"
                         )
 
                         return
@@ -46,9 +67,9 @@ module.private = {
 }
 
 module.public = {
-    add_callback = function(node_type, func)
+    add_callback = function(node_type, func, strict)
         module.private.callbacks[node_type] = module.private.callbacks[node_type] or {}
-        table.insert(module.private.callbacks[node_type], func)
+        table.insert(module.private.callbacks[node_type], { cb = func, strict = strict })
     end,
 }
 

--- a/lua/neorg/modules/core/defaults/module.lua
+++ b/lua/neorg/modules/core/defaults/module.lua
@@ -13,6 +13,7 @@ return neorg.modules.create_meta(
     "core.defaults",
     "core.autocommands",
     "core.clipboard",
+    "core.clipboard.code-blocks",
     "core.integrations.treesitter",
     "core.itero",
     "core.keybinds",

--- a/lua/neorg/modules/core/defaults/module.lua
+++ b/lua/neorg/modules/core/defaults/module.lua
@@ -12,6 +12,7 @@ require("neorg.modules.base")
 return neorg.modules.create_meta(
     "core.defaults",
     "core.autocommands",
+    "core.clipboard",
     "core.integrations.treesitter",
     "core.itero",
     "core.keybinds",

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -70,6 +70,8 @@ module.config.public = {
 
                     { ">>", "core.promo.promote", "nested" },
                     { "<<", "core.promo.demote", "nested" },
+
+                    { "y", "core.clipboard.yank" },
                 },
 
                 i = {

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -70,8 +70,6 @@ module.config.public = {
 
                     { ">>", "core.promo.promote", "nested" },
                     { "<<", "core.promo.demote", "nested" },
-
-                    { "y", "core.clipboard.yank" },
                 },
 
                 i = {
@@ -80,6 +78,7 @@ module.config.public = {
                     { "<M-CR>", "core.itero.next-iteration" },
                 },
 
+                -- TODO: Readd these
                 -- v = {
                 --     { ">>", ":<cr><cmd>Neorg keybind all core.promo.promote_range<cr>" },
                 --     { "<<", ":<cr><cmd>Neorg keybind all core.promo.demote_range<cr>" },


### PR DESCRIPTION
This module is specifically designed for interacting with the clipboard. @xfzv this one's for you :p

This PR comes with a bonus module: `core.clipboard.code-blocks`, which removes the indentation whenever you copy the content of a code block. Makes for pasting code snippets e.g. on discord very easy.

Future TODOs may include:
- [ ] Custom behaviour when pasting stuff and not just yanking

Still a little buggy with some weird edge cases with blocks selection and regular visual selection - those will be fleshed out as time passes :). Linewise visual selection works great!