### PR TITLE
fix(modules): Check the right config key in module.wants

### DIFF
--- a/lua/neorg/core/modules.lua
+++ b/lua/neorg/core/modules.lua
@@ -279,7 +279,7 @@ function modules.load_module_from_table(module)
 
             -- This would've always returned false had we not added the current module to the loaded module list earlier above
             if not modules.is_module_loaded(required_module) then
-                if config.user_config[required_module] then
+                if config.user_config.load[required_module] then
                     log.trace(
                         "Wanted module",
                         required_module,


### PR DESCRIPTION
If a module `wants` another module, the loading process checks `config.user_config` for that module configuration. However, module configs are located in `config.user_config.load`.