### PR TITLE
ref(calendar): extract logic, fix bug with time reformatting

### DIFF
--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -378,7 +378,7 @@ module.public = {
                 local positive_target_date = reformat_time({
                     year = date.year,
                     month = date.month + blockid,
-                    day = date.day,
+                    day = 1,
                 })
 
                 module.private.render_month_banner(ui_info, positive_target_date, weekday_banner)
@@ -389,10 +389,10 @@ module.public = {
                 local negative_target_date = reformat_time({
                     year = date.year,
                     month = date.month - blockid,
-                    day = date.day,
+                    day = 1,
                 })
 
-                module.private.render_month_banner(ui_info, negative_target_date, weekday_banner, options.distance)
+                module.private.render_month_banner(ui_info, negative_target_date, weekday_banner)
                 module.private.render_month(ui_info, negative_target_date, date, weekday_banner)
 
                 blockid = blockid + 1

--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -203,9 +203,10 @@ module.private = {
         local render_column = days_of_month[1] - 1
         local render_row = 1
 
+        module.private.extmarks.logical.months[month] = module.private.extmarks.logical.months[month]
+            or {}
+
         for day_of_month, day_of_week in ipairs(days_of_month) do
-            module.private.extmarks.logical.months[month] = module.private.extmarks.logical.months[month]
-                or {}
 
             local is_current_day = current_date.year == target_date.year
                 and current_date.month == target_date.month

--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -48,11 +48,17 @@ module.private = {
             end
         end
 
-        return vim.api.nvim_buf_set_extmark(ui_info.buffer, module.private.namespaces.decorational, row, col, vim.tbl_deep_extend("force", {
-            virt_text = virt_text,
-            virt_text_pos = "overlay",
-            end_col = col + length,
-        }, extra or {}))
+        return vim.api.nvim_buf_set_extmark(
+            ui_info.buffer,
+            module.private.namespaces.decorational,
+            row,
+            col,
+            vim.tbl_deep_extend("force", {
+                virt_text = virt_text,
+                virt_text_pos = "overlay",
+                end_col = col + length,
+            }, extra or {})
+        )
     end,
 
     set_logical_extmark = function(ui_info, row, col, virt_text, alignment, extra)
@@ -203,11 +209,9 @@ module.private = {
         local render_column = days_of_month[1] - 1
         local render_row = 1
 
-        module.private.extmarks.logical.months[month] = module.private.extmarks.logical.months[month]
-            or {}
+        module.private.extmarks.logical.months[month] = module.private.extmarks.logical.months[month] or {}
 
         for day_of_month, day_of_week in ipairs(days_of_month) do
-
             local is_current_day = current_date.year == target_date.year
                 and current_date.month == target_date.month
                 and day_of_month == day
@@ -258,10 +262,9 @@ module.private = {
             30,
             31,
         })[month]
-
     end,
 
-    is_leap_year = function (year)
+    is_leap_year = function(year)
         if year % 4 ~= 0 then
             return false
         end
@@ -272,7 +275,7 @@ module.private = {
         end
 
         return true
-    end
+    end,
 }
 
 module.public = {
@@ -440,7 +443,9 @@ module.public = {
 
                         current_day = 1
                         current_month = current_month + 1
-                        render_month_array(reformat_time({ day = current_day, month = current_month, year = current_year }))
+                        render_month_array(
+                            reformat_time({ day = current_day, month = current_month, year = current_year })
+                        )
                         next_extmark_id = next_month[current_day]
                     else
                         current_day = current_day + 1
@@ -475,7 +480,9 @@ module.public = {
 
                         current_day = #prev_month
                         current_month = current_month - 1
-                        render_month_array(reformat_time({ day = current_day, month = current_month, year = current_year }))
+                        render_month_array(
+                            reformat_time({ day = current_day, month = current_month, year = current_year })
+                        )
                         prev_extmark_id = prev_month[current_day]
                     else
                         current_day = current_day - 1

--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -82,6 +82,7 @@ module.private = {
         )
     end,
 
+    -- TODO: implemant distance like in render_weekday_banner
     render_month_banner = function(ui_info, date, weekday_banner_extmark_id)
         local month_name = os.date(
             "%B",
@@ -179,20 +180,7 @@ module.private = {
 
         local day, month, year = target_date.day, target_date.month, target_date.year
 
-        local days_in_current_month = ({
-            31,
-            (module.private.is_leap_year(year)) and 29 or 28,
-            31,
-            30,
-            31,
-            30,
-            31,
-            31,
-            30,
-            31,
-            30,
-            31,
-        })[month]
+        local days_in_current_month = module.private.get_month_length(month, year)
 
         for i = 1, days_in_current_month do
             days_of_month[i] = tonumber(os.date(
@@ -252,6 +240,24 @@ module.private = {
                 render_column = render_column + 1
             end
         end
+    end,
+
+    get_month_length = function(month, year)
+        return ({
+            31,
+            (module.private.is_leap_year(year)) and 29 or 28,
+            31,
+            30,
+            31,
+            30,
+            31,
+            31,
+            30,
+            31,
+            30,
+            31,
+        })[month]
+
     end,
 
     is_leap_year = function (year)

--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -181,7 +181,7 @@ module.private = {
 
         local days_in_current_month = ({
             31,
-            (year % 4 == 0) and 29 or 28,
+            (module.private.is_leap_year(year)) and 29 or 28,
             31,
             30,
             31,
@@ -253,6 +253,19 @@ module.private = {
             end
         end
     end,
+
+    is_leap_year = function (year)
+        if year % 4 ~= 0 then
+            return false
+        end
+
+        -- Years disible by 100 are leap years only if also divisible by 400
+        if year % 100 == 0 and year % 400 ~= 0 then
+            return false
+        end
+
+        return true
+    end
 }
 
 module.public = {


### PR DESCRIPTION
This fixes the issue that I've talked about recently (when the current date is higher than the previous/following month max day)
It also contains an improvement for the leap year check.