### PR TITLE
feat: add `traverse-link` Neorg mode

### DIFF
--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -102,6 +102,7 @@ module.load = function()
     module.private.ts_utils = ts_utils
 
     module.required["core.mode"].add_mode("traverse-heading")
+    module.required["core.mode"].add_mode("traverse-link")
     modules.await("core.keybinds", function(keybinds)
         keybinds.register_keybinds(module.name, { "next.heading", "previous.heading", "next.link", "previous.link" })
     end)

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -124,6 +124,24 @@ module.config.public = {
                 noremap = true,
             })
 
+            -- Map the below keys only when traverse-link mode is active
+            keybinds.map_event_to_mode("traverse-link", {
+                n = {
+                    -- Move to the next link in the document
+                    { "j", "core.integrations.treesitter.next.link", opts = { desc = "Move to Next Link" } },
+
+                    -- Move to the previous link in the document
+                    {
+                        "k",
+                        "core.integrations.treesitter.previous.link",
+                        opts = { desc = "Move to Previous Link" },
+                    },
+                },
+            }, {
+                silent = true,
+                noremap = true,
+            })
+
             -- Map the below keys on presenter mode
             keybinds.map_event_to_mode("presenter", {
                 n = {


### PR DESCRIPTION
A New mode for quick link traversal using "j" and "k" in that mode.