### PR TITLE
feat(esupports.hop): support `os_open_link` for WSL

### DIFF
--- a/lua/neorg/config.lua
+++ b/lua/neorg/config.lua
@@ -68,6 +68,14 @@ neorg.configuration.os_info = (function()
     elseif os == "darwin" then
         return "mac"
     elseif os == "linux" then
+        local f = io.open('/proc/version', 'r')
+        if f ~= nil then
+            local version = f:read('*all')
+            f:close()
+            if version:find('microsoft') then
+                return "wsl"
+            end
+        end
         return "linux"
     end
 end)()

--- a/lua/neorg/external/helpers.lua
+++ b/lua/neorg/external/helpers.lua
@@ -25,7 +25,7 @@ neorg.utils = {
             return ""
         end
 
-        if current_os == "linux" or current_os == "mac" then
+        if current_os == "linux" or current_os == "mac" or current_os == "wsl" then
             return os.getenv("USER") or ""
         elseif current_os == "windows" then
             return os.getenv("username") or ""

--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -87,6 +87,8 @@ module.public = {
                     o.command = "xdg-open"
                 elseif neorg.configuration.os_info == "mac" then
                     o.command = "open"
+                elseif neorg.configuration.os_info == "wsl" then
+                    o.command = "explorer.exe"
                 end
                 o.args = { link_location }
             end


### PR DESCRIPTION
## Environment

Use Neovim with this plugin in Windows Subsystem for Linux (WSL)

## Steps

1. Create a hyperlink in `.norg` file , e.g.  "{https://github.com}[GitHub]"
2. Move cursor to the hyperlink
3. Press Key **[Enter]**

## Current phenomenon (without this PR)

An error occured:

```
stack traceback:
	[C]: in function 'error'
	...nvim/site/pack/lazy/opt/plenary.nvim/lua/plenary/job.lua:106: in function 'new'
	...pt/neorg/lua/neorg/modules/core/esupports/hop/module.lua:94: in function 'os_open_link'
	...pt/neorg/lua/neorg/modules/core/esupports/hop/module.lua:122: in function <...pt/neorg/lua/neorg/modules/core/esupports/hop/module.lua:121>
```

## With this PR

Link can be opened with Windows default browser successfully.