### PR TITLE
fix(latex): Make latex module want image integration, (partially) fixes #1183

### DIFF
--- a/lua/neorg/core/modules.lua
+++ b/lua/neorg/core/modules.lua
@@ -279,7 +279,7 @@ function modules.load_module_from_table(module)
 
             -- This would've always returned false had we not added the current module to the loaded module list earlier above
             if not modules.is_module_loaded(required_module) then
-                if config.user_config[required_module] then
+                if config.user_config.load[required_module] then
                     log.trace(
                         "Wanted module",
                         required_module,

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -6,6 +6,9 @@ assert(vim.re ~= nil, "Neovim 0.10.0+ is required to run the `core.renderer.late
 
 module.setup = function()
     return {
+        wants = {
+            "core.integrations.image",
+        },
         requires = {
             "core.integrations.treesitter",
             "core.autocommands",


### PR DESCRIPTION
When opening any `norg` file (not necessarily with math inside) directly in neovim with both the `integration.image` and `latex.renderer` configured, every event registered by the latter throws an error.
This is because the latex renderer tries using `module.private.image`, which is the image module and gets required on latex module load. If the image module is however not yet loaded, this return nil and therefore throws an error later.

There are a couple of possible fixes for this.
- In `neorg.module.get_modules` load the module and not just return `nil`.
- Do a better check after invoking `get_module`, since it never errors but only return nil. This does not fix anything, however.
- Use this pull request to "want" the image integration, so it is loaded on latex module load. However, this might not be desired, if multiple possible renderers are to be allowed in the future.
- Do a lazy-load of the image module. I do not know if this is possible right now.
- Make latex renderer lazy-load. Right now, it registers all autocmds it could need. This still requires a forced loading of the image integration later, however.