### PR TITLE
feat(summary) - replace existing summary, use a ranged tag

### DIFF
--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -183,10 +183,13 @@ module.private = {
             local ranged_tag = node:parent()
             for child in ranged_tag:iter_children() do
                 if child:type() == "tag_parameters" then
-                    local _, param = child:iter_children()
-                    local text = module.required["core.integrations.treesitter"].get_node_text(param)
-                    if text == "summary" then
-                        return ranged_tag
+                    local param = child:child(0)
+                    if param ~= nil then
+                        --for param in child:iter_children() do
+                        local text = module.required["core.integrations.treesitter"].get_node_text(param)
+                        if text == "summary" then
+                            return ranged_tag
+                        end
                     end
                 end
             end

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -212,15 +212,13 @@ module.on_event = function(event)
         -- find * replace an existing ranged tag
         local node_line_below = ts.get_first_node_on_line(buffer, start_line)
         if node_line_below and node_line_below:type() == "_paragraph_break" then
-          -- allow for a line break between heading and tag
-          node_line_below = ts.get_first_node_on_line(buffer, start_line+1)
+            -- allow for a line break between heading and tag. Go down one more line.
+            node_line_below = ts.get_first_node_on_line(buffer, start_line+1)
         end
         if node_line_below and node_line_below:type() == "ranged_tag" then
             start_line, _ = node_line_below:start()
             end_line, _ = node_line_below:end_()
             end_line = end_line + 1
-        else
-          neorg.utils.notify(node_line_below:type())
         end
 
         vim.api.nvim_buf_set_lines(buffer, start_line, end_line, true, generated)

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -209,7 +209,7 @@ module.on_event = function(event)
 
         local start_line = event.cursor_position[1]
         local end_line = start_line
-        -- find * replace an existing ranged tag
+        -- find & replace an existing ranged tag below this heading
         local node_line_below = ts.get_first_node_on_line(buffer, start_line)
         if node_line_below and node_line_below:type() == "_paragraph_break" then
             -- allow for a line break between heading and tag. Go down one more line.


### PR DESCRIPTION
## Problem Definition

> When I use `:Neorg generate-workspace-summary`, I expect it to replace the existing summary (which I generated previously). 
> Instead, the `summary` module inserts another summary above the previous one. 

## Why is this an issue?

1. Manually deleting the old summary is annoying and fiddly.
2. It seems risky to try to programmatically replace the existing summary format (there'd be a risk of deleting subsequent content, because there is no 'end' marker).

## Challenges

 * The current implementation does not put the summary inside any ranged element. 
   * It uses one heading per category, each containing a list item & a link for each page. 
   * In theory it might be hard to differentiate between end of the summary and the start of another heading. 
 * You can't [currently] just wrap the existing summary format inside a ranged tag
   * Treesitter complains as soon as you put a `* Heading` or a ` - List item` inside of a ranged tag. I see an ERROR in `:InspectTree`.
   * I also looked at some other ranged elements like `^^`. Same result. 

## Proposal

This approach throws out the old format of the workspace summary, but I think the result is OK. It's a bit of a tradeoff, but I think the benefit of the container (the ranged tag) outweighs the drawbacks of changing the format.

1. Wrap the existing summary in a ranged tag. I chose `|group` because it seems the closest match of the four types. Perhaps we could call it `|summary workspace` in future?
2.  Use a strong carryover tag for each category. `#cat Groceries`
3.  Use a new line for each link. No `- list` items because that would break the parser.
4.  When calling `:Neorg generate-workspace-summary`, the module checks for an existing ranged tag below the current heading. If it exists, replace it with the new summary.

Here's an example of what it produces:

```norg
** My Workspace 
|group summary
  #cat Work
   {:$/index:}[Work Notes]

  #cat Thing Thing2
   {:$/summary:}[Summary]

  #cat Uncategorised
   {:$/inbox:}[Inbox]
   {:$/gha:}[Experiment With Github Action]
   {:$/neorg:}[Neorg Adventures]
   {:$/integration:}[Integration Next Steps]
   {:$/projects:}[Projects - Medium Term]
   {:$/webhooks:}[Webhooks - Next Steps]
|end
```

## Some open points

 * Is the format OK?
   * _Should_ it be possible to add headings / list items inside of a standard ranged tag? Did I find a bug, or is it a feature? Even if it is a bug, is the proposal OK anyway?
   * Is `|group summary` a good choice of ranged tag? Any suggestions?
   * Is `#cat CategoryName` an appropriate choice of carryover tag? 
 * This could be taken further - the module could even search the whole buffer for an existing `|group summary` node. This would make the whole 'refresh this view' more easy to use. No need to fuss over the any more.
 * Maybe use Concealer to hide the range tags & make the summary look prettier?

Ta.
