### PR TITLE
fix(luacheck): fix type errors caused by autoformat

### DIFF
--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -224,17 +224,17 @@ module.on_event = function(event)
         local exported = module.public.export(event.buffer, filetype) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
 
         vim.loop.fs_open(
-            filepath,
+            filepath, ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
             "w",
             438,
-            function(err, fd) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+            function(err, fd)
                 assert(not err, lib.lazy_string_concat("Failed to open file '", filepath, "' for export: ", err))
 
                 vim.loop.fs_write(
-                    fd,
-                    exported,
+                    fd, ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                    exported, ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
                     0,
-                    function(werr) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                    function(werr)
                         assert(
                             not werr,
                             lib.lazy_string_concat("Failed to write to file '", filepath, "' for export: ", werr)
@@ -310,10 +310,10 @@ module.on_event = function(event)
                             )
 
                             vim.loop.fs_write(
-                                fd,
+                                fd, ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
                                 exported,
                                 0,
-                                function(werr) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                                function(werr)
                                     assert(
                                         not werr,
                                         lib.lazy_string_concat(

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -74,9 +74,9 @@ module.load = function()
     module.required["core.autocommands"].enable_autocommand("BufLeave")
 
     if module.config.public.hook then
-        neorg.callbacks.on_event(
+        neorg.callbacks.on_event( ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
             "core.keybinds.events.enable_keybinds",
-            function(_, keybinds) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+            function(_, keybinds)
                 module.config.public.hook(keybinds)
             end
         )

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -430,18 +430,18 @@ module.on_event = function(event)
 
         for file, content in pairs(tangles) do
             vim.loop.fs_open(
-                vim.fn.expand(file),
+                vim.fn.expand(file), ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
                 "w",
                 438,
-                function(err, fd) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                function(err, fd)
                     file_count = file_count - 1
                     assert(not err, lib.lazy_string_concat("Failed to open file '", file, "' for tangling: ", err))
 
                     vim.loop.fs_write(
-                        fd,
+                        fd, ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
                         table.concat(content, "\n"),
                         0,
-                        function(werr) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                        function(werr)
                             assert(
                                 not werr,
                                 lib.lazy_string_concat("Failed to write to file '", file, "' for tangling: ", werr)

--- a/lua/neorg/modules/core/upgrade/module.lua
+++ b/lua/neorg/modules/core/upgrade/module.lua
@@ -254,10 +254,10 @@ module.on_event = function(event)
                 assert(not err, lib.lazy_string_concat("Failed to open file '", path, "' for upgrade: ", err))
 
                 vim.loop.fs_write(
-                    fd,
+                    fd, ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
                     output,
                     0,
-                    function(werr) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                    function(werr)
                         assert(
                             not werr,
                             lib.lazy_string_concat("Failed to write to file '", path, "' for upgrade: ", werr)
@@ -372,10 +372,10 @@ module.on_event = function(event)
                         )
 
                         vim.loop.fs_write(
-                            fd,
+                            fd, ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
                             output,
                             0,
-                            function(werr) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                            function(werr)
                                 assert(
                                     not werr,
                                     lib.lazy_string_concat(


### PR DESCRIPTION
As title.

It seems that stylua automatically reformats the code and the comment are moved so that it doesn't get aligned with the actual problem.

Would you add type checking action to run after the stylua actions as well?
I guess you need to create a separate `GITHUB_TOKEN` for that as I mentioned here: https://github.com/vhyrro/sample-luarocks-plugin/issues/1.

Anyways, this PR changes the places of `---@diagnostic disable-line` so that the langserver is happy again :)