### PR TITLE
feat: warn access to `core.norg` modules instead of breaking

### DIFF
--- a/lua/neorg/modules.lua
+++ b/lua/neorg/modules.lua
@@ -18,6 +18,19 @@ neorg.modules.loaded_module_count = 0
 --- The table of currently loaded modules
 neorg.modules.loaded_modules = {}
 
+-- Warns access to `core.norg.foo` modules since they are deprecated in v3.0.0
+-- Accesses to `core.foo` automatically instead
+setmetatable(neorg.modules.loaded_modules, {
+    __index = function(orig_tbl, old_key)
+        if vim.startswith(old_key, "core.norg") then
+            local new_key = "core" .. string.sub(old_key, 10) -- string.len("core.norg") == 10
+            log.warn(string.format("%s is deprecated in Neorg v3.0.0+. Use %s instead.", old_key, new_key))
+            return orig_tbl[new_key]
+        end
+        return nil
+    end,
+})
+
 --- Loads and enables a module
 -- Loads a specified module. If the module subscribes to any events then they will be activated too.
 ---@param module table #The actual module to load


### PR DESCRIPTION
@vhyrro I read your post on the Discord server and found out that all `core.norg.foo` modules are moved to `core.foo`.

I know you made a major version jump, but even with that,
Please do not break the plugin immediately.

Instead, warning the user should be way better.

Please considering accepting this PR.

Best 