### PR TITLE
fix: completion for TODO items

### DIFF
--- a/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
@@ -86,7 +86,7 @@ module.public = {
         end
 
         function module.private.source:get_trigger_characters()
-            return { "@", "-", "[", " ", "." }
+            return { "@", "-", "[", "(", " ", "." }
         end
 
         module.private.cmp.register_source("neorg", module.private.source)

--- a/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
@@ -86,7 +86,7 @@ module.public = {
         end
 
         function module.private.source:get_trigger_characters()
-            return { "@", "-", "[", "(", " ", "." }
+            return { "@", "-", "(", " ", "." }
         end
 
         module.private.cmp.register_source("neorg", module.private.source)

--- a/lua/neorg/modules/core/norg/completion/module.lua
+++ b/lua/neorg/modules/core/norg/completion/module.lua
@@ -219,23 +219,23 @@ module.public = {
             },
         },
         {
-            regex = "^%s*%-+%s+%[([x%*%s]?)",
+            regex = "^%s*%-+%s+%(([x%*%s]?)",
 
             complete = {
-                { "[ ] ", label = "[ ] (undone)" },
-                { "[-] ", label = "[-] (pending)" },
-                { "[x] ", label = "[x] (done)" },
-                { "[_] ", label = "[_] (cancelled)" },
-                { "[!] ", label = "[!] (important)" },
-                { "[+] ", label = "[+] (recurring)" },
-                { "[=] ", label = "[=] (on hold)" },
-                { "[?] ", label = "[?] (uncertain)" },
+                { "( ) ", label = "( ) (undone)" },
+                { "(-) ", label = "(-) (pending)" },
+                { "(x) ", label = "(x) (done)" },
+                { "(_) ", label = "(_) (cancelled)" },
+                { "(!) ", label = "(!) (important)" },
+                { "(+) ", label = "(+) (recurring)" },
+                { "(=) ", label = "(=) (on hold)" },
+                { "(?) ", label = "(?) (uncertain)" },
             },
 
             options = {
                 type = "TODO",
                 pre = function()
-                    local sub = vim.api.nvim_get_current_line():gsub("^(%s*%-+%s+%[%s*)%]", "%1")
+                    local sub = vim.api.nvim_get_current_line():gsub("^(%s*%-+%s+%(%s*)%)", "%1")
 
                     if sub then
                         vim.api.nvim_set_current_line(sub)


### PR DESCRIPTION
Added the "(" as a trigger character, prevent ( from spawning a ) with the updated regex and updated the completion table.

I'm not super familiar with the new syntax yet.. or the syntax in general; so I'll probably end up reading up on the documentation to see what other completions can be disregarded and what completions should be added. But I'll do that in a future pull request.