### PR TITLE
fix(action): run lint action against pr head

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Linter
-
-on: [push, pull_request_target]
+on:
+  pull_request: ~
+  push:
+    branches:
+      - '*'
 
 jobs:
   luacheck:


### PR DESCRIPTION
[`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) runs against the **target** branch (`neorg/main`) and not the content of the PR head.

Therefore, action results in [this PR](https://github.com/nvim-neorg/neorg/pull/1198) succeeds even tho the actual PR content is [messed up](https://github.com/nvim-neorg/neorg/actions/runs/7059860778/job/19218279880). 