### PR TITLE
feat(hop): keybinding for opening links in new tab and with external apps

### DIFF
--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -77,6 +77,14 @@ module.config.public = {
                         opts = { desc = "Jump to Link (new tab)" },
                     },
 
+                    -- Same as `<CR>`, except opens the destination with external applications
+                    {
+                        leader .. "ge",
+                        "core.esupports.hop.hop-link",
+                        "external",
+                        opts = { desc = "Jump to Link (external)" },
+                    },
+
                     -- Same as `<CR>`, except opens the destination in a vertical split
                     {
                         "<M-CR>",

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -65,9 +65,9 @@ module.config.public = {
 
                     -- Hop to the destination of the link under the cursor
                     { "<CR>", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gd", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gf", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gF", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                    { leader .. "gd", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                    { leader .. "gf", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                    { leader .. "gF", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
 
                     -- Same as `<CR>`, except opens the destination in a new tab
                     {

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -69,6 +69,14 @@ module.config.public = {
                     { "gf", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
                     { "gF", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
 
+                    -- Same as `<CR>`, except opens the destination in a new tab
+                    {
+                        leader .. "gt",
+                        "core.esupports.hop.hop-link",
+                        "tab",
+                        opts = { desc = "Jump to Link (new tab)" },
+                    },
+
                     -- Same as `<CR>`, except opens the destination in a vertical split
                     {
                         "<M-CR>",


### PR DESCRIPTION
Resolves comment https://github.com/nvim-neorg/neorg/issues/1212#issuecomment-1855507662

One can now:
- use `\gt` (t for tab) to open links in new tab
- use `\ge` (e for external) to open links with external apps