### PR TITLE
fix(meta): fix treesitter deprecation warning (#1104)

### DIFF
--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -245,7 +245,7 @@ module.public = {
 
         local meta_root = nil
 
-        languagetree:for_each_child(function(tree)
+        for _, tree in pairs(languagetree:children()) do
             if tree:lang() ~= "norg_meta" or meta_root then
                 return
             end
@@ -257,7 +257,7 @@ module.public = {
             end
 
             meta_root = meta_tree:root()
-        end)
+        end
 
         if not meta_root then
             return

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -576,7 +576,7 @@ module.public = {
 
         local result = {}
 
-        languagetree:for_each_child(function(tree)
+        for _, tree in ipairs(languagetree:children()) do
             if tree:lang() ~= "norg_meta" then
                 return
             end
@@ -661,7 +661,7 @@ module.public = {
                     )
                 end
             end
-        end)
+        end
 
         return result
     end,


### PR DESCRIPTION
Treesitters `for_each_child()` will be deprecated in 0.11. It ias encouraged to use `children()` and implement the recursion yourself.

We use a loop to iterate over the tree's children and call the usual function for each child.

fixes #1104

I am new to lua and this project, so please double check whether this is the behaviour you want. I am not sure if the recursion works.