### PR TITLE
ref(calendar): refactored extmark creation, fixed single month view and added month limit

### DIFF
--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -386,7 +386,6 @@ module.private = {
         month_max = month_max > 12 and (month_max - 12) or month_max
 
         local clear_extmarks_for_month = function (month)
-            print("Clearing extmark for month " .. month)
             for _, extmark_id in ipairs(module.private.extmarks.logical.months[month]) do
                 vim.api.nvim_buf_del_extmark(
                     ui_info.buffer,

--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -247,32 +247,31 @@ module.private = {
         module.private.render_month_banner(ui_info, date, weekday_banner)
         module.private.render_month(ui_info, date, date, weekday_banner)
 
-        local blockid = 1
+        local months_to_render = module.private.rendered_months_in_width(ui_info.width, options.distance)
+        months_to_render = math.floor(months_to_render / 2)
 
-        while math.floor(ui_info.width / (26 + options.distance)) > blockid * 2 do
-            weekday_banner = module.private.render_weekday_banner(ui_info, blockid, options.distance)
+        for i=1,months_to_render do
+            weekday_banner = module.private.render_weekday_banner(ui_info, i, options.distance)
 
             local positive_target_date = reformat_time({
                 year = date.year,
-                month = date.month + blockid,
+                month = date.month + i,
                 day = 1,
             })
 
             module.private.render_month_banner(ui_info, positive_target_date, weekday_banner)
             module.private.render_month(ui_info, positive_target_date, date, weekday_banner)
 
-            weekday_banner = module.private.render_weekday_banner(ui_info, blockid * -1)
+            weekday_banner = module.private.render_weekday_banner(ui_info, i * -1)
 
             local negative_target_date = reformat_time({
                 year = date.year,
-                month = date.month - blockid,
+                month = date.month - i,
                 day = 1,
             })
 
             module.private.render_month_banner(ui_info, negative_target_date, weekday_banner)
             module.private.render_month(ui_info, negative_target_date, date, weekday_banner)
-
-            blockid = blockid + 1
         end
     end,
 
@@ -417,6 +416,15 @@ module.private = {
         end
 
         return true
+    end,
+
+    rendered_months_in_width = function(width, distance)
+        local rendered_month_width = 26
+        local months = math.floor(width / (rendered_month_width + distance))
+        if months % 2 == 0 then
+            return months - 1
+        end
+        return months
     end,
 }
 

--- a/lua/neorg/modules/core/ui/calendar.lua
+++ b/lua/neorg/modules/core/ui/calendar.lua
@@ -398,6 +398,8 @@ module.private = {
         end
 
         for month, _ in pairs(module.private.extmarks.logical.months) do
+            -- Check if the month is outside the current view range
+            -- considering the month wrapping after 12
             if month_min < month_max then
                 if month_min > month or month > month_max then
                     clear_extmarks_for_month(month)
@@ -463,6 +465,12 @@ module.private = {
     rendered_months_in_width = function(width, distance)
         local rendered_month_width = 26
         local months = math.floor(width / (rendered_month_width + distance))
+
+        -- Do not show more than one year
+        if months > 12 then
+            months = 12
+        end
+
         if months % 2 == 0 then
             return months - 1
         end


### PR DESCRIPTION
This PR is mainly aimed at fixing the calendar when the view is too small to show more than one month. Currently, this is breaking the code because other months extmarks are not removed and will be displayed on top of the visible ones.
I've added a function to clear the extmarks of the months that are outside of the current view, and this fixes the issue.

The visible months are now limited to 11 (the center one + 5 on the sides) because having more than 12 months will break a lot of the current code.

I've also slightly refactored the extmark creation functions to make them more DRY.