### PR TITLE
fix(concealer,indent): "require'neorg'" missing in v:lua call

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -1252,7 +1252,11 @@ local function handle_init_event(event)
         }
         vim.api.nvim_set_option_value("foldmethod", "expr", opts)
         vim.api.nvim_set_option_value("foldexpr", "nvim_treesitter#foldexpr()", opts)
-        vim.api.nvim_set_option_value("foldtext", "v:lua.modules.get_module('core.concealer').foldtext()", opts)
+        vim.api.nvim_set_option_value(
+            "foldtext",
+            "v:lua.require'neorg'.modules.get_module('core.concealer').foldtext()",
+            opts
+        )
     end
 end
 

--- a/lua/neorg/modules/core/esupports/indent/module.lua
+++ b/lua/neorg/modules/core/esupports/indent/module.lua
@@ -310,7 +310,7 @@ module.on_event = function(event)
         vim.api.nvim_buf_set_option(
             event.buffer,
             "indentexpr",
-            ("v:lua.modules.get_module('core.esupports.indent').indentexpr(%d)"):format(event.buffer)
+            ("v:lua.require'neorg'.modules.get_module('core.esupports.indent').indentexpr(%d)"):format(event.buffer)
         )
 
         local indentkeys = "o,O,*<M-o>,*<M-O>"


### PR DESCRIPTION
I noticed that the indentation wasn't anymore after 5706f1efdcf55f273de8f52deeb35375a303be72. The problem is that the `v:lua` call for the `indentexpr` tries to access `modules` which is not global. It has to be accessed through `v:lua.require'neorg'`. I grepped for other `v:lua` calls and found the same problem for the `foldtext` option.