### PR TITLE
Better error message and open index file in default workspace if the file exists.

### DIFF
--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -486,14 +486,16 @@ module.on_event = function(event)
     if event.type == "core.neorgcmd.events.dirman.index" then
         local current_ws = module.public.get_current_workspace()
 
-        if current_ws[1] == "default" then
-            utils.notify("No workspace is set! Use `:Neorg workspace <name>` to set the current workspace. Aborting...")
-            return
-        end
-
         local index_path = table.concat({ current_ws[2], "/", module.config.public.index })
 
         if vim.fn.filereadable(index_path) == 0 then
+            if current_ws[1] == "default" then
+                utils.notify(table.concat({
+                    "Index file will not be created in 'default' workspace to avoid confusion.",
+                    "If this is intentional, manually create an index file beforehand to use this command.",
+                }, " "))
+                return
+            end
             if not module.public.touch_file(module.config.public.index, module.public.get_current_workspace()[1]) then
                 utils.notify(
                     table.concat({


### PR DESCRIPTION
When using the `:Neorg index` command inside the `default` workspace, it is hardcoded to abort without doing anything.

This was introduced in this commit: https://github.com/nvim-neorg/neorg/commit/c60747fcc567d7eb50b16c2007bcfd3a81a934d1, where I believe the intention was to not accidentally create an index file when you forgot to set the workspace.
Besides, I do not think the error message is easy to understand.

However, I do want to take repository-specific notes saved right inside that directory and I need this feature.

So, to make both working I propose to move to index file only-if the file already exists (I believe in this case the command call should be intended) and if the file does not exist, give a detailed error message to the user to show what they should do.

I'd be more than happy to hear your opinion @vhyrro . Thanks in advance.