### PR TITLE
feat: option to inject specific metadata instead of defaults

### DIFF
--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -560,7 +560,7 @@ module.events.defined = {
     workspace_changed = modules.define_event(module, "workspace_changed"),
     workspace_added = modules.define_event(module, "workspace_added"),
     workspace_cache_empty = modules.define_event(module, "workspace_cache_empty"),
-	file_created = modules.define_event(module, "file_created")
+    file_created = modules.define_event(module, "file_created"),
 }
 
 module.events.subscribed = {

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -279,15 +279,15 @@ module.public = {
         end)
     end,
 
-    ---@class create_file_opts
+    ---@class core.dirman.create_file_opts
     ---@field no_open? boolean do not open the file after creation?
     ---@field force? boolean overwrite file if it already exists?
-    ---@field metadata? metadata metadata fields, if provided inserts metadata - an empty table uses default values
+    ---@field metadata? core.esupports.metagen.metadata metadata fields, if provided inserts metadata - an empty table uses default values
 
     --- Takes in a path (can include directories) and creates a .norg file from that path
     ---@param path string a path to place the .norg file in
     ---@param workspace? string workspace name
-    ---@param opts? create_file_opts additional options
+    ---@param opts? core.dirman.create_file_opts additional options
     create_file = function(path, workspace, opts)
         opts = opts or {}
 

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -34,6 +34,19 @@ To query the current workspace, run `:Neorg workspace`. To set the workspace, ru
 ### Changing the Current Working Directory
 After a recent update `core.dirman` will no longer change the current working directory after switching
 workspace. To get the best experience it's recommended to set the `autochdir` Neovim option.
+
+
+### Create a new note
+You can use dirman to create new notes in your workspaces.
+
+```lua
+local dirman = require('neorg').modules.get_module("core.dirman")
+dirman.create_file("my_file", "my_ws", {
+    no_open  = false,  -- open file after creation?
+    force    = false,  -- overwrite file if exists
+    metadata = {}      -- key-value table for metadata fields
+})
+```
 --]]
 
 local neorg = require("neorg.core")
@@ -272,6 +285,8 @@ module.public = {
     ---  - opts.no_open (bool) if true, will not open the file in neovim after creating it
     ---  - opts.force (bool) if true, will overwrite existing file content
     ---  - opts.metadata (table) Table of metadata data, overrides defaults if present
+    ---    - the table is a key-value table where the key correspondes to a metadata field,
+    ---      and the value is either a string or a function returning a string.
     create_file = function(path, workspace, opts)
         opts = opts or {}
 

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -279,10 +279,10 @@ module.public = {
         end)
     end,
 
-	---@class create_file_opts
-	---@field no_open? boolean do not open the file after creation?
-	---@field force? boolean overwrite file if it already exists?
-	---@field metadata? metadata metadata fields, if provided inserts metadata - an empty table uses default values
+    ---@class create_file_opts
+    ---@field no_open? boolean do not open the file after creation?
+    ---@field force? boolean overwrite file if it already exists?
+    ---@field metadata? metadata metadata fields, if provided inserts metadata - an empty table uses default values
 
     --- Takes in a path (can include directories) and creates a .norg file from that path
     ---@param path string a path to place the .norg file in

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -311,28 +311,19 @@ module.public = {
 
         -- Create the file
         local fd = vim.loop.fs_open(fname, opts.force and "w" or "a", 438)
-
         if fd then
             vim.loop.fs_close(fd)
         end
 
-        if opts.no_open then
-            -- new tab for easy closing again
-            vim.cmd("tabnew")
-        end
-
-        -- Begin editing that newly created file
-        vim.cmd("e " .. fname)
-
         local metagen = neorg.modules.get_module("core.esupports.metagen")
         if opts.metadata and metagen then
-            metagen.write_metadata(0, true, opts.metadata)
+			local bufnr = module.public.get_file_bufnr(fname)
+            metagen.write_metadata(bufnr, true, opts.metadata)
         end
 
-        vim.cmd("w")
-
-        if opts.no_open then
-            vim.cmd("tabclose")
+        if not opts.no_open then
+			-- Begin editing that newly created file
+			vim.cmd("e " .. fname .. "| w")
         end
     end,
 

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -317,13 +317,13 @@ module.public = {
 
         local metagen = neorg.modules.get_module("core.esupports.metagen")
         if opts.metadata and metagen then
-			local bufnr = module.public.get_file_bufnr(fname)
+            local bufnr = module.public.get_file_bufnr(fname)
             metagen.write_metadata(bufnr, true, opts.metadata)
         end
 
         if not opts.no_open then
-			-- Begin editing that newly created file
-			vim.cmd("e " .. fname .. "| w")
+            -- Begin editing that newly created file
+            vim.cmd("e " .. fname .. "| w")
         end
     end,
 

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -331,11 +331,10 @@ module.public = {
             vim.loop.fs_close(fd)
         end
 
-        local metagen = neorg.modules.get_module("core.esupports.metagen")
-        if opts.metadata and metagen then
-            local bufnr = module.public.get_file_bufnr(fname)
-            metagen.write_metadata(bufnr, true, opts.metadata)
-        end
+        local bufnr = module.public.get_file_bufnr(fname)
+        modules.broadcast_event(
+            modules.create_event(module, "core.dirman.events.file_created", { buffer = bufnr, opts = opts })
+        )
 
         if not opts.no_open then
             -- Begin editing that newly created file
@@ -561,6 +560,7 @@ module.events.defined = {
     workspace_changed = modules.define_event(module, "workspace_changed"),
     workspace_added = modules.define_event(module, "workspace_added"),
     workspace_cache_empty = modules.define_event(module, "workspace_cache_empty"),
+	file_created = modules.define_event(module, "file_created")
 }
 
 module.events.subscribed = {

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -278,15 +278,16 @@ module.public = {
             })
         end)
     end,
+
+	---@class create_file_opts
+	---@field no_open? boolean do not open the file after creation?
+	---@field force? boolean overwrite file if it already exists?
+	---@field metadata? metadata metadata fields, if provided inserts metadata - an empty table uses default values
+
     --- Takes in a path (can include directories) and creates a .norg file from that path
     ---@param path string a path to place the .norg file in
     ---@param workspace? string workspace name
-    ---@param opts? table additional options
-    ---  - opts.no_open (bool) if true, will not open the file in neovim after creating it
-    ---  - opts.force (bool) if true, will overwrite existing file content
-    ---  - opts.metadata (table) Table of metadata data, overrides defaults if present
-    ---    - the table is a key-value table where the key correspondes to a metadata field,
-    ---      and the value is either a string or a function returning a string.
+    ---@param opts? create_file_opts additional options
     create_file = function(path, workspace, opts)
         opts = opts or {}
 

--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -231,10 +231,18 @@ module.public = {
     ---@param buf number #The number of the buffer to inject the metadata into
     ---@param force? boolean #Whether to forcefully override existing metadata
     inject_metadata = function(buf, force)
+        module.public.write_metadata(buf, force, {})
+    end,
+
+    --- Inject the metadata into a buffer
+    ---@param buf number #The number of the buffer to inject the metadata into
+    ---@param force? boolean #Whether to forcefully override existing metadata
+    ---@param metadata table #Table of metadata data, overrides defaults if present
+    write_metadata = function(buf, force, metadata)
         local present, data = module.public.is_metadata_present(buf)
 
         if force or not present then
-            local constructed_metadata = module.public.construct_metadata(buf)
+            local constructed_metadata = module.public.create_metadata(buf, metadata)
             vim.api.nvim_buf_set_lines(buf, data.range[1], data.range[2], false, constructed_metadata)
         end
     end,

--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -185,10 +185,18 @@ module.public = {
         }
     end,
 
-    --- Creates the metadata contents from the configuration's template.
+    --- Constructs the metadata contents from the configuration's template.
     ---@param buf number #The buffer to query potential data from
     ---@return table #A table of strings that can be directly piped to `nvim_buf_set_lines`
     construct_metadata = function(buf)
+        return module.public.create_metadata(buf, {})
+    end,
+
+    --- Creates the metadata contents from the provided metadata table (defaulting to the configuration's template).
+    ---@param buf number #The buffer to query potential data from
+    ---@param metadata table #Table of metadata data, overrides defaults if present
+    ---@return table #A table of strings that can be directly piped to `nvim_buf_set_lines`
+    create_metadata = function(buf, metadata)
         local template = module.config.public.template
         local whitespace = type(module.config.public.tab) == "function" and module.config.public.tab()
             or module.config.public.tab
@@ -200,6 +208,10 @@ module.public = {
         }
 
         for _, data in ipairs(template) do
+            if metadata and metadata[data[1]] then
+                -- override with data from metadata table
+                data = { data[1], metadata[data[1]] }
+            end
             table.insert(
                 result,
                 whitespace .. data[1] .. delimiter .. tostring(type(data[2]) == "function" and data[2]() or data[2])

--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -192,7 +192,7 @@ module.public = {
         return module.public.create_metadata(buf, {})
     end,
 
-    ---@class metadata
+    ---@class core.esupports.metagen.metadata
     ---@field title? function|string the title of the note
     ---@field description? function|string the description of the note
     ---@field authors? function|string the authors of the note
@@ -203,7 +203,7 @@ module.public = {
 
     --- Creates the metadata contents from the provided metadata table (defaulting to the configuration's template).
     ---@param buf number #The buffer to query potential data from
-    ---@param metadata? metadata #Table of metadata, overrides defaults if present
+    ---@param metadata? core.esupports.metagen.metadata #Table of metadata, overrides defaults if present
     ---@return table #A table of strings that can be directly piped to `nvim_buf_set_lines`
     create_metadata = function(buf, metadata)
         local template = module.config.public.template
@@ -246,7 +246,7 @@ module.public = {
     --- Inject the metadata into a buffer
     ---@param buf number #The number of the buffer to inject the metadata into
     ---@param force? boolean #Whether to forcefully override existing metadata
-    ---@param metadata? table #Table of metadata data, overrides defaults if present
+    ---@param metadata? core.esupports.metagen.metadata #Table of metadata data, overrides defaults if present
     write_metadata = function(buf, force, metadata)
         local present, data = module.public.is_metadata_present(buf)
 

--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -374,7 +374,7 @@ module.on_event = function(event)
     elseif event.type == "core.neorgcmd.events.update-metadata" then
         module.public.update_metadata(event.buffer)
         module.private.buffers[event.buffer] = true
-	elseif event.type == "core.dirman.events.file_created" then
+    elseif event.type == "core.dirman.events.file_created" then
         if event.content.opts.metadata then
             module.public.inject_metadata(event.content.buffer, true, event.content.opts.metadata)
         end
@@ -392,9 +392,9 @@ module.events.subscribed = {
         ["inject-metadata"] = true,
         ["update-metadata"] = true,
     },
-	["core.dirman"] = {
-		["file_created"] = true,
-	}
+    ["core.dirman"] = {
+        ["file_created"] = true,
+    },
 }
 
 return module

--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -192,14 +192,14 @@ module.public = {
         return module.public.create_metadata(buf, {})
     end,
 
-	---@class metadata
-	---@field title? function|string the title of the note
-	---@field description? function|string the description of the note
-	---@field authors? function|string the authors of the note
-	---@field categories? function|string the categories of the note
-	---@field created? function|string a timestamp of creation time for the note
-	---@field updated? function|string a timestamp of last time the note was updated
-	---@field version? function|string the neorg version
+    ---@class metadata
+    ---@field title? function|string the title of the note
+    ---@field description? function|string the description of the note
+    ---@field authors? function|string the authors of the note
+    ---@field categories? function|string the categories of the note
+    ---@field created? function|string a timestamp of creation time for the note
+    ---@field updated? function|string a timestamp of last time the note was updated
+    ---@field version? function|string the neorg version
 
     --- Creates the metadata contents from the provided metadata table (defaulting to the configuration's template).
     ---@param buf number #The buffer to query potential data from

--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -192,11 +192,18 @@ module.public = {
         return module.public.create_metadata(buf, {})
     end,
 
+	---@class metadata
+	---@field title? function|string the title of the note
+	---@field description? function|string the description of the note
+	---@field authors? function|string the authors of the note
+	---@field categories? function|string the categories of the note
+	---@field created? function|string a timestamp of creation time for the note
+	---@field updated? function|string a timestamp of last time the note was updated
+	---@field version? function|string the neorg version
+
     --- Creates the metadata contents from the provided metadata table (defaulting to the configuration's template).
     ---@param buf number #The buffer to query potential data from
-    ---@param metadata table #Table of metadata, overrides defaults if present
-    ---  - the table is a key-value table where the key correspondes to a metadata field,
-    ---    and the value is either a string or a function returning a string.
+    ---@param metadata? metadata #Table of metadata, overrides defaults if present
     ---@return table #A table of strings that can be directly piped to `nvim_buf_set_lines`
     create_metadata = function(buf, metadata)
         local template = module.config.public.template
@@ -239,7 +246,7 @@ module.public = {
     --- Inject the metadata into a buffer
     ---@param buf number #The number of the buffer to inject the metadata into
     ---@param force? boolean #Whether to forcefully override existing metadata
-    ---@param metadata table #Table of metadata data, overrides defaults if present
+    ---@param metadata? table #Table of metadata data, overrides defaults if present
     write_metadata = function(buf, force, metadata)
         local present, data = module.public.is_metadata_present(buf)
 

--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -194,7 +194,9 @@ module.public = {
 
     --- Creates the metadata contents from the provided metadata table (defaulting to the configuration's template).
     ---@param buf number #The buffer to query potential data from
-    ---@param metadata table #Table of metadata data, overrides defaults if present
+    ---@param metadata table #Table of metadata, overrides defaults if present
+    ---  - the table is a key-value table where the key correspondes to a metadata field,
+    ---    and the value is either a string or a function returning a string.
     ---@return table #A table of strings that can be directly piped to `nvim_buf_set_lines`
     create_metadata = function(buf, metadata)
         local template = module.config.public.template


### PR DESCRIPTION
This PR closes #1126. I did not want to deprecate any existing functionality so I've made new functions to `write_metadata` with potential new values instead of defaults.

## Challenges
I am unsure if there is still is any need to use `fs_open()` to create the file, now that I instead create a new tab if `no_open` is true. My reasoning for creating a new tab is that in order to `inject_metadata` i need to have a buffer number, so I always open the new file in a new buffer. With tabs i can easily close the new tab without needing to worry about what else was open at the time.

## Additional notes
I noticed that there does not seem to be an easy way to add categories into the metadata as it seems the metadata fields need to return a single string.
I thought about added functionality to allow tables of strings as well such that you could have a method return a collection of categories (e.g. `{ "[", "    cat1", "    cat2", "]" }`)