### PR TITLE
feat: delimit tangled code blocks with headings

### DIFF
--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -280,7 +280,6 @@ module.public = {
                     end
 
                     if file_to_tangle_to then
-
                         -- get current heading
                         local heading_string
                         local heading = module.required["core.integrations.treesitter"].find_parent(node, "heading%d+")
@@ -291,7 +290,6 @@ module.public = {
 
                         -- don't reuse the same header more than once
                         if heading_string and previous_headings[language] ~= heading then
-
                             -- Get commentstring from vim scratch buffer
                             if not commentstrings[language] then
                                 local cur_buf = vim.api.nvim_get_current_buf()
@@ -300,13 +298,13 @@ module.public = {
                                 vim.bo.filetype = language
                                 commentstrings[language] = vim.bo.commentstring
                                 vim.api.nvim_set_current_buf(cur_buf)
-                                vim.api.nvim_buf_delete(tmp_buf, {force = true})
+                                vim.api.nvim_buf_delete(tmp_buf, { force = true })
                             end
 
                             if commentstrings[language] ~= "" then
-                              table.insert(content, 1, "")
-                              table.insert(content, 1, commentstrings[language]:format(heading_string))
-                              previous_headings[language] = heading
+                                table.insert(content, 1, "")
+                                table.insert(content, 1, commentstrings[language]:format(heading_string))
+                                previous_headings[language] = heading
                             end
                         end
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -76,15 +76,15 @@ tangle: {
 
 The `language` option determines which filetype should go into which file.
 It's a simple language-filepath mapping, but it's especially useful when the output file's language type cannot be inferred from the name or shebang.
-It is also possible to use the name `_` as a catch all to direct output to all files not listed.
+It is also possible to use the name `_` as a catch all to direct output for all files not otherwise listed.
 
-The `delimiter` option determines how to delimit codeblocks that exports to the same file.
+The `delimiter` option determines how to delimit code blocks that exports to the same file.
 The following alternatives are allowed:
 
 * `heading` -- Try to determine the filetype of the code block and insert the current heading as a comment as a delimiter.
   If filetype detection fails, `newline` will be used instead.
 * `newline` -- Use an extra newline between blocks.
-* `none` -- Do not add delimiter. This implies that the code blocks are inserted into the the tangle target as-is.
+* `none` -- Do not add delimiter. This implies that the code blocks are inserted into the tangle target as-is.
 
 The `scope` option is discussed below.
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -282,37 +282,37 @@ module.public = {
                     if file_to_tangle_to then
                         if tangles[file_to_tangle_to] then
                             table.insert(content, 1, "")
-
-                            -- get current heading
-                            local heading_string
-                            local heading = module.required["core.integrations.treesitter"].find_parent(node:parent(), "heading%d+")
-                            if heading and heading:named_child(1) then
-                                local srow, scol, erow, ecol = heading:named_child(1):range()
-                                heading_string = vim.api.nvim_buf_get_text(0, srow, scol, erow, ecol, {})[1]
-                            end
-
-                            -- don't reuse the same header more than once
-                            if heading_string and previous_headings[language] ~= heading then
-
-                                -- Get commentstring from vim scratch buffer
-                                if not commentstrings[language] then
-                                    local cur_buf = vim.api.nvim_get_current_buf()
-                                    local tmp_buf = vim.api.nvim_create_buf(false, true)
-                                    vim.api.nvim_set_current_buf(tmp_buf)
-                                    vim.bo.filetype = language
-                                    commentstrings[language] = vim.bo.commentstring
-                                    vim.api.nvim_set_current_buf(cur_buf)
-                                    vim.api.nvim_buf_delete(tmp_buf, {force = true})
-                                end
-
-                                if commentstrings[language] ~= "" then
-                                  table.insert(content, 1, commentstrings[language]:format(heading_string))
-                                  table.insert(content, 1, "")
-                                  previous_headings[language] = heading
-                                end
-                            end
                         else
                             tangles[file_to_tangle_to] = {}
+                        end
+
+                        -- get current heading
+                        local heading_string
+                        local heading = module.required["core.integrations.treesitter"].find_parent(node:parent(), "heading%d+")
+                        if heading and heading:named_child(1) then
+                            local srow, scol, erow, ecol = heading:named_child(1):range()
+                            heading_string = vim.api.nvim_buf_get_text(0, srow, scol, erow, ecol, {})[1]
+                        end
+
+                        -- don't reuse the same header more than once
+                        if heading_string and previous_headings[language] ~= heading then
+
+                            -- Get commentstring from vim scratch buffer
+                            if not commentstrings[language] then
+                                local cur_buf = vim.api.nvim_get_current_buf()
+                                local tmp_buf = vim.api.nvim_create_buf(false, true)
+                                vim.api.nvim_set_current_buf(tmp_buf)
+                                vim.bo.filetype = language
+                                commentstrings[language] = vim.bo.commentstring
+                                vim.api.nvim_set_current_buf(cur_buf)
+                                vim.api.nvim_buf_delete(tmp_buf, {force = true})
+                            end
+
+                            if commentstrings[language] ~= "" then
+                              table.insert(content, 1, commentstrings[language]:format(heading_string))
+                              table.insert(content, 1, "")
+                              previous_headings[language] = heading
+                            end
                         end
 
                         vim.list_extend(tangles[file_to_tangle_to], content)

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -212,7 +212,7 @@ module.public = {
         local options = {
             languages = tangle_settings.languages or tangle_settings,
             scope = tangle_settings.scope or "all", -- "all" | "tagged" | "main"
-            delimiter = tangle_settings.delimiter or "heading", -- "newline" | "heading" | "none"
+            delimiter = tangle_settings.delimiter or "newline", -- "newline" | "heading" | "none"
         }
         if vim.tbl_islist(options.languages) then
             options.filenames_only = options.languages
@@ -300,8 +300,6 @@ module.public = {
                                         break
                                     end
                                 end
-                            elseif declared_filetype then
-                                file_to_tangle_to = options.languages[declared_filetype]
                             end
                             if not file_to_tangle_to then
                                 file_to_tangle_to = options.languages["_"]

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -288,7 +288,7 @@ module.public = {
 
                         -- get current heading
                         local heading_string
-                        local heading = module.required["core.integrations.treesitter"].find_parent(node:parent(), "heading%d+")
+                        local heading = module.required["core.integrations.treesitter"].find_parent(node, "heading%d+")
                         if heading and heading:named_child(1) then
                             local srow, scol, erow, ecol = heading:named_child(1):range()
                             heading_string = vim.api.nvim_buf_get_text(0, srow, scol, erow, ecol, {})[1]

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -217,7 +217,7 @@ module.public = {
         if vim.tbl_islist(options.languages) then
             options.filenames_only = options.languages
             options.languages = {}
-        elseif type(options.languages) == string then
+        elseif type(options.languages) == "string" then
             options.languages = {_ = options.languages}
         end
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -280,11 +280,6 @@ module.public = {
                     end
 
                     if file_to_tangle_to then
-                        if tangles[file_to_tangle_to] then
-                            table.insert(content, 1, "")
-                        else
-                            tangles[file_to_tangle_to] = {}
-                        end
 
                         -- get current heading
                         local heading_string
@@ -309,10 +304,16 @@ module.public = {
                             end
 
                             if commentstrings[language] ~= "" then
-                              table.insert(content, 1, commentstrings[language]:format(heading_string))
                               table.insert(content, 1, "")
+                              table.insert(content, 1, commentstrings[language]:format(heading_string))
                               previous_headings[language] = heading
                             end
+                        end
+
+                        if not tangles[file_to_tangle_to] then
+                            tangles[file_to_tangle_to] = {}
+                        else
+                            table.insert(content, 1, "")
                         end
 
                         vim.list_extend(tangles[file_to_tangle_to], content)

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -76,6 +76,7 @@ tangle: {
 
 The `language` option determines which filetype should go into which file.
 It's a simple language-filepath mapping, but it's especially useful when the output file's language type cannot be inferred from the name or shebang.
+It is also possible to use the name `_` as a catch all to direct output to all files not listed.
 
 The `delimiter` option determines how to delimit codeblocks that exports to the same file.
 The following alternatives are allowed:


### PR DESCRIPTION
An extention to the idea discussed in #955 .

Add heading text as delimiter as a comment if:

1. There is in-fact a current heading. Headings are optional.
2. Current heading hasn't been used as a delimiter before.
3. `commentstring` is available for the filetype in question.

Otherwise just use a newline.

That last one (3) requires making a temporary scratch buffer to trigger ftplugin, which retrieves `commentstring` for all supported filetypes in vim.