### PR TITLE
cleanup: remove `ftdetect` file as Neorg is now natively recognized by Neovim

### DIFF
--- a/ftdetect/norg.lua
+++ b/ftdetect/norg.lua
@@ -1,5 +1,0 @@
-vim.filetype.add({
-    extension = {
-        norg = "norg",
-    },
-})


### PR DESCRIPTION
This PR aims to remove `vim.filetype` logic in setup as it is already covered by the ftdetect file.

FYI: ftdetect directory is going to be deleted once Neovim v0.10 release is stable as I've added support for norg filetype in Neovim's core.