### PR TITLE
feat(todo-items): add missing "need input" icon and action

### DIFF
--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -46,6 +46,10 @@ module.config.public = {
                     -- ^mark Task as Important
                     { leader .. "ti", "core.qol.todo_items.todo.task_important" },
 
+                    -- Marks the task under the cursor as "need_input"
+                    -- ^mark Task as Nedding Input
+                    { leader .. "tn", "core.qol.todo_items.todo.task_need_input" },
+
                     -- Switches the task under the cursor between a select few states
                     { "<C-Space>", "core.qol.todo_items.todo.task_cycle" },
 

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -46,9 +46,9 @@ module.config.public = {
                     -- ^mark Task as Important
                     { leader .. "ti", "core.qol.todo_items.todo.task_important" },
 
-                    -- Marks the task under the cursor as "need_input"
-                    -- ^mark Task as Nedding Input
-                    { leader .. "tn", "core.qol.todo_items.todo.task_need_input" },
+                    -- Marks the task under the cursor as "ambiguous"
+                    -- ^mark Task as ambiguous
+                    { leader .. "ta", "core.qol.todo_items.todo.task_ambiguous" },
 
                     -- Switches the task under the cursor between a select few states
                     { "<C-Space>", "core.qol.todo_items.todo.task_cycle" },

--- a/lua/neorg/modules/core/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/qol/todo_items/module.lua
@@ -424,7 +424,7 @@ module.on_event = function(event)
             done = "x",
             important = "!",
             recurring = "+",
-            need_input = "?",
+            ambiguous = "?",
         }
 
         local match = event.split_type[2]:match(todo_str .. "task_(.+)")
@@ -464,7 +464,7 @@ module.events.subscribed = {
         ["core.qol.todo_items.todo.task_cancelled"] = true,
         ["core.qol.todo_items.todo.task_important"] = true,
         ["core.qol.todo_items.todo.task_recurring"] = true,
-        ["core.qol.todo_items.todo.task_need_input"] = true,
+        ["core.qol.todo_items.todo.task_ambiguous"] = true,
         ["core.qol.todo_items.todo.task_cycle"] = true,
         ["core.qol.todo_items.todo.task_cycle_reverse"] = true,
         ["core.qol.todo_items.warn-deprecated-keybind"] = true,

--- a/lua/neorg/modules/core/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/qol/todo_items/module.lua
@@ -424,6 +424,7 @@ module.on_event = function(event)
             done = "x",
             important = "!",
             recurring = "+",
+            need_input = "?",
         }
 
         local match = event.split_type[2]:match(todo_str .. "task_(.+)")
@@ -463,6 +464,7 @@ module.events.subscribed = {
         ["core.qol.todo_items.todo.task_cancelled"] = true,
         ["core.qol.todo_items.todo.task_important"] = true,
         ["core.qol.todo_items.todo.task_recurring"] = true,
+        ["core.qol.todo_items.todo.task_need_input"] = true,
         ["core.qol.todo_items.todo.task_cycle"] = true,
         ["core.qol.todo_items.todo.task_cycle_reverse"] = true,
         ["core.qol.todo_items.warn-deprecated-keybind"] = true,


### PR DESCRIPTION
The 1.0 spec https://github.com/nvim-neorg/norg-specs/blob/main/1.0-specification.norg including "need input" todo status:

https://github.com/nvim-neorg/norg-specs/blob/f4d696ebfe9c227fc912ad4249c6b34f71f4ace4/1.0-specification.norg#L573

But the current module do not include this status so I create this PR.