### PR TITLE
fix(journal): Remove condition from 'toc' subcommand (fixes #597)

### DIFF
--- a/lua/neorg/modules/core/journal/module.lua
+++ b/lua/neorg/modules/core/journal/module.lua
@@ -449,7 +449,6 @@ module.load = function()
                 toc = {
                     args = 1,
                     name = "journal.toc",
-                    condition = "norg",
                     subcommands = {
                         open = { args = 0, name = "journal.toc.open" },
                         update = { args = 0, name = "journal.toc.update" },


### PR DESCRIPTION
Fixes #597.

```
Problem:    Cannot open the journal TOC from outside a norg file.
Solution:   Remove command condition from the 'toc' subcommand.
```

This condition seemed completely arbitrary to me. Is there any reason that it exists that I'm unaware of?
