### PR TITLE
feat(keybinds.lua): add `desc` fields to task keybinds

### DIFF
--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -27,15 +27,27 @@ module.config.public = {
 
                     -- Marks the task under the cursor as "cancelled"
                     -- ^mark Task as Cancelled
-                    { leader .. "tc", "core.qol.todo_items.todo.task_cancelled", opts = { desc = "Mark as Cancelled" } },
+                    {
+                        leader .. "tc",
+                        "core.qol.todo_items.todo.task_cancelled",
+                        opts = { desc = "Mark as Cancelled" },
+                    },
 
                     -- Marks the task under the cursor as "recurring"
                     -- ^mark Task as Recurring
-                    { leader .. "tr", "core.qol.todo_items.todo.task_recurring", opts = { desc = "Mark as Recurring" } },
+                    {
+                        leader .. "tr",
+                        "core.qol.todo_items.todo.task_recurring",
+                        opts = { desc = "Mark as Recurring" },
+                    },
 
                     -- Marks the task under the cursor as "important"
                     -- ^mark Task as Important
-                    { leader .. "ti", "core.qol.todo_items.todo.task_important", opts = { desc = "Mark as Important" } },
+                    {
+                        leader .. "ti",
+                        "core.qol.todo_items.todo.task_important",
+                        opts = { desc = "Mark as Important" },
+                    },
 
                     -- Marks the task under the cursor as "ambiguous"
                     -- ^mark Task as ambiguous

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -11,35 +11,35 @@ module.config.public = {
                 n = {
                     -- Marks the task under the cursor as "undone"
                     -- ^mark Task as Undone
-                    { leader .. "tu", "core.qol.todo_items.todo.task_undone", { desc = "Undone" } },
+                    { leader .. "tu", "core.qol.todo_items.todo.task_undone", opts = { desc = "Mark as Undone" } },
 
                     -- Marks the task under the cursor as "pending"
                     -- ^mark Task as Pending
-                    { leader .. "tp", "core.qol.todo_items.todo.task_pending", { desc = "Pending" } },
+                    { leader .. "tp", "core.qol.todo_items.todo.task_pending", opts = { desc = "Mark as Pending" } },
 
                     -- Marks the task under the cursor as "done"
                     -- ^mark Task as Done
-                    { leader .. "td", "core.qol.todo_items.todo.task_done", { desc = "Done" } },
+                    { leader .. "td", "core.qol.todo_items.todo.task_done", opts = { desc = "Mark as Done" } },
 
                     -- Marks the task under the cursor as "on_hold"
                     -- ^mark Task as on Hold
-                    { leader .. "th", "core.qol.todo_items.todo.task_on_hold", { desc = "On Hold" } },
+                    { leader .. "th", "core.qol.todo_items.todo.task_on_hold", opts = { desc = "Mark as On Hold" } },
 
                     -- Marks the task under the cursor as "cancelled"
                     -- ^mark Task as Cancelled
-                    { leader .. "tc", "core.qol.todo_items.todo.task_cancelled", { desc = "Cancelled" } },
+                    { leader .. "tc", "core.qol.todo_items.todo.task_cancelled", opts = { desc = "Mark as Cancelled" } },
 
                     -- Marks the task under the cursor as "recurring"
                     -- ^mark Task as Recurring
-                    { leader .. "tr", "core.qol.todo_items.todo.task_recurring", { desc = "Recurring" } },
+                    { leader .. "tr", "core.qol.todo_items.todo.task_recurring", opts = { desc = "Mark as Recurring" } },
 
                     -- Marks the task under the cursor as "important"
                     -- ^mark Task as Important
-                    { leader .. "ti", "core.qol.todo_items.todo.task_important", { desc = "Important" } },
+                    { leader .. "ti", "core.qol.todo_items.todo.task_important", opts = { desc = "Mark as Important" } },
 
                     -- Marks the task under the cursor as "ambiguous"
                     -- ^mark Task as ambiguous
-                    { leader .. "ta", "core.qol.todo_items.todo.task_ambiguous", { desc = "Ambigous" } },
+                    { leader .. "ta", "core.qol.todo_items.todo.task_ambiguous", opts = { desc = "Mark as Ambigous" } },
 
                     -- Switches the task under the cursor between a select few states
                     { "<C-Space>", "core.qol.todo_items.todo.task_cycle" },

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -11,35 +11,35 @@ module.config.public = {
                 n = {
                     -- Marks the task under the cursor as "undone"
                     -- ^mark Task as Undone
-                    { leader .. "tu", "core.qol.todo_items.todo.task_undone" },
+                    { leader .. "tu", "core.qol.todo_items.todo.task_undone", { desc = "Undone" } },
 
                     -- Marks the task under the cursor as "pending"
                     -- ^mark Task as Pending
-                    { leader .. "tp", "core.qol.todo_items.todo.task_pending" },
+                    { leader .. "tp", "core.qol.todo_items.todo.task_pending", { desc = "Pending" } },
 
                     -- Marks the task under the cursor as "done"
                     -- ^mark Task as Done
-                    { leader .. "td", "core.qol.todo_items.todo.task_done" },
+                    { leader .. "td", "core.qol.todo_items.todo.task_done", { desc = "Done" } },
 
                     -- Marks the task under the cursor as "on_hold"
                     -- ^mark Task as on Hold
-                    { leader .. "th", "core.qol.todo_items.todo.task_on_hold" },
+                    { leader .. "th", "core.qol.todo_items.todo.task_on_hold", { desc = "On Hold" } },
 
                     -- Marks the task under the cursor as "cancelled"
                     -- ^mark Task as Cancelled
-                    { leader .. "tc", "core.qol.todo_items.todo.task_cancelled" },
+                    { leader .. "tc", "core.qol.todo_items.todo.task_cancelled", { desc = "Cancelled" } },
 
                     -- Marks the task under the cursor as "recurring"
                     -- ^mark Task as Recurring
-                    { leader .. "tr", "core.qol.todo_items.todo.task_recurring" },
+                    { leader .. "tr", "core.qol.todo_items.todo.task_recurring", { desc = "Recurring" } },
 
                     -- Marks the task under the cursor as "important"
                     -- ^mark Task as Important
-                    { leader .. "ti", "core.qol.todo_items.todo.task_important" },
+                    { leader .. "ti", "core.qol.todo_items.todo.task_important", { desc = "Important" } },
 
                     -- Marks the task under the cursor as "ambiguous"
                     -- ^mark Task as ambiguous
-                    { leader .. "ta", "core.qol.todo_items.todo.task_ambiguous" },
+                    { leader .. "ta", "core.qol.todo_items.todo.task_ambiguous", { desc = "Ambigous" } },
 
                     -- Switches the task under the cursor between a select few states
                     { "<C-Space>", "core.qol.todo_items.todo.task_cycle" },

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -316,18 +316,23 @@ module.public = {
                     for neovim_mode, keymaps in pairs(keys) do
                         -- Loop though all the keymaps in that mode
                         for _, keymap in ipairs(keymaps) do
+                            if keymap[3] and type(keymap[3]) == "table" then
+                                for extraopt, value in pairs(keymap[3]) do
+                                    opts[extraopt] = value
+                                end
+                            end
                             -- Map the keybind and keep track of it using the map() function
                             payload.map(
                                 mode,
                                 neovim_mode,
                                 keymap[1],
-                                "<cmd>Neorg keybind "
-                                    .. mode
-                                    .. " "
-                                    .. table.concat(vim.list_slice(keymap, 2), " ")
-                                    .. "<CR>",
+                                "<cmd>Neorg keybind " .. mode .. " " .. keymap[2] .. "<CR>",
                                 opts
                             )
+                            opts = {
+                                silent = true,
+                                noremap = true,
+                            }
                         end
                     end
                 end

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -316,23 +316,18 @@ module.public = {
                     for neovim_mode, keymaps in pairs(keys) do
                         -- Loop though all the keymaps in that mode
                         for _, keymap in ipairs(keymaps) do
-                            if keymap[3] and type(keymap[3]) == "table" then
-                                for extraopt, value in pairs(keymap[3]) do
-                                    opts[extraopt] = value
-                                end
-                            end
                             -- Map the keybind and keep track of it using the map() function
                             payload.map(
                                 mode,
                                 neovim_mode,
                                 keymap[1],
-                                "<cmd>Neorg keybind " .. mode .. " " .. keymap[2] .. "<CR>",
-                                opts
+                                "<cmd>Neorg keybind "
+                                    .. mode
+                                    .. " "
+                                    .. table.concat(vim.list_slice(keymap, 2), " ")
+                                    .. "<CR>",
+                                vim.tbl_deep_extend("force", opts, keymap.opts or {})
                             )
-                            opts = {
-                                silent = true,
-                                noremap = true,
-                            }
                         end
                     end
                 end


### PR DESCRIPTION
this is to support proper desc= options for which-key, not clear if this is the right place to do this or not. I also don't like setting opts = defaults in the loop but i couldn't think of another way with out changing the rest of the code. 