### PR TITLE
Add a new strategy `by_path` for summary generation

### DIFF
--- a/lua/neorg/core/lib.lua
+++ b/lua/neorg/core/lib.lua
@@ -386,6 +386,18 @@ function lib.number_wrap(value, min, max)
     return wrapped_value
 end
 
+--- Split a path into its components
+--- example: /my/cool/path/file.txt --> { my, cool, path, file.txt }
+---@param path string #The path to split
+---@return table #The path components
+function lib.tokenize_path(path)
+    local tokens = {}
+    for capture in path:gmatch("[^/\\]+") do
+        table.insert(tokens, capture)
+    end
+    return tokens
+end
+
 --- Lazily copy a table-like object.
 ---@param to_copy table|any #The table to copy. If any other type is provided it will be copied immediately.
 ---@return table #The copied table

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -167,7 +167,8 @@ module.load = function()
                         table.insert(
                             result,
                             table.concat({
-                                "   - {:$",
+                                string.rep(" ", heading_level),
+                                " - {:$",
                                 datapoint.norgname,
                                 ":}[",
                                 lib.title(datapoint.title),


### PR DESCRIPTION
I like to organize my .norg files in subfolders and I'd like to use the names of these subfolders as the category for the files contained in them. With this change the command `generate-workspace-summary` can make use of this information.