### PR TITLE
fix(docgen): propagate docgen error exit code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 documentation:
-	nvim --headless -u docgen/minimal_init.vim -c "cd ./docgen" -c "source init.lua" -c 'qa'
+	! ( nvim --headless -u docgen/minimal_init.vim -c "cd ./docgen" -c "source init.lua" -c 'qa' 2>&1 | grep -q "stack traceback:" )
 
 local-documentation:
 	nvim --headless -c "cd ./docgen" -c "source init.lua" -c 'qa'


### PR DESCRIPTION
This stops PR docgen from failing silently and nuking the wiki.
<s>Reference: https://github.com/neovim/neovim/issues/18093#issuecomment-1108044394</s>