### PR TITLE
fix(`:h neorg`): make link point to correct line in specs

### DIFF
--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -145,7 +145,7 @@ version: 0.1
 ** Links
 
    For more info on links check the
-   {https://github.com/nvim-neorg/norg-specs/blob/main/1.0-specification.norg#L1336}[spec].
+   {https://github.com/nvim-neorg/norg-specs/blob/main/1.0-specification.norg#L1340}[spec].
 
 *** Link Targets
 


### PR DESCRIPTION
Just a quick documentation change to make the link on line 148 of the `:help neorg` doc point to the correct line.

Side note: I made an issue (#1091) before this PR. For future small changes like this one, should I make both the issue and PR or just the PR? Thanks!