### PR TITLE
feat: support dotrepeat for `promo` and `todo_items`

### DIFF
--- a/lua/neorg/core/utils.lua
+++ b/lua/neorg/core/utils.lua
@@ -170,4 +170,26 @@ function utils.read_files(files, callback)
     end
 end
 
+-- following https://gist.github.com/kylechui/a5c1258cd2d86755f97b10fc921315c3
+function utils.set_operatorfunc(f)
+    utils._neorg_operatorfunc = f
+    vim.go.operatorfunc = "v:lua.require'neorg'.utils._neorg_operatorfunc"
+end
+
+function utils.wrap_dotrepeat(event_handler)
+    return function(event)
+        utils._neorg_is_dotrepeat = false
+        utils.set_operatorfunc(function()
+            if utils._neorg_is_dotrepeat then
+                local pos = vim.fn.getpos('.')
+                event.buffer = pos[1]
+                event.cursor_position = {pos[2], pos[3]}
+            end
+            utils._neorg_is_dotrepeat = true
+            event_handler(event)
+        end)
+        vim.cmd("normal! g@l")
+    end
+end
+
 return utils

--- a/lua/neorg/modules/core/promo/module.lua
+++ b/lua/neorg/modules/core/promo/module.lua
@@ -302,7 +302,7 @@ module.public = {
     end,
 }
 
-module.on_event = function(event)
+module.on_event = neorg.utils.wrap_dotrepeat(function(event)
     local row = event.cursor_position[1] - 1
 
     if event.split_type[1] ~= "core.keybinds" then
@@ -348,7 +348,7 @@ module.on_event = function(event)
             )
         end
     end
-end
+end)
 
 module.events.subscribed = {
     ["core.keybinds"] = {

--- a/lua/neorg/modules/core/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/qol/todo_items/module.lua
@@ -399,7 +399,7 @@ module.public = {
     end,
 }
 
-module.on_event = function(event)
+module.on_event = neorg.utils.wrap_dotrepeat(function(event)
     local todo_str = "core.qol.todo_items.todo."
 
     if event.split_type[1] == "core.keybinds" then
@@ -446,7 +446,7 @@ module.on_event = function(event)
             )
         end
     end
-end
+end)
 
 module.events.subscribed = {
     ["core.keybinds"] = {


### PR DESCRIPTION
A dotrepeat wrapper for event handlers is implemented in neorg.utils.
As showcases, promo and task event handlers are wrapped, so for example `>>` and `<C-Space>` can now be dot-repeated.