### PR TITLE
fix(summary)!: fix norg links, use first heading as title if found

### DIFF
--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -40,15 +40,52 @@ module.load = function()
     local ts = module.required["core.integrations.treesitter"]
 
     module.config.public.strategy = neorg.lib.match(module.config.public.strategy)({
-        metadata = function()
+        default = function()
+            -- declare query on load so that it's parsed once, on first use
+            local heading_query
+
+            local get_first_heading_title = function(bufnr)
+                local document_root = ts.get_document_root(bufnr)
+                if not heading_query then
+                  -- allow second level headings, just in case
+                  local heading_query_string = [[
+                         [
+                             (heading1
+                                 title: (paragraph_segment) @next-segment
+                             )
+                             (heading2
+                                 title: (paragraph_segment) @next-segment
+                             )
+                         ]
+                     ]]
+                  heading_query = neorg.utils.ts_parse_query("norg", heading_query_string)
+                end
+                  -- search up to 20 lines (a doc could potentially have metadata without metadata.title)
+                for _, heading in heading_query:iter_captures(document_root, bufnr, 1, 20) do
+                    local start_line, _ = heading:start()
+                    local lines = vim.api.nvim_buf_get_lines(bufnr, start_line, start_line+1, false)
+                    if #lines > 0 then
+                      local title = lines[1]:gsub("^%s*%*+%s*", "") -- strip out '*' prefix (handle '* title', ' **title', etc)
+                      if title ~= "" then -- exclude an empty heading like `*` (although the query should have excluded)
+                        return title
+                      end
+                    end
+                end
+            end
+
             return function(files, heading_level)
                 local categories = vim.defaulttable()
 
                 neorg.utils.read_files(files, function(bufnr, filename)
                     local metadata = ts.get_document_metadata(bufnr)
 
-                    if not metadata or vim.tbl_isempty(metadata) then
-                        return
+                    if not metadata then
+                        metadata = {}
+                    end
+
+                    local norgname = filename:match("(.+)%.norg$") -- strip extension for link destinations
+                    if not norgname then
+                      norgname  = filename
                     end
 
                     -- normalise categories into a list. Could be vim.NIL, a number, a string or a list ...
@@ -59,7 +96,10 @@ module.load = function()
                     end
                     for _, category in ipairs(metadata.categories) do
                         if not metadata.title then
-                            metadata.title = vim.fs.basename(filename)
+                            metadata.title = get_first_heading_title(bufnr)
+                            if not metadata.title then
+                              metadata.title = vim.fs.basename(norgname)
+                            end
                         end
                         if metadata.description == vim.NIL then
                             metadata.description = nil
@@ -68,7 +108,7 @@ module.load = function()
                             categories[neorg.lib.title(category)],
                             {
                                 title = tostring(metadata.title),
-                                filename = filename,
+                                norgname = norgname,
                                 description = metadata.description,
                             }
                         )
@@ -83,7 +123,7 @@ module.load = function()
                     for _, datapoint in ipairs(data) do
                         table.insert(
                             result,
-                            table.concat({ "   - {:", datapoint.filename, ":}[", neorg.lib.title(datapoint.title), "]" })
+                            table.concat({ "   - {:", datapoint.norgname, ":}[", neorg.lib.title(datapoint.title), "]" })
                                 .. (datapoint.description and (table.concat({ " - ", datapoint.description })) or "")
                         )
                     end
@@ -102,12 +142,10 @@ module.config.public = {
     -- The strategy to use to generate a summary.
     --
     -- Possible options are:
-    -- - "metadata" - read the metadata to categorize and annotate files. Files
-    --   without metadata will be ignored.
-    -- - "headings" (UNIMPLEMENTED) - read the top level heading and use that as the title.
-    --   files in subdirectories are treated as subheadings.
+    -- - "default" - read the metadata to categorize and annotate files. Files
+    --   without metadata will use the top level heading as the title. If no headings are present, the filename will be used.
     ---@type string|fun(files: string[], heading_level: number?): string[]?
-    strategy = "metadata",
+    strategy = "default",
 }
 
 module.public = {}


### PR DESCRIPTION
Fixes and improvements following on from https://github.com/nvim-neorg/neorg/pull/927 . I noticed a bug in the link destinations, so I went ahead and did some of what @vhyrro suggested.

- [x] Fix norg links ( `{:index.norg:}[My Index]` => `{:index:}[My Index]` ) - lol, funny I didn't notice this last time.
- [x] Links now use paths relative to the workspace root. `{:index:}` rather than `{:/Users/me/notes/work/index:}` . (It assumes you're in the workspace root, which _seems_ OK?)
- [x] When there's no `metadata.title`, it queries TS to find the first heading text. The TS query allows heading1 or heading2, and it checks matches up to 20 lines into the doc (e.g. if there's metadata but no title). IDK if this is right or if the query could be improved, but it seems like an OK starting point.
- [x] When there's no metadata or headings (e.g. an empty file), then the title becomes `Index` rather than `Index.norg`.
- [x] The summary now includes files which have no metadata (because we can present something useful now).
- [x] Breaking change - rename the strategy `metadata` to `default` because now it uses a mixture of metadata and headings/filenames now.

My summary looks like this now (as before, I only have scraps of document metadata, and some files are completely empty):

```norg
** My Heading Which My Cursor Was On
*** Homebase
   - {:index:}[Work Notes]
*** Uncategorised
   - {:help:}[Help]
   - {:inbox:}[Inbox]
   - {:main:}[Neorg Notes]
   - {:neorg:}[Neorg Adventures]
   - {:nostuff:}[Nostuff]
   - {:projects:}[Projects - Medium Term]
   - {:journal/index:}[2023]
   - {:journal/template:}[Template]
   - {:journal/2023/05/04:}[04]
   - {:journal/2023/05/05:}[05 Tues]
   - {:journal/2023/05/06:}[6]
   - {:journal/2023/05/07:}[7]
   - {:journal/2023/05/08:}[8]
   - {:journal/2023/05/18:}[18]
```
