### PR TITLE
feat(summary): add strategy which categorizes current directory only

### DIFF
--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -203,7 +203,7 @@ module.load = function()
                 -- get files in current directory
                 for name, type in scanned_dir do
                     if type == "file" and vim.endswith(name, ".norg") then
-                        table.insert(files, path .. "/" .. name)
+                        table.insert(files, "/" .. path .. "/" .. name)
                     end
                     -- if directory, add it straight to categories
                     if type == "directory" then
@@ -213,7 +213,7 @@ module.load = function()
                             f:close()
                             table.insert(categories["Directories"], {
                                 title = tostring(name),
-                                norgname = name .. "/index",
+                                norgname = "/" .. name .. "/index",
                             })
                         end
                     end

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -209,7 +209,7 @@ module.load = function()
                     if type == "directory" then
                         local child = path .. "/" .. name .. "/" .. "index.norg"
                         local f = io.open(child, "r")
-                        if f ~= nil then
+                        if f ~= nil and not include_categories then
                             f:close()
                             table.insert(categories["Directories"], {
                                 title = tostring(name),


### PR DESCRIPTION
### Why

I like to structure my notes in hierarchial manner inside folders. However, the workspace summary creates a summary of the whole workspace, even though I would like to create a summary of only current directory, creating links to subfolder index files. And that is what these modifications do.

### What

I added new strategy `current_dir` which creates links to subfolder `index.norg` files and categorizes the regular files in the directory as before. If subdirectory does not contain index.norg file, it is not created and the link is not added.

### Open points / problems

- What I did, I just copied the default strategy and modified the beginning of it a little. However, this leads the module to have quite a lot of duplicated code.
- I also had to read the files of the current directory again, which is inefficient.

P.S. This is my first pull request to open source project ever. I hope the changes are not too bad.