### PR TITLE
fix(dirman): add `raw_path` option to work with arbitrary filetype

### DIFF
--- a/lua/neorg/modules/core/dirman/utils/module.lua
+++ b/lua/neorg/modules/core/dirman/utils/module.lua
@@ -14,7 +14,11 @@ local log, modules = neorg.log, neorg.modules
 local module = neorg.modules.create("core.dirman.utils")
 
 module.public = {
-    expand_path = function(path)
+    ---Resolve `$<workspace>/path/to/file` and return the real path
+    ---@param path string # path
+    ---@param raw_path boolean? # If true, returns resolved path, else, return with appended ".norg"
+    ---@return string? # Resolved path. If path does not start with `$` or not absolute, adds relative from current file.
+    expand_path = function(path, raw_path)
         -- Expand special chars like `$`
         local custom_workspace_path = path:match("^%$([^/\\]*)[/\\]")
 
@@ -47,7 +51,7 @@ module.public = {
             path = (vim.tbl_contains({ "/", "~" }, path:sub(1, 1)) and "" or (vim.fn.expand("%:p:h") .. "/")) .. path
         end
 
-        return path .. ".norg"
+        return path .. (raw_path and "" or ".norg")
     end,
 }
 


### PR DESCRIPTION
`core.dirman.utils.expand_path` is the function to resolve filepath with workspace notation (`$<workspace>/`).

This should work with arbitrary file type as it will be used to resolve files in for example `.image $/relative/path/to/image.png`, but currently, it is hardcoded to append `.norg` after the file path.

I've added an argument `raw_path` which, when is true, does not append the norg extension.

The previous calls to this function does not specify this arg, (hence nil) so we should have backwards compatibility.

### Note

https://github.com/nvim-neorg/neorg/blob/98f390d8b0c42e40196ea4d831b42b3908137bc3/lua/neorg/modules/core/dirman/utils/module.lua#L45-L47

Not in the scope of this PR but I don't think this works on Windows. I don't have an environment to test Windows so I'll leave it to someone else for a fix.

Possibly related: https://github.com/nvim-neorg/neorg/issues/241