### PR TITLE
bugfix for external_file links containing :linenumber

### DIFF
--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -448,10 +448,10 @@ module.public = {
 
                 -- remove `:linenumber` from destination (to avoid opening a file named file.txt:123)
                 local line
-                local i, j = string.find(destination, ':%d+$')
+                local i, j = string.find(destination, ":%d+$")
                 if i then
-                  line = tonumber(string.sub(destination, i+1, j))
-                  destination = string.sub(destination, 0, i-1)
+                    line = tonumber(string.sub(destination, i + 1, j))
+                    destination = string.sub(destination, 0, i - 1)
                 end
 
                 neorg.lib.match(vim.fn.fnamemodify(destination, ":e"))({
@@ -459,23 +459,26 @@ module.public = {
                     png = open_in_external_app,
                     [{ "jpg", "jpeg" }] = open_in_external_app,
                     [module.config.public.external_filetypes] = open_in_external_app,
-                    _ = neorg.lib.wrap(vim.api.nvim_cmd, {cmd="edit", args={vim.fn.fnamemodify(destination, ":p")}}, {}),
+                    _ = neorg.lib.wrap(
+                        vim.api.nvim_cmd,
+                        { cmd = "edit", args = { vim.fn.fnamemodify(destination, ":p") } },
+                        {}
+                    ),
                 })
 
                 if line then
-                  -- set cursor to linenumber
-                  -- 2 workarounds:
-                  -- 1) I couldn't find a way to send the `e +linenumber filename` syntax via vim.api.nvim_cmd.
-                  -- 2) If I try to wrap both `neorg.lib.wrap`s into a single `function()`, the set_cursor happens too early
-                  --    (in the current buffer, not the new buffer)
-                  local nothing = function()
-                  end
-                  neorg.lib.match(vim.fn.fnamemodify(destination, ":e"))({
-                      pdf = nothing,
-                      png = nothing,
-                      [{ "jpg", "jpeg" }] = nothing,
-                      [module.config.public.external_filetypes] = nothing,
-                      _ = neorg.lib.wrap(vim.api.nvim_win_set_cursor, 0, { line, 0 })
+                    -- set cursor to linenumber
+                    -- 2 workarounds:
+                    -- 1) I couldn't find a way to send the `e +linenumber filename` syntax via vim.api.nvim_cmd.
+                    -- 2) If I try to wrap both `neorg.lib.wrap`s into a single `function()`, the set_cursor happens too early
+                    --    (in the current buffer, not the new buffer)
+                    local nothing = function() end
+                    neorg.lib.match(vim.fn.fnamemodify(destination, ":e"))({
+                        pdf = nothing,
+                        png = nothing,
+                        [{ "jpg", "jpeg" }] = nothing,
+                        [module.config.public.external_filetypes] = nothing,
+                        _ = neorg.lib.wrap(vim.api.nvim_win_set_cursor, 0, { line, 0 }),
                     })
                 end
                 return {}


### PR DESCRIPTION
Currently when you link to an external file like `{/ file.txt:123}`, it opens a file named `file.txt:123` instead of `file.txt` on line 123.

This addresses it, but there are 2 (related) workarounds here - see comments. I'd appreciate any help with eliminating them.

My first neorg PR. Ta