### PR TITLE
fix(highlights): assert on treesitter being enabled

### DIFF
--- a/lua/neorg/modules/core/highlights/module.lua
+++ b/lua/neorg/modules/core/highlights/module.lua
@@ -539,6 +539,7 @@ module.public = {
 
     --- Reads the highlights configuration table and applies all defined highlights
     trigger_highlights = function()
+        assert(require("nvim-treesitter.query").has_highlights("norg"))
         --- Recursively descends down the highlight configuration and applies every highlight accordingly
         ---@param highlights table #The table of highlights to descend down
         ---@param callback #(function(hl_name, highlight, prefix) -> bool) - a callback function to be invoked for every highlight. If it returns true then we should recurse down the table tree further


### PR DESCRIPTION
This stops the propagation of highlighting problems caused by packer lazy loading (`ft = "norg"`)