### PR TITLE
refactor: use new icons for `done`/`undone` as per nerd fonts 3.0

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -838,13 +838,13 @@ module.config.public = {
 
             done = {
                 enabled = true,
-                icon = "",
+                icon = "󰄬",
                 query = "(todo_item_done) @icon",
             },
 
             pending = {
                 enabled = true,
-                icon = "",
+                icon = "󰥔",
                 query = "(todo_item_pending) @icon",
             },
 


### PR DESCRIPTION
The icons used to conceal 'done' and 'pending' tasks were [moved to new code points](https://github.com/ryanoasis/nerd-fonts/blob/master/changelog.md#breaking-2-material-design-icons-codepoints). This commit fixes them according to [this translation table](https://github.com/ryanoasis/nerd-fonts/issues/1059#issuecomment-1404891287).