### PR TITLE
feat: add `dirman.summary` module

### DIFF
--- a/lua/neorg/modules/core/norg/dirman/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/module.lua
@@ -472,6 +472,9 @@ module.public = {
         file:close()
         return true
     end,
+    get_index = function()
+        return module.config.public.index
+    end,
 }
 
 module.on_event = function(event)

--- a/lua/neorg/modules/core/norg/dirman/summary/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/summary/module.lua
@@ -5,6 +5,7 @@
 require("neorg.modules.base")
 require("neorg.modules")
 
+local log = require("neorg.external.log")
 local module = neorg.modules.create("core.norg.dirman.summary")
 
 module.setup = function()
@@ -32,7 +33,7 @@ module.config.public = {
             file = function()
                 return module.required["core.norg.dirman"].get_index()
             end,
-            -- The summary location, must be a heading.
+            -- The summary location, must be a top level heading.
             location = "* Index",
             -- File categories to include in the summary, if empty will include all notes
             categories = {},
@@ -44,8 +45,43 @@ module.public = {}
 
 module.events.subscribed = {
     ["core.neorgcmd"] = {
-        ["generate-workspace-summary"] = true,
+        ["dirman.summary"] = true,
     },
 }
-
+module.on_event = function(event)
+    local dirman = module.required["core.norg.dirman"]
+    if event.type == "core.neorgcmd.events.dirman.summary" then
+        local dir = dirman.get_current_workspace()[1]
+        local files = dirman.get_norg_files(dir)
+        local output = vim.defaulttable()
+        local function gen_string(tbl, name, all_parents, heading_level)
+            local str = heading_level .. name .. "\n"
+            if type(tbl) ~= "table" then
+                return name
+            end
+            for i, v in ipairs(tbl) do
+                tbl[i] = nil
+                str = str .. "{:" .. all_parents .. tostring(v) .. ":}[" .. tostring(v) .. "]\n"
+            end
+            for subdir, path in pairs(tbl) do
+                str = str .. gen_string(path, subdir, all_parents .. subdir .. "/", heading_level .. "*")
+            end
+            return str
+        end
+        for _, v in ipairs(files) do
+            v = string.reverse(string.gsub(string.reverse(v), "gron.", "", 1))
+            local path_list = vim.split(v, "/")
+            local tbl = output
+            for i, p in ipairs(path_list) do
+                path_list[i] = nil
+                if vim.tbl_isempty(path_list) then
+                    table.insert(tbl, p)
+                else
+                    tbl = tbl[p]
+                end
+            end
+        end
+        local str = gen_string(output, "", "", "*")
+    end
+end
 return module

--- a/lua/neorg/modules/core/norg/dirman/summary/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/summary/module.lua
@@ -1,0 +1,51 @@
+--[[
+    DIRMAN SUMMARY
+    module to generate a summary of a workspace inside a note 
+--]]
+require("neorg.modules.base")
+require("neorg.modules")
+
+local module = neorg.modules.create("core.norg.dirman.summary")
+
+module.setup = function()
+    return {
+        sucess = true,
+        requires = { "core.norg.dirman", "core.neorgcmd" },
+    }
+end
+
+module.load = function()
+    module.required["core.neorgcmd"].add_commands_from_table({
+        ["generate-workspace-summary"] = {
+            args = 0,
+            condition = "norg",
+            name = "dirman.summary",
+        },
+    })
+end
+
+module.config.public = {
+    -- The list of summaries, by default contains one inside the index file of a workspace.
+    summaries = {
+        {
+            -- The file to include the summary in
+            file = function()
+                return module.required["core.norg.dirman"].get_index()
+            end,
+            -- The summary location, must be a heading.
+            location = "* Index",
+            -- File categories to include in the summary, if empty will include all notes
+            categories = {},
+        },
+    },
+}
+
+module.public = {}
+
+module.events.subscribed = {
+    ["core.neorgcmd"] = {
+        ["generate-workspace-summary"] = true,
+    },
+}
+
+return module


### PR DESCRIPTION
it took me way too long to do this, really lost all my lua skills. there are various ways to improve but for a first version i think it is good. this code is probably undercommented, so if anything is unclear please ask.
possible improvements,
- allow user to configure which heading gets the summary
- allow user to configure which file gets the summary
- filter files by metadata
- move query logic to core.queries and make a new function there
- add a comment that gron. substitution is to allow files like xx.norg.norg
- expose some logic as lua functions
- make calling :Neorg generate-workspace-summary also call :w
- make the links relative to workspace root so they work for files in subdirectories
as this is around 100 lines i opted for implementing only generating the summary for now.