### PR TITLE
ref!(ftdetect): rewrite filetype detection logic from VimL to Lua

### DIFF
--- a/ftdetect/norg.lua
+++ b/ftdetect/norg.lua
@@ -1,0 +1,5 @@
+vim.filetype.add({
+  extension = {
+    norg = "norg",
+  }
+})

--- a/ftdetect/norg.vim
+++ b/ftdetect/norg.vim
@@ -1,1 +1,0 @@
-autocmd BufRead,BufNewFile *.norg setlocal filetype=norg


### PR DESCRIPTION
This PR aims to modernize old VimL files to use Lua files with the Neovim Lua API,
also because I hate Vim Script.
