### PR TITLE
fix(tempus): paste correct weekday from calendar

### DIFF
--- a/lua/neorg/modules/core/tempus/module.lua
+++ b/lua/neorg/modules/core/tempus/module.lua
@@ -257,9 +257,11 @@ module.public = {
         end
 
         return module.private.tostringable_date({
+            -- os.date("*t") returns wday with Sunday as 1, needs to be
+            -- converted to Monday as 1
             weekday = osdate.wday and {
-                number = osdate.wday,
-                name = neorg.lib.title(weekdays[osdate.wday]),
+                number = osdate.wday == 1 and 7 or osdate.wday-1,
+                name = neorg.lib.title(weekdays[osdate.wday == 1 and 7 or osdate.wday-1]),
             } or nil,
             day = osdate.day,
             month = osdate.month and {


### PR DESCRIPTION
When trying to insert a date from the calendar view the wrong weekday is shown. The problem is that `os.date("*t")` returns `wday` with Sunday as 1, while the `weekday` names in the tempus module assume Monday as 1.