### PR TITLE
feat: prefix all keybind descriptions with "neorg" for discoverability

### DIFF
--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -14,26 +14,38 @@ module.config.public = {
                 n = {
                     -- Marks the task under the cursor as "undone"
                     -- ^mark Task as Undone
-                    { leader .. "tu", "core.qol.todo_items.todo.task_undone", opts = { desc = "Mark as Undone" } },
+                    {
+                        leader .. "tu",
+                        "core.qol.todo_items.todo.task_undone",
+                        opts = { desc = "[neorg] Mark as Undone" },
+                    },
 
                     -- Marks the task under the cursor as "pending"
                     -- ^mark Task as Pending
-                    { leader .. "tp", "core.qol.todo_items.todo.task_pending", opts = { desc = "Mark as Pending" } },
+                    {
+                        leader .. "tp",
+                        "core.qol.todo_items.todo.task_pending",
+                        opts = { desc = "[neorg] Mark as Pending" },
+                    },
 
                     -- Marks the task under the cursor as "done"
                     -- ^mark Task as Done
-                    { leader .. "td", "core.qol.todo_items.todo.task_done", opts = { desc = "Mark as Done" } },
+                    { leader .. "td", "core.qol.todo_items.todo.task_done", opts = { desc = "[neorg] Mark as Done" } },
 
                     -- Marks the task under the cursor as "on_hold"
                     -- ^mark Task as on Hold
-                    { leader .. "th", "core.qol.todo_items.todo.task_on_hold", opts = { desc = "Mark as On Hold" } },
+                    {
+                        leader .. "th",
+                        "core.qol.todo_items.todo.task_on_hold",
+                        opts = { desc = "[neorg] Mark as On Hold" },
+                    },
 
                     -- Marks the task under the cursor as "cancelled"
                     -- ^mark Task as Cancelled
                     {
                         leader .. "tc",
                         "core.qol.todo_items.todo.task_cancelled",
-                        opts = { desc = "Mark as Cancelled" },
+                        opts = { desc = "[neorg] Mark as Cancelled" },
                     },
 
                     -- Marks the task under the cursor as "recurring"
@@ -41,7 +53,7 @@ module.config.public = {
                     {
                         leader .. "tr",
                         "core.qol.todo_items.todo.task_recurring",
-                        opts = { desc = "Mark as Recurring" },
+                        opts = { desc = "[neorg] Mark as Recurring" },
                     },
 
                     -- Marks the task under the cursor as "important"
@@ -49,51 +61,63 @@ module.config.public = {
                     {
                         leader .. "ti",
                         "core.qol.todo_items.todo.task_important",
-                        opts = { desc = "Mark as Important" },
+                        opts = { desc = "[neorg] Mark as Important" },
                     },
 
                     -- Marks the task under the cursor as "ambiguous"
                     -- ^mark Task as ambiguous
-                    { leader .. "ta", "core.qol.todo_items.todo.task_ambiguous", opts = { desc = "Mark as Ambigous" } },
+                    {
+                        leader .. "ta",
+                        "core.qol.todo_items.todo.task_ambiguous",
+                        opts = { desc = "[neorg] Mark as Ambigous" },
+                    },
 
                     -- Switches the task under the cursor between a select few states
-                    { "<C-Space>", "core.qol.todo_items.todo.task_cycle", opts = { desc = "Cycle Task" } },
+                    { "<C-Space>", "core.qol.todo_items.todo.task_cycle", opts = { desc = "[neorg] Cycle Task" } },
 
                     -- Creates a new .norg file to take notes in
                     -- ^New Note
-                    { leader .. "nn", "core.dirman.new.note", opts = { desc = "Create New Note" } },
+                    { leader .. "nn", "core.dirman.new.note", opts = { desc = "[neorg] Create New Note" } },
 
                     -- Hop to the destination of the link under the cursor
-                    { "<CR>", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gd", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gf", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gF", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                    { "<CR>", "core.esupports.hop.hop-link", opts = { desc = "[neorg] Jump to Link" } },
+                    { "gd", "core.esupports.hop.hop-link", opts = { desc = "[neorg] Jump to Link" } },
+                    { "gf", "core.esupports.hop.hop-link", opts = { desc = "[neorg] Jump to Link" } },
+                    { "gF", "core.esupports.hop.hop-link", opts = { desc = "[neorg] Jump to Link" } },
 
                     -- Same as `<CR>`, except opens the destination in a vertical split
                     {
                         "<M-CR>",
                         "core.esupports.hop.hop-link",
                         "vsplit",
-                        opts = { desc = "Jump to Link (Vertical Split)" },
+                        opts = { desc = "[neorg] Jump to Link (Vertical Split)" },
                     },
 
-                    { ">.", "core.promo.promote", opts = { desc = "Promote Object (Non-Recursively)" } },
-                    { "<,", "core.promo.demote", opts = { desc = "Demote Object (Non-Recursively)" } },
+                    { ">.", "core.promo.promote", opts = { desc = "[neorg] Promote Object (Non-Recursively)" } },
+                    { "<,", "core.promo.demote", opts = { desc = "[neorg] Demote Object (Non-Recursively)" } },
 
-                    { ">>", "core.promo.promote", "nested", opts = { desc = "Promote Object (Recursively)" } },
-                    { "<<", "core.promo.demote", "nested", opts = { desc = "Demote Object (Recursively)" } },
+                    { ">>", "core.promo.promote", "nested", opts = { desc = "[neorg] Promote Object (Recursively)" } },
+                    { "<<", "core.promo.demote", "nested", opts = { desc = "[neorg] Demote Object (Recursively)" } },
 
-                    { leader .. "lt", "core.pivot.toggle-list-type", opts = { desc = "Toggle (Un)ordered List" } },
-                    { leader .. "li", "core.pivot.invert-list-type", opts = { desc = "Invert (Un)ordered List" } },
+                    {
+                        leader .. "lt",
+                        "core.pivot.toggle-list-type",
+                        opts = { desc = "[neorg] Toggle (Un)ordered List" },
+                    },
+                    {
+                        leader .. "li",
+                        "core.pivot.invert-list-type",
+                        opts = { desc = "[neorg] Invert (Un)ordered List" },
+                    },
 
-                    { leader .. "id", "core.tempus.insert-date", opts = { desc = "Insert Date" } },
+                    { leader .. "id", "core.tempus.insert-date", opts = { desc = "[neorg] Insert Date" } },
                 },
 
                 i = {
-                    { "<C-t>", "core.promo.promote", opts = { desc = "Promote Object (Recursively)" } },
-                    { "<C-d>", "core.promo.demote", opts = { desc = "Demote Object (Recursively)" } },
-                    { "<M-CR>", "core.itero.next-iteration", "<CR>", opts = { desc = "Continue Object" } },
-                    { "<M-d>", "core.tempus.insert-date-insert-mode", opts = { desc = "Insert Date" } },
+                    { "<C-t>", "core.promo.promote", opts = { desc = "[neorg] Promote Object (Recursively)" } },
+                    { "<C-d>", "core.promo.demote", opts = { desc = "[neorg] Demote Object (Recursively)" } },
+                    { "<M-CR>", "core.itero.next-iteration", "<CR>", opts = { desc = "[neorg] Continue Object" } },
+                    { "<M-d>", "core.tempus.insert-date-insert-mode", opts = { desc = "[neorg] Insert Date" } },
                 },
 
                 -- TODO: Readd these
@@ -110,13 +134,17 @@ module.config.public = {
             keybinds.map_event_to_mode("traverse-heading", {
                 n = {
                     -- Move to the next heading in the document
-                    { "j", "core.integrations.treesitter.next.heading", opts = { desc = "Move to Next Heading" } },
+                    {
+                        "j",
+                        "core.integrations.treesitter.next.heading",
+                        opts = { desc = "[neorg] Move to Next Heading" },
+                    },
 
                     -- Move to the previous heading in the document
                     {
                         "k",
                         "core.integrations.treesitter.previous.heading",
-                        opts = { desc = "Move to Previous Heading" },
+                        opts = { desc = "[neorg] Move to Previous Heading" },
                     },
                 },
             }, {
@@ -128,13 +156,13 @@ module.config.public = {
             keybinds.map_event_to_mode("traverse-link", {
                 n = {
                     -- Move to the next link in the document
-                    { "j", "core.integrations.treesitter.next.link", opts = { desc = "Move to Next Link" } },
+                    { "j", "core.integrations.treesitter.next.link", opts = { desc = "[neorg] Move to Next Link" } },
 
                     -- Move to the previous link in the document
                     {
                         "k",
                         "core.integrations.treesitter.previous.link",
-                        opts = { desc = "Move to Previous Link" },
+                        opts = { desc = "[neorg] Move to Previous Link" },
                     },
                 },
             }, {
@@ -145,13 +173,13 @@ module.config.public = {
             -- Map the below keys on presenter mode
             keybinds.map_event_to_mode("presenter", {
                 n = {
-                    { "<CR>", "core.presenter.next_page", opts = { desc = "Next Page" } },
-                    { "l", "core.presenter.next_page", opts = { desc = "Next Page" } },
-                    { "h", "core.presenter.previous_page", opts = { desc = "Previous Page" } },
+                    { "<CR>", "core.presenter.next_page", opts = { desc = "[neorg] Next Page" } },
+                    { "l", "core.presenter.next_page", opts = { desc = "[neorg] Next Page" } },
+                    { "h", "core.presenter.previous_page", opts = { desc = "[neorg] Previous Page" } },
 
                     -- Keys for closing the current display
-                    { "q", "core.presenter.close", opts = { desc = "Close Presentation" } },
-                    { "<Esc>", "core.presenter.close", opts = { desc = "Close Presentation" } },
+                    { "q", "core.presenter.close", opts = { desc = "[neorg] Close Presentation" } },
+                    { "<Esc>", "core.presenter.close", opts = { desc = "[neorg] Close Presentation" } },
                 },
             }, {
                 silent = true,
@@ -162,18 +190,18 @@ module.config.public = {
             -- Apply the below keys to all modes
             keybinds.map_to_mode("all", {
                 n = {
-                    { leader .. "mn", "<cmd>Neorg mode norg<CR>", opts = { desc = "Enter Norg Mode" } },
+                    { leader .. "mn", "<cmd>Neorg mode norg<CR>", opts = { desc = "[neorg] Enter Norg Mode" } },
                     {
                         leader .. "mh",
                         "<cmd>Neorg mode traverse-heading<CR>",
-                        opts = { desc = "Enter Heading Traversal Mode" },
+                        opts = { desc = "[neorg] Enter Heading Traversal Mode" },
                     },
                     {
                         leader .. "ml",
                         "<cmd>Neorg mode traverse-link<CR>",
-                        opts = { desc = "Enter Link Traversal Mode" },
+                        opts = { desc = "[neorg] Enter Link Traversal Mode" },
                     },
-                    { "gO", "<cmd>Neorg toc split<CR>", opts = { desc = "Open a Table of Contents" } },
+                    { "gO", "<cmd>Neorg toc split<CR>", opts = { desc = "[neorg] Open a Table of Contents" } },
                 },
             }, {
                 silent = true,


### PR DESCRIPTION
closes #1113 

Prefix was not capitalized to be bit more searchable (in case users use case-sensitive search)

---

Command used to to generate the change:

```
sed -i 's/desc = "/desc = "[neorg] /' lua/neorg/modules/core/keybinds/keybinds.lua
stylua lua/neorg/modules/core/keybinds/keybinds.lua
```