### PR TITLE
feat(tempus): Default to current year when parsing

### DIFF
--- a/lua/neorg/modules/core/tempus/module.lua
+++ b/lua/neorg/modules/core/tempus/module.lua
@@ -306,6 +306,9 @@ module.public = {
 
         local output = {}
 
+        -- Add current year as default in case it isn't provided
+        output.year = os.date("%Y")
+
         for word in vim.gsplit(input, "%s+") do
             if word:len() == 0 then
                 goto continue


### PR DESCRIPTION
This change allows a user to enter a date without the current year such as "May 22" and default to the current year. When using the journal module and entering a date someone can avoid having to specifying the year every time when they are talking about the current year.

Hey I remember on discord I had asked about having a hook into the calendar module from the journal. I use it all the time so thank you! I remember using the custom input and I just didn't feel like writing out 2023 every single time but it would error if I didn't provide the year. So I updated the tempus module so that it would have a default year of the current one if someone only provided the month and date. Let me know if perhaps it should be done elsewhere.