### PR TITLE
fix: replace `get_filetype` with `vim.filetype.match`

### DIFF
--- a/lua/neorg/external/helpers.lua
+++ b/lua/neorg/external/helpers.lua
@@ -142,22 +142,6 @@ neorg.utils = {
 
         return ret
     end,
-    get_filetype = function(file, force_filetype)
-        local filetype = force_filetype
-
-        -- Getting a filetype properly is... difficult
-        -- This is why we leverage Neovim instead.
-        -- We create a dummy buffer with the filepath the user wanted to export to
-        -- and query the filetype from there.
-        if not filetype then
-            local dummy_buffer = vim.uri_to_bufnr(vim.uri_from_fname(file))
-            vim.fn.bufload(dummy_buffer)
-            filetype = vim.api.nvim_buf_get_option(dummy_buffer, "filetype")
-            vim.api.nvim_buf_delete(dummy_buffer, { force = true })
-        end
-
-        return filetype
-    end,
 
     --- Custom neorg notifications. Wrapper around vim.notify
     ---@param msg string message to send

--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -219,7 +219,7 @@ module.on_event = function(event)
         -- Example: Neorg export to-file my-custom-file markdown
 
         local filepath = vim.fn.expand(event.content[1])
-        local filetype = event.content[2] or vim.filetype.match{ filename=filepath }
+        local filetype = event.content[2] or vim.filetype.match({ filename = filepath })
         local exported = module.public.export(event.buffer, filetype)
 
         vim.loop.fs_open(filepath, "w", 438, function(err, fd)

--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -69,7 +69,7 @@ module.config.public = {
 
 module.public = {
     --- Returns a module that can handle conversion from `.norg` to the target filetype
-    ---@param ftype string #The filetype to export to (as returned by e.g. `get_filetype()`)
+    ---@param ftype string #The filetype to export to
     ---@return table?,table? #The export module and its configuration, else nil
     get_converter = function(ftype)
         if not neorg.modules.is_module_loaded("core.export." .. ftype) then
@@ -219,7 +219,7 @@ module.on_event = function(event)
         -- Example: Neorg export to-file my-custom-file markdown
 
         local filepath = vim.fn.expand(event.content[1])
-        local filetype = neorg.utils.get_filetype(filepath, event.content[2])
+        local filetype = event.content[2] or vim.filetype.match{ filename=filepath }
         local exported = module.public.export(event.buffer, filetype)
 
         vim.loop.fs_open(filepath, "w", 438, function(err, fd)

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -200,7 +200,7 @@ module.public = {
         if type(parsed_document_metadata.tangle) == "table" then
             if vim.tbl_islist(parsed_document_metadata.tangle) then
                 for _, file in ipairs(parsed_document_metadata.tangle) do
-                    options.languages[neorg.utils.get_filetype(file)] = file
+                    options.languages[vim.filetype.match{filename = file}] = file
                 end
             elseif parsed_document_metadata.tangle.languages then
                 for language, file in pairs(parsed_document_metadata.tangle.languages) do
@@ -208,7 +208,7 @@ module.public = {
                 end
             end
         elseif type(parsed_document_metadata.tangle) == "string" then
-            options.languages[neorg.utils.get_filetype(parsed_document_metadata.tangle)] =
+            options.languages[vim.filetype.match{filename = parsed_document_metadata.tangle}] =
                 parsed_document_metadata.tangle
         end
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -200,7 +200,7 @@ module.public = {
         if type(parsed_document_metadata.tangle) == "table" then
             if vim.tbl_islist(parsed_document_metadata.tangle) then
                 for _, file in ipairs(parsed_document_metadata.tangle) do
-                    options.languages[vim.filetype.match{filename = file}] = file
+                    options.languages[vim.filetype.match({ filename = file })] = file
                 end
             elseif parsed_document_metadata.tangle.languages then
                 for language, file in pairs(parsed_document_metadata.tangle.languages) do
@@ -208,7 +208,7 @@ module.public = {
                 end
             end
         elseif type(parsed_document_metadata.tangle) == "string" then
-            options.languages[vim.filetype.match{filename = parsed_document_metadata.tangle}] =
+            options.languages[vim.filetype.match({ filename = parsed_document_metadata.tangle })] =
                 parsed_document_metadata.tangle
         end
 

--- a/lua/neorg/modules/core/ui/calendar/module.lua
+++ b/lua/neorg/modules/core/ui/calendar/module.lua
@@ -66,7 +66,8 @@ module.private = {
 
         local buffer, window = module.required["core.ui"].create_split(
             "calendar-" .. tostring(os.clock()):gsub("%.", "-"),
-            {}, options.height or MIN_HEIGHT + (options.padding or 0)
+            {},
+            options.height or MIN_HEIGHT + (options.padding or 0)
         )
 
         vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {

--- a/lua/neorg/modules/core/ui/calendar/views/monthly.lua
+++ b/lua/neorg/modules/core/ui/calendar/views/monthly.lua
@@ -356,15 +356,21 @@ module.private = {
                     }, "center"),
 
                     -- Help text at the bottom left of the screen
-                    help_and_custom_input = module.private.set_decorational_extmark(ui_info, ui_info.height - 1, 0, 0, {
-                        { "?", "@character" },
-                        { " - " },
-                        { "help", "@text.strong" },
-                        { "    " },
-                        { "i", "@character" },
-                        { " - " },
-                        { "custom input", "@text.strong" },
-                    }),
+                    help_and_custom_input = module.private.set_decorational_extmark(
+                        ui_info,
+                        ui_info.height - 1,
+                        0,
+                        0,
+                        {
+                            { "?", "@character" },
+                            { " - " },
+                            { "help", "@text.strong" },
+                            { "    " },
+                            { "i", "@character" },
+                            { " - " },
+                            { "custom input", "@text.strong" },
+                        }
+                    ),
 
                     -- The current view (bottom right of the screen)
                     current_view = module.private.set_decorational_extmark(


### PR DESCRIPTION
`utils.get_filetype` doesn't seem to work in autocmd like `BufWritePre` and `BufWritePost`, which is a real problem if you like to set up auto-tangle.

Fortunatly, neovim 0.8 introduce `vim.filetype.match` that does the same natively without issues.

Since the complexity of `get_filetype` has become trivial, I've deprecated the function.