### PR TITLE
fix(concealer): more precise anticonceal feature detection

### DIFF
--- a/lua/neorg/core/utils.lua
+++ b/lua/neorg/core/utils.lua
@@ -104,7 +104,10 @@ end
 ---@param patch number #The patch number (in case you need it)
 ---@return boolean #Whether Neovim is running at the same or a higher version than the one given
 function utils.is_minimum_version(major, minor, patch)
-    return major <= version.major and minor <= version.minor and patch <= version.patch
+    if major ~= version.major then return major < version.major end
+    if minor ~= version.minor then return minor < version.minor end
+    if patch ~= version.patch then return patch < version.patch end
+    return true
 end
 
 --- Parses a version string like "0.4.2" and provides back a table like { major = <number>, minor = <number>, patch = <number> }

--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -62,7 +62,21 @@ end
 
 --- end utils
 
-local has_anticonceal = utils.is_minimum_version(0, 10, 0)
+local has_anticonceal = (function()
+    if not utils.is_minimum_version(0, 10, 0) then
+        return false
+    end
+
+    if utils.is_minimum_version(0, 10, 1) then
+        return true
+    end
+
+    local full_version = vim.api.nvim_cmd({cmd="version"}, {output=true})
+    local _, _, sub_version = string.find(full_version, "-(%d+)[+]")
+    if not sub_version then return true end  -- no longer a dev version
+    sub_version = tonumber(sub_version)
+    return sub_version and sub_version > 575
+end)()
 
 local module = modules.create("core.concealer", {
     "preset_basic",


### PR DESCRIPTION
The previous version comparison logic seems flawed: (0,10,0) should be greater than (0,7,1), not less.

To ensure that anticonceal is available, it's [not enough](https://github.com/nvim-neorg/neorg/issues/292#issuecomment-1646543885) to only check version being 0.10.0. We must also ensure that the subversion (the number after '-') is greater than 575 or something iirc.