### PR TITLE
fix(export.markdown): fix export of `embed` tags

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -217,7 +217,7 @@ module.public = {
                     0,
                 },
                 tag_indent = 0,
-                tag_close = "",
+                tag_close = nil,
                 ranged_tag_indentation_level = 0,
                 is_url = false,
             }

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -416,8 +416,10 @@ module.public = {
                 elseif
                     text == "embed"
                     and node:next_named_sibling()
-                    and module.required["core.integrations.treesitter"].get_node_text(node:next_named_sibling())
-                        == "markdown"
+                    and vim.tbl_contains(
+                        { "markdown", "html" },
+                        module.required["core.integrations.treesitter"].get_node_text(node:next_named_sibling())
+                    )
                 then
                     return {
                         state = {

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -151,6 +151,7 @@ module.load = function()
             "definition-lists",
             "mathematics",
             "metadata",
+            "latex",
         }
     end
 
@@ -162,7 +163,7 @@ module.config.public = {
     -- default no extensions are loaded (the exporter is commonmark compliant).
     -- You can also set this value to `"all"` to enable all extensions.
     -- The full extension list is: `todo-items-basic`, `todo-items-pending`, `todo-items-extended`,
-    -- `definition-lists`, `mathematics` and `metadata`.
+    -- `definition-lists`, `mathematics`, `metadata` and `latex`.
     extensions = {},
 
     -- Data about how to render mathematics.
@@ -417,7 +418,7 @@ module.public = {
                     text == "embed"
                     and node:next_named_sibling()
                     and vim.tbl_contains(
-                        { "markdown", "html" },
+                        { "markdown", "html", module.config.public.extensions["latex"] and "latex" or nil },
                         module.required["core.integrations.treesitter"].get_node_text(node:next_named_sibling())
                     )
                 then

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -415,8 +415,8 @@ module.public = {
                     }
                 elseif
                     text == "embed"
-                    and node:next_sibling()
-                    and module.required["core.integrations.treesitter"].get_node_text(node:next_sibling())
+                    and node:next_named_sibling()
+                    and module.required["core.integrations.treesitter"].get_node_text(node:next_named_sibling())
                         == "markdown"
                 then
                     return {

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -162,7 +162,7 @@ module.config.public = {
     -- default no extensions are loaded (the exporter is commonmark compliant).
     -- You can also set this value to `"all"` to enable all extensions.
     -- The full extension list is: `todo-items-basic`, `todo-items-pending`, `todo-items-extended`,
-    -- `definition-lists`, `mathematics` and 'metadata'.
+    -- `definition-lists`, `mathematics` and `metadata`.
     extensions = {},
 
     -- Data about how to render mathematics.


### PR DESCRIPTION
fixes #720, along with markdown embeds not being exported (unless they were the first tag in the file), the first tag on a file always being exported by default, and adds support to export latex `embed` tags (disabled by default through an extension)