### PR TITLE
fix(toc): clear title after assigning prefix

### DIFF
--- a/lua/neorg/modules/core/qol/toc/module.lua
+++ b/lua/neorg/modules/core/qol/toc/module.lua
@@ -177,6 +177,7 @@ module.public = {
                     else
                         prefix = nil
                     end
+                    title = nil
                 elseif capture == "title" then
                     title = node
                 elseif capture == "cancelled" then


### PR DESCRIPTION
Title should be cleared when encountering new prefix, otherwise for docs like:

```norg
^ footnote-title
text

* heading-text
```

the toc would be `* footnote-title`.