### PR TITLE
fix(core.summary): bugs + flexibility around incomplete metadata

### DIFF
--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -65,7 +65,7 @@ module.load = function()
                           metadata.description = nil
                         end
                         table.insert(
-                            categories[category],
+                            categories[neorg.lib.title(category)],
                             { title = tostring(metadata.title), filename = filename, description = metadata.description }
                         )
                     end
@@ -74,7 +74,7 @@ module.load = function()
                 local prefix = string.rep("*", heading_level)
 
                 for category, data in vim.spairs(categories) do
-                    table.insert(result, prefix .. " " .. neorg.lib.title(category))
+                    table.insert(result, prefix .. " " .. category)
 
                     for _, datapoint in ipairs(data) do
                         table.insert(


### PR DESCRIPTION
A few bugfixes & added flexibility, after trying to use `:Neorg generate-workspace-summary` on my workspace.

## Bugs and inconveniences

> * Currently the `metadata` strategy is making assumptions about the metadata in your doc, and failing with an error if specific key is not present.
>     * e.g. if you `:Neorg inject-metadata` and your metadata doesn't specify a `description` or `categories`, then it just errors. 
>     * If you don't have a `title`, you get nothing. 
>     * It also doesn't like numeric titles like in a journal, e.g. I had `06` for 6th May. It fails in this case too.
>
> * The generated summary always uses a **  heading regardless of what level of heading your cursor is on.
> * If you have inconsistent title casing in your metadata categories, the alphabetic ordering doesn't work (even though the categories are rendered with title case)

## Fixes

- [x] Avoid errors when category or description or title is `vim.NIL` or numeric. I made a default category 'Uncategorised' for `.norg` files without a category, and I gave a default title of `vim.fn.basename(filename)` if none was defined.
- [x] Heading is now 1 deeper than the node under cursor.
- [x] Categories are title-cased _before_ being sorted by `vim.spairs()`. 

## Results

Some example output. My cursor was over the `** Summary` heading.

`index.norg` was the only file in my workspace with a `category` (`homebase`) in the metadata, and it didn't have a `title`. Those journal entries had a numeric title like `06`, etc.

```norg
** Summary
*** Homebase
   - {:/Users/xxx/notes/work/index.norg:}[Index.norg]
*** Uncategorised
   - {:/Users/xxx/notes/work/main.norg:}[Neorg Notes]
   - {:/Users/xxx/notes/work/journal/template.norg:}[Template]
   - {:/Users/xxx/notes/work/journal/2023/05/06.norg:}[6]
   - {:/Users/xxx/notes/work/journal/2023/05/07.norg:}[7]
   - {:/Users/xxx/notes/work/journal/2023/05/08.norg:}[8]
   - {:/Users/xxx/notes/work/journal/2023/05/18.norg:}[18]
```
