### PR TITLE
fix(config): fix luajit version detection

### DIFF
--- a/lua/neorg/core/config.lua
+++ b/lua/neorg/core/config.lua
@@ -12,7 +12,7 @@ local function neovim_version()
         end
 
         if not key then
-            key, value = line:match("(LUAJIT)%s+(.+)")
+            key, value = line:match("(LuaJIT)%s+(.+)")
         end
 
         if key then


### PR DESCRIPTION
![image](https://github.com/nvim-neorg/neorg/assets/41065736/e59dbe80-00bf-4e26-a97d-d513fb0a2cd7)

LuaJIT version in command `:version` starts with `LuaJIT` and not `LUAJIT` at least on my machine (Manjaro KDE).

But the actual intention of this PR is to bring up the debate on whether we need this function in the first place.

NVIM will only detect the patch version and only when using nightly (1572 in the example above), and in stable (or other tag release versions), it fails to detect.

On top of that, I don't see it being used throughout the codebase.
It is possible that some other external module might be using it, but it is rather advised to use `vim.fn.has("nvim-0.9.0") == 1` if you want a specific neovim version, and I don't think the lua version will change (except for possibly very minor changes) and stick to LuaJIT compatible with `lua v5.1`.

Do you think it is worth keeping this function in the codebase?

I'm asking this question since `vim.api.nvim_exec`, which is used in this function, will be deprecated in `v0.10.0` to `vim.api.nvim_exec2` with different parameters, and if we want to keep the compatibility, we need to write a compatibility layer by ourselves. It'd be easier to simply delete the entire function lol.