### PR TITLE
fix(calendar): display weekdays based on `nvim_strwidth`

### DIFF
--- a/lua/neorg/core/utils.lua
+++ b/lua/neorg/core/utils.lua
@@ -206,4 +206,21 @@ function utils.wrap_dotrepeat(event_handler)
     end
 end
 
+--- Truncate input str to fit inside the col_limit when displayed. Takes non-ascii chars into account.
+---@param str string
+---@param col_limit integer #str will be cut so that when displayed, the display length does not exceed limit
+---@return string #substring of input str
+function utils.truncate_by_cell(str, col_limit)
+    if str and str:len() == vim.api.nvim_strwidth(str) then
+        return vim.fn.strcharpart(str, 0, col_limit)
+    end
+    local short = vim.fn.strcharpart(str, 0, col_limit)
+    if vim.api.nvim_strwidth(short) > col_limit then
+        while vim.api.nvim_strwidth(short) > col_limit do
+            short = vim.fn.strcharpart(short, 0, vim.fn.strchars(short) - 1)
+        end
+    end
+    return short
+end
+
 return utils

--- a/lua/neorg/modules/core/ui/calendar/views/monthly.lua
+++ b/lua/neorg/modules/core/ui/calendar/views/monthly.lua
@@ -1,5 +1,5 @@
 local neorg = require("neorg.core")
-local lib, log, modules = neorg.lib, neorg.log, neorg.modules
+local lib, log, modules, utils = neorg.lib, neorg.log, neorg.modules, neorg.utils
 
 local module = modules.create("core.ui.calendar.views.monthly")
 
@@ -111,9 +111,9 @@ module.private = {
                         day = date.day,
                     })
                 )
-
-                -- NOTE(vhyrro): This is just here to make the language server's type annotator happy.
-                assert(type(month_name) == "string")
+                ---@cast month_name string
+                -- local month_length = vim.api.nvim_strwidth(month_name)
+                local month_length = string.len(month_name)
 
                 local weekday_banner_id = vim.api.nvim_buf_get_extmark_by_id(
                     ui_info.buffer,
@@ -129,8 +129,8 @@ module.private = {
                     4,
                     weekday_banner_id[2]
                         + math.ceil((weekday_banner_id[3].end_col - weekday_banner_id[2]) / 2)
-                        - math.floor(month_name:len() / 2),
-                    month_name:len(),
+                        - math.floor(month_length / 2),
+                    month_length,
                     { { month_name, "@text.underline" } },
                     nil,
                     {
@@ -148,26 +148,17 @@ module.private = {
                 -- This makes the weekdays retrieved locale dependent (which is what we want).
                 local weekdays = {}
                 local weekdays_string_length = 0
-
                 for i = 1, 7 do
-                    table.insert(weekdays, {
-                        os.date(
-                            "%a",
-                            os.time({
-                                year = 2000,
-                                month = 5,
-                                day = i,
-                            })
-                        ):sub(1, 2),
-                        "@text.title",
-                    })
-
-                    if i ~= 7 then
-                        table.insert(weekdays, { "  " })
-                    end
-
-                    weekdays_string_length = weekdays_string_length + (i ~= 7 and 4 or 2)
+                    local weekday = os.date("%a", os.time({ year = 2000, month = 5, day = i }))
+                    ---@cast weekday string
+                    local truncated = utils.truncate_by_cell(weekday, 2)
+                    local truncated_length = vim.api.nvim_strwidth(truncated)
+                    weekdays[#weekdays + 1] = { truncated, "@text.title" }
+                    weekdays[#weekdays + 1] = { (" "):rep(4 - truncated_length) }
+                    weekdays_string_length = truncated_length -- remember last day's length
                 end
+                weekdays[#weekdays] = nil -- delete last padding
+                weekdays_string_length = weekdays_string_length + 4 * 6
 
                 -- This serves as the index of this week banner extmark inside the extmark table
                 local absolute_offset = offset + (offset < 0 and (-offset * 100) or 0)

--- a/lua/neorg/modules/core/ui/calendar/views/monthly.lua
+++ b/lua/neorg/modules/core/ui/calendar/views/monthly.lua
@@ -112,8 +112,7 @@ module.private = {
                     })
                 )
                 ---@cast month_name string
-                -- local month_length = vim.api.nvim_strwidth(month_name)
-                local month_length = string.len(month_name)
+                local month_length = vim.api.nvim_strwidth(month_name)
 
                 local weekday_banner_id = vim.api.nvim_buf_get_extmark_by_id(
                     ui_info.buffer,


### PR DESCRIPTION
Living in a non-latin country, life is sometimes hard with neovim.

Unfortunately in lua 5.1, passing Japanese characters `string.len("あいうえお")` does not count the _letters_ but return the byte length which does not fit accurately when the letters are multi-width. The above should be 5 _letters_ but returns 15.

The following screenshot is the result in the calendar ui of `weekday:sub(1, 2)` displaying corrupted weekdays.

![image](https://github.com/nvim-neorg/neorg/assets/41065736/fb0cede0-621f-458f-89ba-2aa64c71d23e)

As a reference, here's a code you can copy paste to reproduce.
```lua
local weekdays = {
  monday = "月曜日",
  tuesday = "火曜日",
  wednesday = "水曜日",
  thursday = "木曜日",
  friday = "金曜日",
  saturday = "土曜日",
  sunday = "日曜日",
}

for en, ja in pairs(weekdays) do
  vim.print(en)
  vim.print(ja)
  for i = 1, string.len(ja) - 1 do
    vim.print(ja:sub(i, i + 1)) ---> prints corrupted bytecodes
  end
  vim.print("======")
end
```

In this PR, I have implemented a util function that truncates string by the display length to solve this problem. The following image is the result with this PR.

![image](https://github.com/nvim-neorg/neorg/assets/41065736/ef669ab9-e5b7-4f13-a6ca-8c2f7fa778f7)

---

But here comes the ~~fun~~ part.

Well in Japanese, the first letters of the weekday names are used to distinguish (as *月* 曜日, *火* 曜日, ...) so we have no problem with basically a modified version of `weekday:sub(1, 2)`, but in Chinese, the names are like the image below where the difference is in the last character (星期 _一_, 星期 _二_, ...) which makes the matter worse.

![Chinese weekday names](https://goeastmandarin.com/wp-content/uploads/2023/09/days-of-the-week-in-chinese-1024x575-712x400.jpeg)

Maybe just using English everywhere with a hard coded lookup table might be a better solution rather than trying to support many languages (especially in the UI space) since I believe _intelligent_ people using vim will have at least some knowledge of English.

---

I searched through the code base and I think this is the only place right now that might call `string.sub` on a non-latin string. Currently, it is mostly used to parse neovim commands and so on.

However, if we are going to parse the filename, metadata, heading or any other things where user can input anything, we should be careful not to use `string.len` or `string.sub` which might cause some issues that are not easy to test.
I'm quite suspicious that there might be a bug where we call `vim.api.nvim_buf_set_extmark` abd calculate the length of the string, as some point out in this issue: https://github.com/neovim/neovim/issues/14010.