### PR TITLE
fix(ui): remove possible ui noise caused by user's opts

### DIFF
--- a/lua/neorg/modules/core/ui/module.lua
+++ b/lua/neorg/modules/core/ui/module.lua
@@ -124,6 +124,8 @@ module.public = {
         vim.api.nvim_buf_set_name(buf, bufname)
         vim.api.nvim_win_set_buf(0, buf)
 
+        vim.api.nvim_win_set_option(0, "list", false)
+        vim.api.nvim_win_set_option(0, "colorcolumn", "")
         vim.api.nvim_win_set_option(0, "number", false)
         vim.api.nvim_win_set_option(0, "relativenumber", false)
         vim.api.nvim_win_set_option(0, "signcolumn", "no")


### PR DESCRIPTION
Hello everyone! Thanks for great plugin. I tried to fix this in config by using autocmds, but couldn't make it work, so I decided to make this PR, I believe this is sensible default for UI window

**Before:**
<img width="1727" alt="image" src="https://github.com/nvim-neorg/neorg/assets/67468725/0c209f81-850e-4629-a03a-7875ec13a7f1">

**After:**
<img width="1728" alt="image" src="https://github.com/nvim-neorg/neorg/assets/67468725/e5dbaa7f-774d-4b8c-b058-3ae3b123b8d7">
