### PR TITLE
fix: record that module `upgrade` requires at least 1 arg

### DIFF
--- a/lua/neorg/modules/core/upgrade/module.lua
+++ b/lua/neorg/modules/core/upgrade/module.lua
@@ -45,6 +45,8 @@ module.load = function()
     modules.await("core.neorgcmd", function(neorgcmd)
         neorgcmd.add_commands_from_table({
             upgrade = {
+                min_args = 1,
+                max_args = 1,
                 subcommands = {
                     ["current-file"] = {
                         name = "core.upgrade.current-file",


### PR DESCRIPTION
Fixes #1206 
The purpose is to ensure that `neorgcmd` can launch the ui selector when the user doesn't provide the necessary arguments to the `upgrade` module.

At `/neorg/lua/neorg/modules/core/neorgcmd/module.lua:258`, a check is performed to ensure that at least the minimum number of arguments have been provided for the given module. The core module `upgrade` currently does not set this `min_args` property at all, resulting in an error when attempting to call `:Neorg upgrade`. By communicating that `upgrade` requires at least 1 arg, `neorgcmd` will be able to call the function `select_next_cmd_arg` at line 260.