### PR TITLE
fix: `folke/todo-comments.nvim` comments highlighting (again)

### DIFF
--- a/queries/norg/highlights.scm
+++ b/queries/norg/highlights.scm
@@ -244,6 +244,9 @@
   (superscript) @neorg.error
   (#set! priority 300))
 
+; Comments
+(inline_comment) @comment
+
 ; Conceals
 (
     [


### PR DESCRIPTION
Fixes https://github.com/nvim-neorg/neorg/issues/642

Not sure why but this was fixed with https://github.com/nvim-neorg/neorg/pull/643 and then disappeared a while ago.

Please don't break it again :pray: