### PR TITLE
docs(README): improve lazy.nvim installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,6 @@ You can install it through your favorite plugin manager:
     {
       "nvim-neorg/neorg",
       build = ":Neorg sync-parsers",
-      -- lazy-load on filetype
-      ft = "norg",
       -- tag = "*",
       dependencies = { "nvim-lua/plenary.nvim" },
       config = function()

--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ You can install it through your favorite plugin manager:
     {
       "nvim-neorg/neorg",
       build = ":Neorg sync-parsers",
+      -- lazy-load on filetype
+      ft = "norg",
+      -- tag = "*",
       dependencies = { "nvim-lua/plenary.nvim" },
       config = function()
         require("neorg").setup {


### PR DESCRIPTION
I've added:
1. Lazy loading on file type.
2. The "tag" thingy.