### PR TITLE
Feat!: Keybind Refactor

### DIFF
--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -6,207 +6,202 @@ local module = modules.create("core.keybinds.keybinds")
 ---@class core.keybinds
 module.config.public = {
     keybind_presets = {
-        neorg = function(keybinds)
-            local leader = keybinds.leader
+        neorg = function(opts)
+            local leader = opts.leader
+            local default_bindings = {
+                -- Map all the below keybinds only when the "norg" mode is active
+                norg = {
+                    n = {
+                        -- Marks the task under the cursor as "undone"
+                        -- ^mark Task as Undone
+                        [leader .. "tu"] = {
 
-            -- Map all the below keybinds only when the "norg" mode is active
-            keybinds.map_event_to_mode("norg", {
-                n = {
-                    -- Marks the task under the cursor as "undone"
-                    -- ^mark Task as Undone
-                    {
-                        leader .. "tu",
-                        "core.qol.todo_items.todo.task_undone",
-                        opts = { desc = "Mark as Undone" },
+                            "core.qol.todo_items.todo.task_undone",
+                            opts = { desc = "Mark as Undone" },
+                        },
+
+                        -- Marks the task under the cursor as "pending"
+                        -- ^mark Task as Pending
+                        [leader .. "tp"] = {
+
+                            "core.qol.todo_items.todo.task_pending",
+                            opts = { desc = "Mark as Pending" },
+                        },
+
+                        -- Marks the task under the cursor as "done"
+                        -- ^mark Task as Done
+                        [leader .. "td"] = { "core.qol.todo_items.todo.task_done", opts = { desc = "Mark as Done" } },
+
+                        -- Marks the task under the cursor as "on_hold"
+                        -- ^mark Task as on Hold
+                        [leader .. "th"] = {
+
+                            "core.qol.todo_items.todo.task_on_hold",
+                            opts = { desc = "Mark as On Hold" },
+                        },
+
+                        -- Marks the task under the cursor as "cancelled"
+                        -- ^mark Task as Cancelled
+                        [leader .. "tc"] = {
+
+                            "core.qol.todo_items.todo.task_cancelled",
+                            opts = { desc = "Mark as Cancelled" },
+                        },
+
+                        -- Marks the task under the cursor as "recurring"
+                        -- ^mark Task as Recurring
+                        [leader .. "tr"] = {
+
+                            "core.qol.todo_items.todo.task_recurring",
+                            opts = { desc = "Mark as Recurring" },
+                        },
+
+                        -- Marks the task under the cursor as "important"
+                        -- ^mark Task as Important
+                        [leader .. "ti"] = {
+
+                            "core.qol.todo_items.todo.task_important",
+                            opts = { desc = "Mark as Important" },
+                        },
+
+                        -- Marks the task under the cursor as "ambiguous"
+                        -- ^mark Task as ambiguous
+                        [leader .. "ta"] = {
+
+                            "core.qol.todo_items.todo.task_ambiguous",
+                            opts = { desc = "Mark as Ambigous" },
+                        },
+
+                        -- Switches the task under the cursor between a select few states
+                        ["<C-Space>"] = { "core.qol.todo_items.todo.task_cycle", opts = { desc = "Cycle Task" } },
+
+                        -- Creates a new .norg file to take notes in
+                        -- ^New Note
+                        [leader .. "nn"] = { "core.dirman.new.note", opts = { desc = "Create New Note" } },
+
+                        -- Hop to the destination of the link under the cursor
+                        ["<CR>"] = { "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                        ["gd"] = { "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                        ["gf"] = { "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                        ["gF"] = { "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+
+                        -- Same as `<CR>`, except opens the destination in a vertical split
+                        ["<M-CR>"] = {
+
+                            "core.esupports.hop.hop-link",
+                            "vsplit",
+                            opts = { desc = "Jump to Link (Vertical Split)" },
+                        },
+
+                        [">."] = { "core.promo.promote", opts = { desc = "Promote Object (Non-Recursively)" } },
+                        ["<,"] = { "core.promo.demote", opts = { desc = "Demote Object (Non-Recursively)" } },
+
+                        [">>"] = { "core.promo.promote", "nested", opts = { desc = "Promote Object (Recursively)" } },
+                        ["<<"] = { "core.promo.demote", "nested", opts = { desc = "Demote Object (Recursively)" } },
+
+                        [leader .. "lt"] = {
+
+                            "core.pivot.toggle-list-type",
+                            opts = { desc = "Toggle (Un)ordered List" },
+                        },
+                        [leader .. "li"] = {
+
+                            "core.pivot.invert-list-type",
+                            opts = { desc = "Invert (Un)ordered List" },
+                        },
+
+                        [leader .. "id"] = { "core.tempus.insert-date", opts = { desc = "Insert Date" } },
                     },
 
-                    -- Marks the task under the cursor as "pending"
-                    -- ^mark Task as Pending
-                    {
-                        leader .. "tp",
-                        "core.qol.todo_items.todo.task_pending",
-                        opts = { desc = "Mark as Pending" },
+                    i = {
+                        ["<C-t>"] = { "core.promo.promote", opts = { desc = "Promote Object (Recursively)" } },
+                        ["<C-d>"] = { "core.promo.demote", opts = { desc = "Demote Object (Recursively)" } },
+                        ["<M-CR>"] = { "core.itero.next-iteration", "<CR>", opts = { desc = "Continue Object" } },
+                        ["<M-d>"] = { "core.tempus.insert-date-insert-mode", opts = { desc = "Insert Date" } },
                     },
 
-                    -- Marks the task under the cursor as "done"
-                    -- ^mark Task as Done
-                    { leader .. "td", "core.qol.todo_items.todo.task_done", opts = { desc = "Mark as Done" } },
-
-                    -- Marks the task under the cursor as "on_hold"
-                    -- ^mark Task as on Hold
-                    {
-                        leader .. "th",
-                        "core.qol.todo_items.todo.task_on_hold",
-                        opts = { desc = "Mark as On Hold" },
-                    },
-
-                    -- Marks the task under the cursor as "cancelled"
-                    -- ^mark Task as Cancelled
-                    {
-                        leader .. "tc",
-                        "core.qol.todo_items.todo.task_cancelled",
-                        opts = { desc = "Mark as Cancelled" },
-                    },
-
-                    -- Marks the task under the cursor as "recurring"
-                    -- ^mark Task as Recurring
-                    {
-                        leader .. "tr",
-                        "core.qol.todo_items.todo.task_recurring",
-                        opts = { desc = "Mark as Recurring" },
-                    },
-
-                    -- Marks the task under the cursor as "important"
-                    -- ^mark Task as Important
-                    {
-                        leader .. "ti",
-                        "core.qol.todo_items.todo.task_important",
-                        opts = { desc = "Mark as Important" },
-                    },
-
-                    -- Marks the task under the cursor as "ambiguous"
-                    -- ^mark Task as ambiguous
-                    {
-                        leader .. "ta",
-                        "core.qol.todo_items.todo.task_ambiguous",
-                        opts = { desc = "Mark as Ambigous" },
-                    },
-
-                    -- Switches the task under the cursor between a select few states
-                    { "<C-Space>", "core.qol.todo_items.todo.task_cycle", opts = { desc = "Cycle Task" } },
-
-                    -- Creates a new .norg file to take notes in
-                    -- ^New Note
-                    { leader .. "nn", "core.dirman.new.note", opts = { desc = "Create New Note" } },
-
-                    -- Hop to the destination of the link under the cursor
-                    { "<CR>", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gd", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gf", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-                    { "gF", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
-
-                    -- Same as `<CR>`, except opens the destination in a vertical split
-                    {
-                        "<M-CR>",
-                        "core.esupports.hop.hop-link",
-                        "vsplit",
-                        opts = { desc = "Jump to Link (Vertical Split)" },
-                    },
-
-                    { ">.", "core.promo.promote", opts = { desc = "Promote Object (Non-Recursively)" } },
-                    { "<,", "core.promo.demote", opts = { desc = "Demote Object (Non-Recursively)" } },
-
-                    { ">>", "core.promo.promote", "nested", opts = { desc = "Promote Object (Recursively)" } },
-                    { "<<", "core.promo.demote", "nested", opts = { desc = "Demote Object (Recursively)" } },
-
-                    {
-                        leader .. "lt",
-                        "core.pivot.toggle-list-type",
-                        opts = { desc = "Toggle (Un)ordered List" },
-                    },
-                    {
-                        leader .. "li",
-                        "core.pivot.invert-list-type",
-                        opts = { desc = "Invert (Un)ordered List" },
-                    },
-
-                    { leader .. "id", "core.tempus.insert-date", opts = { desc = "Insert Date" } },
+                    -- TODO: Readd these
+                    -- v = {
+                    --     { ">>", ":<cr><cmd>Neorg keybind all core.promo.promote_range<cr>" },
+                    --     { "<<", ":<cr><cmd>Neorg keybind all core.promo.demote_range<cr>" },
+                    -- },
                 },
 
-                i = {
-                    { "<C-t>", "core.promo.promote", opts = { desc = "Promote Object (Recursively)" } },
-                    { "<C-d>", "core.promo.demote", opts = { desc = "Demote Object (Recursively)" } },
-                    { "<M-CR>", "core.itero.next-iteration", "<CR>", opts = { desc = "Continue Object" } },
-                    { "<M-d>", "core.tempus.insert-date-insert-mode", opts = { desc = "Insert Date" } },
-                },
+                -- Map the below keys only when traverse-heading mode is active
+                ["traverse-heading"] = {
+                    n = {
+                        -- Move to the next heading in the document
+                        j = {
+                            "core.integrations.treesitter.next.heading",
+                            opts = { desc = "Move to Next Heading" },
+                        },
 
-                -- TODO: Readd these
-                -- v = {
-                --     { ">>", ":<cr><cmd>Neorg keybind all core.promo.promote_range<cr>" },
-                --     { "<<", ":<cr><cmd>Neorg keybind all core.promo.demote_range<cr>" },
-                -- },
-            }, {
-                silent = true,
-                noremap = true,
-            })
-
-            -- Map the below keys only when traverse-heading mode is active
-            keybinds.map_event_to_mode("traverse-heading", {
-                n = {
-                    -- Move to the next heading in the document
-                    {
-                        "j",
-                        "core.integrations.treesitter.next.heading",
-                        opts = { desc = "Move to Next Heading" },
-                    },
-
-                    -- Move to the previous heading in the document
-                    {
-                        "k",
-                        "core.integrations.treesitter.previous.heading",
-                        opts = { desc = "Move to Previous Heading" },
+                        -- Move to the previous heading in the document
+                        k = {
+                            "core.integrations.treesitter.previous.heading",
+                            opts = { desc = "Move to Previous Heading" },
+                        },
                     },
                 },
-            }, {
-                silent = true,
-                noremap = true,
-            })
 
-            -- Map the below keys only when traverse-link mode is active
-            keybinds.map_event_to_mode("traverse-link", {
-                n = {
-                    -- Move to the next link in the document
-                    { "j", "core.integrations.treesitter.next.link", opts = { desc = "Move to Next Link" } },
+                -- Map the below keys only when traverse-link mode is active
+                ["traverse-link"] = {
+                    n = {
+                        -- Move to the next link in the document
+                        j = { "core.integrations.treesitter.next.link", opts = { desc = "Move to Next Link" } },
 
-                    -- Move to the previous link in the document
-                    {
-                        "k",
-                        "core.integrations.treesitter.previous.link",
-                        opts = { desc = "Move to Previous Link" },
+                        -- Move to the previous link in the document
+                        k = {
+                            "core.integrations.treesitter.previous.link",
+                            opts = { desc = "Move to Previous Link" },
+                        },
                     },
                 },
-            }, {
-                silent = true,
-                noremap = true,
-            })
 
-            -- Map the below keys on presenter mode
-            keybinds.map_event_to_mode("presenter", {
-                n = {
-                    { "<CR>", "core.presenter.next_page", opts = { desc = "Next Page" } },
-                    { "l", "core.presenter.next_page", opts = { desc = "Next Page" } },
-                    { "h", "core.presenter.previous_page", opts = { desc = "Previous Page" } },
+                -- Map the below keys on presenter mode
+                presenter = {
+                    n = {
+                        ["<CR>"] = { "core.presenter.next_page", opts = { desc = "Next Page" } },
+                        l = { "core.presenter.next_page", opts = { desc = "Next Page" } },
+                        h = { "core.presenter.previous_page", opts = { desc = "Previous Page" } },
 
-                    -- Keys for closing the current display
-                    { "q", "core.presenter.close", opts = { desc = "Close Presentation" } },
-                    { "<Esc>", "core.presenter.close", opts = { desc = "Close Presentation" } },
-                },
-            }, {
-                silent = true,
-                noremap = true,
-                nowait = true,
-            })
-
-            -- Apply the below keys to all modes
-            keybinds.map_to_mode("all", {
-                n = {
-                    { leader .. "mn", "<cmd>Neorg mode norg<CR>", opts = { desc = "Enter Norg Mode" } },
-                    {
-                        leader .. "mh",
-                        "<cmd>Neorg mode traverse-heading<CR>",
-                        opts = { desc = "Enter Heading Traversal Mode" },
+                        -- Keys for closing the current display
+                        q = { "core.presenter.close", opts = { desc = "Close Presentation" } },
+                        ["<Esc>"] = { "core.presenter.close", opts = { desc = "Close Presentation" } },
                     },
-                    {
-                        leader .. "ml",
-                        "<cmd>Neorg mode traverse-link<CR>",
-                        opts = { desc = "Enter Link Traversal Mode" },
-                    },
-                    { "gO", "<cmd>Neorg toc split<CR>", opts = { desc = "Open a Table of Contents" } },
                 },
-            }, {
-                silent = true,
-                noremap = true,
-            })
+
+                -- Apply the below keys to all modes
+                all = {
+                    n = {
+                        [leader .. "mn"] = {
+                            function()
+                                vim.cmd("Neorg mode norg")
+                            end,
+                            opts = { desc = "Enter Norg Mode" },
+                        },
+                        [leader .. "mh"] = {
+                            function()
+                                vim.cmd("Neorg mode traverse-heading")
+                            end,
+                            opts = { desc = "Enter Heading Traversal Mode" },
+                        },
+                        [leader .. "ml"] = {
+                            function()
+                                vim.cmd("Neorg mode traverse-link")
+                            end,
+                            opts = { desc = "Enter Link Traversal Mode" },
+                        },
+                        ["gO"] = {
+                            function()
+                                vim.cmd("Neorg toc split")
+                            end,
+                            opts = { desc = "Open a Table of Contents" },
+                        },
+                    },
+                },
+            }
+            return vim.tbl_deep_extend("force", default_bindings, opts.overwrite)
         end,
     },
 }

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -15,7 +15,6 @@ module.config.public = {
                         -- Marks the task under the cursor as "undone"
                         -- ^mark Task as Undone
                         [leader .. "tu"] = {
-
                             "core.qol.todo_items.todo.task_undone",
                             opts = { desc = "Mark as Undone" },
                         },
@@ -23,7 +22,6 @@ module.config.public = {
                         -- Marks the task under the cursor as "pending"
                         -- ^mark Task as Pending
                         [leader .. "tp"] = {
-
                             "core.qol.todo_items.todo.task_pending",
                             opts = { desc = "Mark as Pending" },
                         },
@@ -35,7 +33,6 @@ module.config.public = {
                         -- Marks the task under the cursor as "on_hold"
                         -- ^mark Task as on Hold
                         [leader .. "th"] = {
-
                             "core.qol.todo_items.todo.task_on_hold",
                             opts = { desc = "Mark as On Hold" },
                         },
@@ -43,7 +40,6 @@ module.config.public = {
                         -- Marks the task under the cursor as "cancelled"
                         -- ^mark Task as Cancelled
                         [leader .. "tc"] = {
-
                             "core.qol.todo_items.todo.task_cancelled",
                             opts = { desc = "Mark as Cancelled" },
                         },
@@ -51,7 +47,6 @@ module.config.public = {
                         -- Marks the task under the cursor as "recurring"
                         -- ^mark Task as Recurring
                         [leader .. "tr"] = {
-
                             "core.qol.todo_items.todo.task_recurring",
                             opts = { desc = "Mark as Recurring" },
                         },
@@ -59,7 +54,6 @@ module.config.public = {
                         -- Marks the task under the cursor as "important"
                         -- ^mark Task as Important
                         [leader .. "ti"] = {
-
                             "core.qol.todo_items.todo.task_important",
                             opts = { desc = "Mark as Important" },
                         },
@@ -67,7 +61,6 @@ module.config.public = {
                         -- Marks the task under the cursor as "ambiguous"
                         -- ^mark Task as ambiguous
                         [leader .. "ta"] = {
-
                             "core.qol.todo_items.todo.task_ambiguous",
                             opts = { desc = "Mark as Ambigous" },
                         },
@@ -87,7 +80,6 @@ module.config.public = {
 
                         -- Same as `<CR>`, except opens the destination in a vertical split
                         ["<M-CR>"] = {
-
                             "core.esupports.hop.hop-link",
                             "vsplit",
                             opts = { desc = "Jump to Link (Vertical Split)" },
@@ -100,12 +92,10 @@ module.config.public = {
                         ["<<"] = { "core.promo.demote", "nested", opts = { desc = "Demote Object (Recursively)" } },
 
                         [leader .. "lt"] = {
-
                             "core.pivot.toggle-list-type",
                             opts = { desc = "Toggle (Un)ordered List" },
                         },
                         [leader .. "li"] = {
-
                             "core.pivot.invert-list-type",
                             opts = { desc = "Invert (Un)ordered List" },
                         },

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -17,7 +17,7 @@ module.config.public = {
                     {
                         leader .. "tu",
                         "core.qol.todo_items.todo.task_undone",
-                        opts = { desc = "[neorg] Mark as Undone" },
+                        opts = { desc = "Mark as Undone" },
                     },
 
                     -- Marks the task under the cursor as "pending"
@@ -25,19 +25,19 @@ module.config.public = {
                     {
                         leader .. "tp",
                         "core.qol.todo_items.todo.task_pending",
-                        opts = { desc = "[neorg] Mark as Pending" },
+                        opts = { desc = "Mark as Pending" },
                     },
 
                     -- Marks the task under the cursor as "done"
                     -- ^mark Task as Done
-                    { leader .. "td", "core.qol.todo_items.todo.task_done", opts = { desc = "[neorg] Mark as Done" } },
+                    { leader .. "td", "core.qol.todo_items.todo.task_done", opts = { desc = "Mark as Done" } },
 
                     -- Marks the task under the cursor as "on_hold"
                     -- ^mark Task as on Hold
                     {
                         leader .. "th",
                         "core.qol.todo_items.todo.task_on_hold",
-                        opts = { desc = "[neorg] Mark as On Hold" },
+                        opts = { desc = "Mark as On Hold" },
                     },
 
                     -- Marks the task under the cursor as "cancelled"
@@ -45,7 +45,7 @@ module.config.public = {
                     {
                         leader .. "tc",
                         "core.qol.todo_items.todo.task_cancelled",
-                        opts = { desc = "[neorg] Mark as Cancelled" },
+                        opts = { desc = "Mark as Cancelled" },
                     },
 
                     -- Marks the task under the cursor as "recurring"
@@ -53,7 +53,7 @@ module.config.public = {
                     {
                         leader .. "tr",
                         "core.qol.todo_items.todo.task_recurring",
-                        opts = { desc = "[neorg] Mark as Recurring" },
+                        opts = { desc = "Mark as Recurring" },
                     },
 
                     -- Marks the task under the cursor as "important"
@@ -61,7 +61,7 @@ module.config.public = {
                     {
                         leader .. "ti",
                         "core.qol.todo_items.todo.task_important",
-                        opts = { desc = "[neorg] Mark as Important" },
+                        opts = { desc = "Mark as Important" },
                     },
 
                     -- Marks the task under the cursor as "ambiguous"
@@ -69,55 +69,55 @@ module.config.public = {
                     {
                         leader .. "ta",
                         "core.qol.todo_items.todo.task_ambiguous",
-                        opts = { desc = "[neorg] Mark as Ambigous" },
+                        opts = { desc = "Mark as Ambigous" },
                     },
 
                     -- Switches the task under the cursor between a select few states
-                    { "<C-Space>", "core.qol.todo_items.todo.task_cycle", opts = { desc = "[neorg] Cycle Task" } },
+                    { "<C-Space>", "core.qol.todo_items.todo.task_cycle", opts = { desc = "Cycle Task" } },
 
                     -- Creates a new .norg file to take notes in
                     -- ^New Note
-                    { leader .. "nn", "core.dirman.new.note", opts = { desc = "[neorg] Create New Note" } },
+                    { leader .. "nn", "core.dirman.new.note", opts = { desc = "Create New Note" } },
 
                     -- Hop to the destination of the link under the cursor
-                    { "<CR>", "core.esupports.hop.hop-link", opts = { desc = "[neorg] Jump to Link" } },
-                    { "gd", "core.esupports.hop.hop-link", opts = { desc = "[neorg] Jump to Link" } },
-                    { "gf", "core.esupports.hop.hop-link", opts = { desc = "[neorg] Jump to Link" } },
-                    { "gF", "core.esupports.hop.hop-link", opts = { desc = "[neorg] Jump to Link" } },
+                    { "<CR>", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                    { "gd", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                    { "gf", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
+                    { "gF", "core.esupports.hop.hop-link", opts = { desc = "Jump to Link" } },
 
                     -- Same as `<CR>`, except opens the destination in a vertical split
                     {
                         "<M-CR>",
                         "core.esupports.hop.hop-link",
                         "vsplit",
-                        opts = { desc = "[neorg] Jump to Link (Vertical Split)" },
+                        opts = { desc = "Jump to Link (Vertical Split)" },
                     },
 
-                    { ">.", "core.promo.promote", opts = { desc = "[neorg] Promote Object (Non-Recursively)" } },
-                    { "<,", "core.promo.demote", opts = { desc = "[neorg] Demote Object (Non-Recursively)" } },
+                    { ">.", "core.promo.promote", opts = { desc = "Promote Object (Non-Recursively)" } },
+                    { "<,", "core.promo.demote", opts = { desc = "Demote Object (Non-Recursively)" } },
 
-                    { ">>", "core.promo.promote", "nested", opts = { desc = "[neorg] Promote Object (Recursively)" } },
-                    { "<<", "core.promo.demote", "nested", opts = { desc = "[neorg] Demote Object (Recursively)" } },
+                    { ">>", "core.promo.promote", "nested", opts = { desc = "Promote Object (Recursively)" } },
+                    { "<<", "core.promo.demote", "nested", opts = { desc = "Demote Object (Recursively)" } },
 
                     {
                         leader .. "lt",
                         "core.pivot.toggle-list-type",
-                        opts = { desc = "[neorg] Toggle (Un)ordered List" },
+                        opts = { desc = "Toggle (Un)ordered List" },
                     },
                     {
                         leader .. "li",
                         "core.pivot.invert-list-type",
-                        opts = { desc = "[neorg] Invert (Un)ordered List" },
+                        opts = { desc = "Invert (Un)ordered List" },
                     },
 
-                    { leader .. "id", "core.tempus.insert-date", opts = { desc = "[neorg] Insert Date" } },
+                    { leader .. "id", "core.tempus.insert-date", opts = { desc = "Insert Date" } },
                 },
 
                 i = {
-                    { "<C-t>", "core.promo.promote", opts = { desc = "[neorg] Promote Object (Recursively)" } },
-                    { "<C-d>", "core.promo.demote", opts = { desc = "[neorg] Demote Object (Recursively)" } },
-                    { "<M-CR>", "core.itero.next-iteration", "<CR>", opts = { desc = "[neorg] Continue Object" } },
-                    { "<M-d>", "core.tempus.insert-date-insert-mode", opts = { desc = "[neorg] Insert Date" } },
+                    { "<C-t>", "core.promo.promote", opts = { desc = "Promote Object (Recursively)" } },
+                    { "<C-d>", "core.promo.demote", opts = { desc = "Demote Object (Recursively)" } },
+                    { "<M-CR>", "core.itero.next-iteration", "<CR>", opts = { desc = "Continue Object" } },
+                    { "<M-d>", "core.tempus.insert-date-insert-mode", opts = { desc = "Insert Date" } },
                 },
 
                 -- TODO: Readd these
@@ -137,14 +137,14 @@ module.config.public = {
                     {
                         "j",
                         "core.integrations.treesitter.next.heading",
-                        opts = { desc = "[neorg] Move to Next Heading" },
+                        opts = { desc = "Move to Next Heading" },
                     },
 
                     -- Move to the previous heading in the document
                     {
                         "k",
                         "core.integrations.treesitter.previous.heading",
-                        opts = { desc = "[neorg] Move to Previous Heading" },
+                        opts = { desc = "Move to Previous Heading" },
                     },
                 },
             }, {
@@ -156,13 +156,13 @@ module.config.public = {
             keybinds.map_event_to_mode("traverse-link", {
                 n = {
                     -- Move to the next link in the document
-                    { "j", "core.integrations.treesitter.next.link", opts = { desc = "[neorg] Move to Next Link" } },
+                    { "j", "core.integrations.treesitter.next.link", opts = { desc = "Move to Next Link" } },
 
                     -- Move to the previous link in the document
                     {
                         "k",
                         "core.integrations.treesitter.previous.link",
-                        opts = { desc = "[neorg] Move to Previous Link" },
+                        opts = { desc = "Move to Previous Link" },
                     },
                 },
             }, {
@@ -173,13 +173,13 @@ module.config.public = {
             -- Map the below keys on presenter mode
             keybinds.map_event_to_mode("presenter", {
                 n = {
-                    { "<CR>", "core.presenter.next_page", opts = { desc = "[neorg] Next Page" } },
-                    { "l", "core.presenter.next_page", opts = { desc = "[neorg] Next Page" } },
-                    { "h", "core.presenter.previous_page", opts = { desc = "[neorg] Previous Page" } },
+                    { "<CR>", "core.presenter.next_page", opts = { desc = "Next Page" } },
+                    { "l", "core.presenter.next_page", opts = { desc = "Next Page" } },
+                    { "h", "core.presenter.previous_page", opts = { desc = "Previous Page" } },
 
                     -- Keys for closing the current display
-                    { "q", "core.presenter.close", opts = { desc = "[neorg] Close Presentation" } },
-                    { "<Esc>", "core.presenter.close", opts = { desc = "[neorg] Close Presentation" } },
+                    { "q", "core.presenter.close", opts = { desc = "Close Presentation" } },
+                    { "<Esc>", "core.presenter.close", opts = { desc = "Close Presentation" } },
                 },
             }, {
                 silent = true,
@@ -190,18 +190,18 @@ module.config.public = {
             -- Apply the below keys to all modes
             keybinds.map_to_mode("all", {
                 n = {
-                    { leader .. "mn", "<cmd>Neorg mode norg<CR>", opts = { desc = "[neorg] Enter Norg Mode" } },
+                    { leader .. "mn", "<cmd>Neorg mode norg<CR>", opts = { desc = "Enter Norg Mode" } },
                     {
                         leader .. "mh",
                         "<cmd>Neorg mode traverse-heading<CR>",
-                        opts = { desc = "[neorg] Enter Heading Traversal Mode" },
+                        opts = { desc = "Enter Heading Traversal Mode" },
                     },
                     {
                         leader .. "ml",
                         "<cmd>Neorg mode traverse-link<CR>",
-                        opts = { desc = "[neorg] Enter Link Traversal Mode" },
+                        opts = { desc = "Enter Link Traversal Mode" },
                     },
-                    { "gO", "<cmd>Neorg toc split<CR>", opts = { desc = "[neorg] Open a Table of Contents" } },
+                    { "gO", "<cmd>Neorg toc split<CR>", opts = { desc = "Open a Table of Contents" } },
                 },
             }, {
                 silent = true,

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -381,6 +381,10 @@ module.public = {
                                         local opts = data.opts or {}
                                         opts.buffer = buf
 
+                                        if opts.desc and not vim.startswith(opts.desc, "[neorg]") then
+                                            opts.desc = "[neorg] " .. opts.desc
+                                        end
+
                                         vim.keymap.set(mode, key, data.command, opts)
                                     end
                                 end)


### PR DESCRIPTION
### Todo:
Function to detect conflicts which will automatically cleanup the keybinds table (if that's wanted).
Not yet done because it's not clear whether a conflicting keybind should still be set or not. A warning would be omitted in any case.
Perhaps that could also be something displayed in a healthcheck. -> would have to get merged table before setting keymaps and `vim.keymap.get` all of them to see if they are set to something