### PR TITLE
refactoring concealer

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -1547,7 +1547,6 @@ module.on_event = function(event)
                 has_conceal = (
                     vim.api.nvim_win_is_valid(event.window)
                         and (vim.api.nvim_win_get_option(event.window, "conceallevel") > 0)
-                    or false
                 )
 
                 if mode ~= "i" then
@@ -1600,10 +1599,8 @@ module.on_event = function(event)
                         module.private.largest_change_end = _end
                     end
 
-                    module.private.largest_change_start = start < module.private.largest_change_start and start
-                        or module.private.largest_change_start
-                    module.private.largest_change_end = _end > module.private.largest_change_end and _end
-                        or module.private.largest_change_end
+                    module.private.largest_change_start = math.min(start, module.private.largest_change_start)
+                    module.private.largest_change_end = math.max(_end, module.private.largest_change_end)
                 end
             end,
         })


### PR DESCRIPTION
I'm trying to solve the concealer problems (https://github.com/nvim-neorg/neorg/issues/821, https://github.com/nvim-neorg/neorg/issues/831, https://github.com/nvim-neorg/neorg/issues/833, etc.) systematically, but the current implementation is not very easy to deal with. Not few lines have large (up to 18) indentation levels.

https://github.com/nvim-neorg/neorg/blob/a295adf945a215d84e7a6252faf1b7a4dc9db8f7/lua/neorg/modules/core/concealer/module.lua#L386

This is a tracker PR of the refactoring of concealer and probably of the fixes as well.