### PR TITLE
fix: neovim 0.9 vim.treesitter.parse_query deprecation

### DIFF
--- a/docgen/docgen.lua
+++ b/docgen/docgen.lua
@@ -143,7 +143,7 @@ end
 ---@param root userdata #The root node
 ---@return userdata? #The `module.config.public` node
 docgen.get_module_config_node = function(buffer, root)
-    local query = vim.treesitter.parse_query(
+    local query = neorg.utils.ts_parse_query(
         "lua",
         [[
         (assignment_statement

--- a/lua/neorg/external/helpers.lua
+++ b/lua/neorg/external/helpers.lua
@@ -9,7 +9,7 @@ neorg.utils = {
     --- @param query_string string # Query in s-expr syntax
     --- @return any # Parsed query
     ts_parse_query = function(language, query_string)
-        if vim.fn.has("nvim-0.9") == 1 then
+        if vim.treesitter.query.parse then
             return vim.treesitter.query.parse(language, query_string)
         else
             return vim.treesitter.parse_query(language, query_string)

--- a/lua/neorg/external/helpers.lua
+++ b/lua/neorg/external/helpers.lua
@@ -4,6 +4,17 @@
 --]]
 
 neorg.utils = {
+    --- A version agnostic way to call the neovim treesitter query parser
+    --- @param language string # Language to use for the query
+    --- @param query_string string # Query in s-expr syntax
+    --- @return any # Parsed query
+    ts_parse_query = function(language, query_string)
+        if vim.fn.has("nvim-0.9") == 1 then
+            return vim.treesitter.query.parse(language, query_string)
+        else
+            return vim.treesitter.parse_query(language, query_string)
+        end
+    end,
 
     --- An OS agnostic way of querying the current user
     get_username = function()

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -8,6 +8,7 @@
 --]]
 
 require("neorg.modules.base")
+require("neorg.external.helpers")
 
 local module = neorg.modules.create("core.integrations.treesitter")
 
@@ -156,7 +157,7 @@ module.public = {
         if not document_root then
             return
         end
-        local next_match_query = vim.treesitter.parse_query("norg", query_string)
+        local next_match_query = neorg.utils.ts_parse_query("norg", query_string)
         for id, node in next_match_query:iter_captures(document_root, 0, line_number - 1, -1) do
             if next_match_query.captures[id] == "next-segment" then
                 local start_line, start_col = node:range()
@@ -190,7 +191,7 @@ module.public = {
         if not document_root then
             return
         end
-        local previous_match_query = vim.treesitter.parse_query("norg", query_string)
+        local previous_match_query = neorg.utils.ts_parse_query("norg", query_string)
         local final_node = nil
 
         for id, node in previous_match_query:iter_captures(document_root, 0, 0, line_number) do
@@ -611,7 +612,7 @@ module.public = {
                 return
             end
 
-            local query = vim.treesitter.parse_query(
+            local query = neorg.utils.ts_parse_query(
                 "norg_meta",
                 [[
                 (metadata
@@ -694,7 +695,7 @@ module.public = {
     ---@param start number? #The start line for the query
     ---@param finish number? #The end line for the query
     execute_query = function(query_string, callback, buffer, start, finish)
-        local query = vim.treesitter.parse_query("norg", query_string)
+        local query = neorg.utils.ts_parse_query("norg", query_string)
         local root = module.public.get_document_root(buffer)
 
         if not root then

--- a/lua/neorg/modules/core/looking-glass/module.lua
+++ b/lua/neorg/modules/core/looking-glass/module.lua
@@ -14,6 +14,8 @@ block you would like to magnify - it is not bound to any key as of currently,
 but you may map it yourself via the [`core.keybinds`](@core.keybinds) module.
 --]]
 
+require("neorg.external.helpers")
+
 local module = neorg.modules.create("core.looking-glass")
 
 module.setup = function()
@@ -179,7 +181,7 @@ module.public = {
 module.on_event = function(event)
     if event.split_type[2] == "core.looking-glass.magnify-code-block" then
         -- First we must check if the user has their cursor under a code block
-        local query = vim.treesitter.parse_query(
+        local query = neorg.utils.ts_parse_query(
             "norg",
             [[
             (ranged_verbatim_tag

--- a/lua/neorg/modules/core/norg/concealer/module.lua
+++ b/lua/neorg/modules/core/norg/concealer/module.lua
@@ -13,6 +13,7 @@ masks, or sometimes completely hides many categories of markup.
 --]]
 
 require("neorg.modules.base")
+require("neorg.external.helpers")
 
 local module = neorg.modules.create("core.norg.concealer")
 
@@ -98,7 +99,7 @@ module.public = {
                 if icon_data.query then
                     -- Attempt to parse the query provided by `icon_data.query`
                     -- A query must have at least one capture, e.g. "(test_node) @icon"
-                    local query = vim.treesitter.parse_query("norg", icon_data.query)
+                    local query = neorg.utils.ts_parse_query("norg", icon_data.query)
 
                     -- This is a mapping of [id] = to_omit pairs, where `id` is a treesitter
                     -- node's id and `to_omit` is a boolean.
@@ -209,7 +210,7 @@ module.public = {
         if tree then
             -- Query all code blocks
             local ok, query = pcall(
-                vim.treesitter.parse_query,
+                neorg.utils.ts_parse_query,
                 "norg",
                 [[(
                     (ranged_verbatim_tag (tag_name) @_name) @tag

--- a/lua/neorg/modules/core/norg/dirman/summary/module.lua
+++ b/lua/neorg/modules/core/norg/dirman/summary/module.lua
@@ -72,7 +72,7 @@ module.on_event = function(event)
         dirman.open_file(dir, index)
         local tstree = vim.treesitter.get_parser(0)
         local buflc = vim.api.nvim_buf_line_count(0)
-        local query = vim.treesitter.query.parse_query(
+        local query = neorg.utils.ts_parse_query(
             "norg",
             [[ 
             (heading1 (heading1_prefix) title: (paragraph_segment) @title (#eq? @title "Index"))

--- a/lua/neorg/modules/core/norg/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/hop/module.lua
@@ -253,7 +253,7 @@ module.public = {
             return
         end
 
-        local query = vim.treesitter.parse_query("norg", query_str)
+        local query = neorg.utils.ts_parse_query("norg", query_str)
 
         for id, node in query:iter_captures(document_root, 0) do
             local capture = query.captures[id]
@@ -341,7 +341,7 @@ module.public = {
             return
         end
 
-        local query = vim.treesitter.parse_query("norg", query_text)
+        local query = neorg.utils.ts_parse_query("norg", query_text)
         local range = module.required["core.integrations.treesitter"].get_node_range(link_node)
 
         local parsed_link_information = {}
@@ -527,7 +527,7 @@ module.public = {
                     return
                 end
 
-                local query = vim.treesitter.parse_query("norg", query_str)
+                local query = neorg.utils.ts_parse_query("norg", query_str)
 
                 for id, node in query:iter_captures(document_root, buf_pointer) do
                     local capture = query.captures[id]
@@ -725,7 +725,7 @@ module.private = {
             end
         end
 
-        local query = vim.treesitter.parse_query("norg", query_str)
+        local query = neorg.utils.ts_parse_query("norg", query_str)
 
         local document_root = module.required["core.integrations.treesitter"].get_document_root(buffer)
 

--- a/lua/neorg/modules/core/norg/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/norg/esupports/metagen/module.lua
@@ -12,6 +12,7 @@ The metagen module exposes two commands - `:Neorg inject-metadata` and `:Neorg u
 --]]
 
 require("neorg.modules.base")
+require("neorg.external.helpers")
 
 local module = neorg.modules.create("core.norg.esupports.metagen")
 
@@ -88,7 +89,7 @@ module.public = {
     ---@param buf number #The buffer to check in
     ---@return boolean,table #Whether the metadata was present, and the range of the metadata node
     is_metadata_present = function(buf)
-        local query = vim.treesitter.parse_query(
+        local query = neorg.utils.ts_parse_query(
             "norg",
             [[
                  (ranged_verbatim_tag
@@ -214,7 +215,7 @@ module.public = {
 
         local current_date = os.date("%Y-%m-%d")
 
-        local query = vim.treesitter.parse_query(
+        local query = neorg.utils.ts_parse_query(
             "norg_meta",
             [[
             (pair

--- a/lua/neorg/modules/core/syntax/module.lua
+++ b/lua/neorg/modules/core/syntax/module.lua
@@ -19,6 +19,7 @@ Any edit is assumed to break this module.
 --]]
 
 require("neorg.modules.base")
+require("neorg.external.helpers")
 
 local module = neorg.modules.create("core.syntax")
 
@@ -115,7 +116,7 @@ module.public = {
 
         if tree then
             -- get the language node used by the code block
-            local code_lang = vim.treesitter.parse_query(
+            local code_lang = neorg.utils.ts_parse_query(
                 "norg",
                 [[(
                     (ranged_verbatim_tag (tag_name) @_tagname (tag_parameters) @language)

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -147,6 +147,8 @@ print("Ayo")
 The first code block will be tangled to `./output.lua`, the second code block will also be tangled to `./output.lua` and the third code block will be ignored.
 --]]
 
+require("neorg.external.helpers")
+
 local module = neorg.modules.create("core.tangle")
 
 module.setup = function()
@@ -241,7 +243,7 @@ module.public = {
             ]],
         })
 
-        local query = vim.treesitter.parse_query("norg", query_str)
+        local query = neorg.utils.ts_parse_query("norg", query_str)
 
         for id, node in query:iter_captures(document_root, buffer, 0, -1) do
             local capture = query.captures[id]


### PR DESCRIPTION
Hello everyone,

neovim 0.9 deprecated the `vim.treesitter.parse_query` call a few days ago.
You should now use `vim.treesitter.query.parse` instead.

I introduced a new `neorg.utils.ts_parse_query` function that will check the
neovim version used and use the right call. I replaced all usage of `parse_query`
with the new function.

Have a great day everyone!