### PR TITLE
fix(utils): don't dotrepeat insert mode actions

### DIFF
--- a/lua/neorg/core/utils.lua
+++ b/lua/neorg/core/utils.lua
@@ -187,6 +187,11 @@ end
 
 function utils.wrap_dotrepeat(event_handler)
     return function(event)
+        if vim.api.nvim_get_mode().mode == "i" then
+            event_handler(event)
+            return
+        end
+
         utils._neorg_is_dotrepeat = false
         utils.set_operatorfunc(function()
             if utils._neorg_is_dotrepeat then


### PR DESCRIPTION
This fixes a cursor misplacement problem caused by calling `vim.normal()` under insert mode.

For example, pressing `<ctrl-T>` at `* |` where `|` is the cursor will result in `**| ` currently, instead of `** |` as expected.