### PR TITLE
fix(journal): value assigned to variable current_quarter is unused

### DIFF
--- a/lua/neorg/modules/core/journal/module.lua
+++ b/lua/neorg/modules/core/journal/module.lua
@@ -47,7 +47,6 @@ module.examples = {
                                 if not current_year or current_year < entry[1] then
                                     current_year = entry[1]
                                     current_month = nil
-                                    current_quarter = nil
                                     table.insert(output, "* " .. current_year)
                                 end
 


### PR DESCRIPTION
The action `luacheck` fails from https://github.com/nvim-neorg/neorg/pull/1165, with _value assigned to variable current_quarter is unused_ as you can see [here](https://github.com/nvim-neorg/neorg/actions/runs/6881253495/job/18717231193).

This PR fixes that.
Basically, `current_quater` is substituted with `[1-4]` right after (if-else covers all cases), so there's no reason to put it to `nil` here.

In the action I mentioned above, there's also another error in `core.latex.render` so I asked @nolbap to fix it here: https://github.com/nvim-neorg/neorg/pull/1133#issuecomment-1817793348.