### PR TITLE
feat(toc): add toc item filter

### DIFF
--- a/lua/neorg/modules/core/qol/toc/module.lua
+++ b/lua/neorg/modules/core/qol/toc/module.lua
@@ -51,6 +51,10 @@ module.config.public = {
     -- If `true`, the width of the Table of Contents window will automatically
     -- fit its longest line
     fit_width = true,
+
+    -- A function that takes node type as argument and returns true if this
+    -- type of node should appear in the Table of Contents
+    toc_filter = function(node_type) return node_type:match("^heading") end,
 }
 
 module.public = {
@@ -149,6 +153,7 @@ module.public = {
 
         local prefix, title
         local extmarks = {}
+        local toc_filter = module.config.public.toc_filter
 
         local success = module.required["core.integrations.treesitter"].execute_query(
             [[
@@ -163,7 +168,7 @@ module.public = {
                 local capture = query.captures[id]
 
                 if capture == "prefix" then
-                    if node:type():match("_prefix$") then
+                    if node:type():match("_prefix$") and (type(toc_filter) ~= 'function' or toc_filter(node:type())) then
                         prefix = node
                     else
                         prefix = nil


### PR DESCRIPTION
Currently all nodes whose type ends with `_prefix` are extracted into the ToC window, including footnotes, whose node type is `single_footnote_prefix`.

This PR adds a customizable filter function for ToC items, which only allows headings into the ToC by default.