### PR TITLE
fix(summary): escape ws_root special characters

### DIFF
--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -89,7 +89,8 @@ module.load = function()
                     if not norgname then
                         norgname = filename
                     end
-                    norgname = norgname:gsub("^" .. ws_root, "")
+                    local escaped_ws_root = ws_root:gsub("([%(%)%.%%%+%-%*%?%[%^%$%]])", "%%%1")
+                    norgname = norgname:gsub("^" .. escaped_ws_root, "")
 
                     -- normalise categories into a list. Could be vim.NIL, a number, a string or a list ...
                     if not metadata.categories or metadata.categories == vim.NIL then

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -90,7 +90,7 @@ module.load = function()
                         norgname = filename
                     end
                     local escaped_ws_root = ws_root:gsub("([%(%)%.%%%+%-%*%?%[%^%$%]])", "%%%1")
-                    norgname = norgname:gsub("^" .. escaped_ws_root, "")
+                    norgname = string.sub(norgname, string.len(ws_root) + 1)
 
                     -- normalise categories into a list. Could be vim.NIL, a number, a string or a list ...
                     if not metadata.categories or metadata.categories == vim.NIL then


### PR DESCRIPTION
   hey there :)  

   i was just trying to debug the links in the summary module not being generated properly.
   the issue is that the links are generated as ones relative to current workspace root
   ( the format of `:$/path/from/current/workspace:`).
   however the actuals paths post gsub remain full paths.
   for debugging i modified the module.lua like so: 
   ``` lua
   local norgname = filename:match("(.+)%.norg$") -- strip extension for link destinations
   vim.print("looking at file: " .. filename)
   if not norgname then
       -- NOTE: either here
       vim.print("DEBUG: treated it as a non norg file")
       norgname = filename
   end
   -- NOTE: or here
   norgname = norgname:gsub("^" .. ws_root, "")
   vim.print("post gsub: " .. norgname )
   ```
   and that gave me this:
   
```
   looking at file: /home/cherry-cat/Notes/General/index.norg
   post gsub: /home/cherry-cat/Notes/General/index
   looking at file: /home/cherry-cat/Notes/General/coding/debugging_neorg_auto_cats.norg
   post gsub: /home/cherry-cat/Notes/General/coding/debugging_neorg_auto_cats
   looking at file: /home/cherry-cat/Notes/General/coding/debugging_neorg_telescope.norg
   post gsub: /home/cherry-cat/Notes/General/coding/debugging_neorg_telescope
   looking at file: /home/cherry-cat/Notes/General/coding/debugging_telescope_cc_dressing.norg
   post gsub: /home/cherry-cat/Notes/General/coding/debugging_telescope_cc_dressing
   looking at file: /home/cherry-cat/Notes/General/coding/factory_pattern.norg
   post gsub: /home/cherry-cat/Notes/General/coding/factory_pattern
```
   
and so on for every file. \ 
with ws_root being: `/home/cherry-cat/Notes/General` \ 

   i figured out that the issue lies in the special character 
   in my user name not being escaped (._.)

   so i added this bit here before the norgname
   ``` lua
   local escaped_ws_root = ws_root:gsub("([%(%)%.%%%+%-%*%?%[%^%$%]])", "%%%1")
   norgname = string.gsub(norgname,"^" .. escaped_ws_root, "")
   ```

i am legit the worst at regex. and idk if these characters can even be part of a path so probably it's good if someone reads this regex.

sorry also for not opening an issue i guess. i thought maybe this is ok because its just 2 lines that are changed pretty straight forwardly. 

best regards :wave: