### PR TITLE
ref(selection_popup)!: modernize code of selection popup

### DIFF
--- a/lua/neorg/modules/core/clipboard/module.lua
+++ b/lua/neorg/modules/core/clipboard/module.lua
@@ -48,17 +48,13 @@ module.load = function()
 
                                 return callback.cb(
                                     node,
-                                    vim.split(
-                                        register,
-                                        "\n",
-                                        { ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
-                                            plain = true,
-                                            -- TODO: This causes problems in places
-                                            -- where you actually want to copy
-                                            -- newlines.
-                                            trimempty = true,
-                                        }
-                                    ),
+                                    vim.split(register, "\n", { ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                                        plain = true,
+                                        -- TODO: This causes problems in places
+                                        -- where you actually want to copy
+                                        -- newlines.
+                                        trimempty = true,
+                                    }),
                                     {
                                         start = range[1],
                                         ["end"] = range[2],

--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -206,7 +206,7 @@ module.public = {
 
         local selection = module.required["core.ui"]
             .begin_selection(module.required["core.ui"].create_split("link-not-found"))
-            :listener("delete-buffer", {
+            :listener({
                 "<Esc>",
             }, function(self)
                 self:destroy()

--- a/lua/neorg/modules/core/tempus/module.lua
+++ b/lua/neorg/modules/core/tempus/module.lua
@@ -225,18 +225,14 @@ module.public = {
         return os.date( ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
             "*t",
             os.time(
-                vim.tbl_deep_extend(
-                    "force",
-                    os.date("*t"),
-                    { ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
-                        day = parsed_date.day,
-                        month = parsed_date.month and parsed_date.month.number or nil,
-                        year = parsed_date.year,
-                        hour = parsed_date.time and parsed_date.time.hour,
-                        min = parsed_date.time and parsed_date.time.minute,
-                        sec = parsed_date.time and parsed_date.time.second,
-                    }
-                )
+                vim.tbl_deep_extend("force", os.date("*t"), { ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                    day = parsed_date.day,
+                    month = parsed_date.month and parsed_date.month.number or nil,
+                    year = parsed_date.year,
+                    hour = parsed_date.time and parsed_date.time.hour,
+                    min = parsed_date.time and parsed_date.time.minute,
+                    sec = parsed_date.time and parsed_date.time.second,
+                })
             )
         )
     end,

--- a/lua/neorg/modules/core/ui/calendar/views/monthly.lua
+++ b/lua/neorg/modules/core/ui/calendar/views/monthly.lua
@@ -349,21 +349,15 @@ module.private = {
                     }, "center"),
 
                     -- Help text at the bottom left of the screen
-                    help_and_custom_input = module.private.set_decorational_extmark(
-                        ui_info,
-                        ui_info.height - 1,
-                        0,
-                        0,
-                        {
-                            { "?", "@character" },
-                            { " - " },
-                            { "help", "@text.strong" },
-                            { "    " },
-                            { "i", "@character" },
-                            { " - " },
-                            { "custom input", "@text.strong" },
-                        }
-                    ),
+                    help_and_custom_input = module.private.set_decorational_extmark(ui_info, ui_info.height - 1, 0, 0, {
+                        { "?", "@character" },
+                        { " - " },
+                        { "help", "@text.strong" },
+                        { "    " },
+                        { "i", "@character" },
+                        { " - " },
+                        { "custom input", "@text.strong" },
+                    }),
 
                     -- The current view (bottom right of the screen)
                     current_view = module.private.set_decorational_extmark(

--- a/lua/neorg/modules/core/ui/module.lua
+++ b/lua/neorg/modules/core/ui/module.lua
@@ -377,10 +377,10 @@ module.examples = {
                     return self:text(text, "@text.title")
                 end,
             })
-            :listener("destroy", { "<Esc>" }, function(self)
+            :listener({ "<Esc>" }, function(self)
                 self:destroy()
             end)
-            :listener("go-back", { "<BS>" }, function(self)
+            :listener({ "<BS>" }, function(self)
                 self:pop_page()
             end)
 
@@ -418,7 +418,7 @@ module.examples = {
                             :text("Also, psst, pressing `g` will give you a small surprise")
                             :blank()
                             :flag("a", "does nothing too")
-                            :listener("print-message", { "g" }, function()
+                            :listener({ "g" }, function()
                                 log.warn("You are awesome :)")
                             end)
                     end)

--- a/lua/neorg/modules/core/ui/selection_popup.lua
+++ b/lua/neorg/modules/core/ui/selection_popup.lua
@@ -12,8 +12,9 @@ local module = modules.create("core.ui.selection_popup")
 module.public = {
     --- Constructs a new selection
     ---@param buffer number #The number of the buffer the selection should attach to
+    ---@param keybind_buffer number? #An alternate buffer from which the keybinds for the selection popup are entered.
     ---@return table #A selection object
-    begin_selection = function(buffer)
+    begin_selection = function(buffer, keybind_buffer)
         -- Data that is gathered up over the lifetime of the selection popup
         local data = {}
 
@@ -105,7 +106,7 @@ module.public = {
                 -- Go through all keys that the user has bound a listener to and bind them!
                 for _, key in ipairs(keys) do
                     vim.keymap.set(mode or "n", key, lib.wrap(func, self), {
-                        buffer = buffer,
+                        buffer = keybind_buffer or buffer,
                         silent = true,
                         nowait = true,
                     })
@@ -126,7 +127,7 @@ module.public = {
                 -- Go through all keys that the user has bound a listener to and bind them!
                 for _, key in pairs(keys) do
                     vim.keymap.set(mode or "n", key, lib.wrap(func, self), {
-                        buffer = buffer,
+                        buffer = keybind_buffer or buffer,
                         silent = true,
                         nowait = true,
                     })


### PR DESCRIPTION
This PR modernizes the old Neovim 0.5 code for the beloved selection popup system that Neorg uses (that's the thing you see when your link is broken!). This is a breaking change as any external module using this UI element now has to update their `:listener` and `:locallistener` calls to excludethe first parameter.

