### PR TITLE
ref(calendar): extract rendering logic, add and improve keybinds

### DIFF
--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -457,8 +457,8 @@ module.public = {
 
         do
             -- TODO: Make cursor wrapping behaviour configurable
-            vim.api.nvim_buf_set_keymap(buffer, "n", "l", "", {
-                callback = function()
+            vim.keymap.set("n", "l",
+                function()
                     local new_date = reformat_time({
                         year = current_date.year,
                         month = current_date.month,
@@ -467,10 +467,11 @@ module.public = {
                     module.private.render_view(ui_info, view, new_date, current_date, options)
                     current_date = new_date
                 end,
-            })
+                { buffer = buffer }
+            )
 
-            vim.api.nvim_buf_set_keymap(buffer, "n", "h", "", {
-                callback = function()
+            vim.keymap.set("n", "h",
+                function()
                     local new_date = reformat_time({
                         year = current_date.year,
                         month = current_date.month,
@@ -479,10 +480,11 @@ module.public = {
                     module.private.render_view(ui_info, view, new_date, current_date, options)
                     current_date = new_date
                 end,
-            })
+                { buffer = buffer }
+            )
 
-            vim.api.nvim_buf_set_keymap(buffer, "n", "j", "", {
-                callback = function()
+            vim.keymap.set("n", "j",
+                function()
                     local new_date = reformat_time({
                         year = current_date.year,
                         month = current_date.month,
@@ -491,10 +493,11 @@ module.public = {
                     module.private.render_view(ui_info, view, new_date, current_date, options)
                     current_date = new_date
                 end,
-            })
+                { buffer = buffer }
+            )
 
-            vim.api.nvim_buf_set_keymap(buffer, "n", "k", "", {
-                callback = function()
+            vim.keymap.set("n", "k",
+                function()
                     local new_date = reformat_time({
                         year = current_date.year,
                         month = current_date.month,
@@ -503,7 +506,8 @@ module.public = {
                     module.private.render_view(ui_info, view, new_date, current_date, options)
                     current_date = new_date
                 end,
-            })
+                { buffer = buffer }
+            )
         end
     end,
 


### PR DESCRIPTION
This commit completes the extraction of the rendering logic out of the `create_calendar` function. This allows us to re-render the view sections as needed without too much extra code. It also simplifies the keybindings logic, and allowed the easy integration of "j" and "k" keybindings, which goes to the previous and next week, respectively.
The new keybinding logic also fixes an issue with leap years. Previously, if the month of february was rendered with 29 days, and then we moved to a different year where february only had 28 days, it would break the logic and not render correctly.