### PR TITLE
fix(docgen): inline `esupports.metagen` template function definitions

### DIFF
--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -41,16 +41,17 @@ module.config.public = {
         -- The title field generates a title for the file based on the filename.
         {
             "title",
-            function()
-                return vim.fn.expand("%:p:t:r")
-            end,
+            function() return vim.fn.expand("%:p:t:r") end,
         },
 
         -- The description field is always kept empty for the user to fill in.
         { "description", "" },
 
         -- The authors field is autopopulated by querying the current user's system username.
-        { "authors", require("neorg.external.helpers").get_username },
+        { 
+            "authors",
+            function() return require("neorg.external.helpers").get_username() end,
+        },
 
         -- The categories field is always kept empty for the user to fill in.
         { "categories", "" },
@@ -58,23 +59,22 @@ module.config.public = {
         -- The created field is populated with the current date as returned by `os.date`.
         {
             "created",
-            function()
-                return os.date("%Y-%m-%d")
-            end,
+            function() return os.date("%Y-%m-%d") end,
         },
 
         -- When creating fresh, new metadata, the updated field is populated the same way
         -- as the `created` date.
         {
             "updated",
-            function()
-                return os.date("%Y-%m-%d")
-            end,
+            function() return os.date("%Y-%m-%d") end,
         },
 
         -- The version field determines which Norg version was used when
         -- the file was created.
-        { "version", require("neorg.config").norg_version },
+        {
+            "version",
+            function() return require("neorg.config").norg_version end
+        },
     },
 }
 


### PR DESCRIPTION
So they show up in the wiki.

## Current state
Here in the [wiki](https://github.com/nvim-neorg/neorg/wiki/Metagen) for the default implementation in the template it only show the `function()` part:
![screenshot_23-06-14_18:50:40](https://github.com/nvim-neorg/neorg/assets/25589715/b9bbaca8-77a4-49c2-b465-25f738bc06eb)
That it is only saying `function()` is just confusing.

## Desired state
I would like to see the full function definition, so I can copy over the ones that I like and adjust what I don't like in my config:
![screenshot_23-06-14_19:03:18](https://github.com/nvim-neorg/neorg/assets/25589715/f21a08ae-f44c-424d-90e0-af45dc01b67f)

