### PR TITLE
fix(calendar): give calendar enough space to render

### DIFF
--- a/lua/neorg/modules/core/ui/calendar/module.lua
+++ b/lua/neorg/modules/core/ui/calendar/module.lua
@@ -62,10 +62,11 @@ module.private = {
     end,
 
     open_window = function(options)
+        local MIN_HEIGHT = 14
+
         local buffer, window = module.required["core.ui"].create_split(
             "calendar-" .. tostring(os.clock()):gsub("%.", "-"),
-            {},
-            options.height or math.floor(vim.opt.lines:get() * 0.3)
+            {}, options.height or MIN_HEIGHT + (options.padding or 0)
         )
 
         vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {


### PR DESCRIPTION
This commit changes the logic for creating the calendar window to always request at least the minimum size necessary to render the full calendar. Previously, a window size could be created even though it was too small to render the calendar.