### PR TITLE
fix: don't use deprecated `query.get_node_text()` call

### DIFF
--- a/lua/neorg/modules/core/queries/native/module.lua
+++ b/lua/neorg/modules/core/queries/native/module.lua
@@ -133,7 +133,7 @@ module.public = {
 
         for _, node in ipairs(nodes) do
             local temp_buf = module.public.get_temp_buf(node[2])
-            local extracted = vim.split(vim.treesitter.query.get_node_text(node[1], temp_buf), "\n")
+            local extracted = vim.split(vim.treesitter.get_node_text(node[1], temp_buf), "\n")
 
             if opts.all_lines then
                 table.insert(res, extracted)


### PR DESCRIPTION
When I entered presenter mode in Neorg, I would receive a deprecation warning about `vim.treesitter.query.get_node_text`,
along with a suggestion to replace it with `vim.treesitter.get_node_text`. This PR does exactly that and only that.