### PR TITLE
fix(concealer): stop concealer if buffer is not loaded

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -1505,7 +1505,7 @@ module.on_event = function(event)
                         or (block_bottom * module.config.public.performance.increment - 1 >= 0)
                     local block_top_valid = block_top * module.config.public.performance.increment - 1 < line_count
 
-                    if not block_bottom_valid and not block_top_valid then
+                    if not vim.api.nvim_buf_is_loaded(buf) or (not block_bottom_valid and not block_top_valid) then
                         timer:stop()
                         return
                     end


### PR DESCRIPTION
Many potential causes for buffer to be unloaded, but `:h vimgrep` is a big one. Without this fix, `:vimgrep` can get caught in an infinite loop of errors because the concealer wants to keep going until everything is done, but that can not happen if `:vimgrep` does not find a match and immediately deletes the buffer.