### PR TITLE
doc(neorg): fix min reverse indentation count from 2 to 3

### DIFF
--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -122,7 +122,7 @@ version: 0.1
       We can move this text to the fifth level again! 🤯
       ---
 
-     So using 2 or more `-` signs not followed by anything, you move *one* level backwards in the
+     So using 3 or more `-` signs not followed by anything, you move *one* level backwards in the
      indentation (we like using three characters though :p).
 
      Doing the same but with `=` characters instead all heading levels will be closed and


### PR DESCRIPTION
Hey, new neorg user here, thank you for the very cool plugin!

I couldn't figure out why reverse indentation didn't work until I realized the docs were not up to date :) Hope this saves the headache for anyone else.