### PR TITLE
fix(export): `gsub` export links that contain `#`, `?`. closes #807

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -118,15 +118,6 @@ module.load = function()
     module.config.public.extensions = neorg.lib.to_keys(module.config.public.extensions)
 end
 
-module.config.private = {
-    url_escapes = {
-        ["%%3f"] = "?",
-        ["%%23"] = "#",
-        ["%%5b"] = "[",
-        ["%%5d"] = "]",
-    },
-}
-
 module.config.public = {
     -- Any extensions you may want to use when exporting to markdown. By
     -- default no extensions are loaded (the exporter is commonmark compliant).
@@ -574,13 +565,6 @@ module.public = {
 
                 if state.is_url then
                     state.is_url = false
-                    local url = vim.uri_from_fname(output[#output - 1]):sub(string.len("file://") + 1)
-                    if url ~= output[#output - 1] then -- at least something has changed
-                        for key, value in pairs(module.config.private.url_escapes) do
-                            url = string.gsub(url, key, value)
-                        end
-                    end
-                    output[#output - 1] = url
                     return output
                 end
 

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -118,6 +118,15 @@ module.load = function()
     module.config.public.extensions = neorg.lib.to_keys(module.config.public.extensions)
 end
 
+module.config.private = {
+    url_escapes = {
+        ["%%3f"] = "?",
+        ["%%23"] = "#",
+        ["%%5b"] = "[",
+        ["%%5d"] = "]",
+    },
+}
+
 module.config.public = {
     -- Any extensions you may want to use when exporting to markdown. By
     -- default no extensions are loaded (the exporter is commonmark compliant).
@@ -565,7 +574,13 @@ module.public = {
 
                 if state.is_url then
                     state.is_url = false
-                    output[#output - 1] = vim.uri_from_fname(output[#output - 1]):sub(string.len("file://") + 1)
+                    local url = vim.uri_from_fname(output[#output - 1]):sub(string.len("file://") + 1)
+                    if url ~= output[#output - 1] then -- at least something has changed
+                        for key, value in pairs(module.config.private.url_escapes) do
+                            url = string.gsub(url, key, value)
+                        end
+                    end
+                    output[#output - 1] = url
                     return output
                 end
 


### PR DESCRIPTION
Hi, thanks for the nice plugin!

As I mentioned in #807, several characters in links inside exported markdown files are escaped and do not link to the desired position.

Several examples are...

- `{https://www.youtube.com/watch?v=j4lTvIGRhmw}["?" => "%3f"]`
  - ["?" => "%3f"](https://www.youtube.com/watch%3fv=j4lTvIGRhmw)
- `{https://github.com/nvim-neorg/neorg/#-installationquickstart}["#" => "%23"]`
  - ["#" => "%23"](https://github.com/nvim-neorg/neorg/%23-installationquickstart)

where if you follow the links above, they do not jump to the correct link, due to the conversion.

This PR aims to fix / workaround the output from `vim.uri_from_fname()` to fix this issue.

Hope this helps.
Best,