### PR TITLE
docs(README): make lazy.nvim install instructions more standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,24 +204,26 @@ You can install it through your favorite plugin manager:
 
   ```lua
   require("lazy").setup({
-      {
-          "nvim-neorg/neorg",
-          build = ":Neorg sync-parsers",
-          opts = {
-              load = {
-                  ["core.defaults"] = {}, -- Loads default behaviour
-                  ["core.concealer"] = {}, -- Adds pretty icons to your documents
-                  ["core.dirman"] = { -- Manages Neorg workspaces
-                      config = {
-                          workspaces = {
-                              notes = "~/notes",
-                          },
-                      },
-                  },
+    {
+      "nvim-neorg/neorg",
+      build = ":Neorg sync-parsers",
+      dependencies = { "nvim-lua/plenary.nvim" },
+      config = function()
+        require("neorg").setup {
+          load = {
+            ["core.defaults"] = {}, -- Loads default behaviour
+            ["core.concealer"] = {}, -- Adds pretty icons to your documents
+            ["core.dirman"] = { -- Manages Neorg workspaces
+              config = {
+                workspaces = {
+                  notes = "~/notes",
+                },
               },
+            },
           },
-          dependencies = { { "nvim-lua/plenary.nvim" } },
-      }
+        }
+      end,
+    },
   })
   ```
 


### PR DESCRIPTION
Using ```config = function()``` is generally preferred over using ```opt```, so the section for lazy.nvim should be using 
```config = function()``` instead of ```opt```