### PR TITLE
[Lua]: Add annotations to the core codebase.

### DIFF
--- a/lua/neorg.lua
+++ b/lua/neorg.lua
@@ -5,6 +5,8 @@
 local neorg = require("neorg.core")
 local config, log, modules = neorg.config, neorg.log, neorg.modules
 
+--- @module "neorg.core.config"
+
 --- Initializes Neorg. Parses the supplied user configuration, initializes all selected modules and adds filetype checking for `.norg`.
 --- @param cfg neorg.configuration.user A table that reflects the structure of `config.user_config`.
 --- @see config.user_config

--- a/lua/neorg.lua
+++ b/lua/neorg.lua
@@ -1,35 +1,33 @@
---[[
---    ROOT NEORG FILE
---    This file is the beginning of the entire plugin. It's here that everything fires up and starts pumping.
---]]
+--- @brief [[
+--- This file marks the beginning of the entire plugin. It's here that everything fires up and starts pumping.
+--- @brief ]]
 
--- Require the most important modules
 local neorg = require("neorg.core")
 local config, log, modules = neorg.config, neorg.log, neorg.modules
 
---- This function takes in a user config, parses it, initializes everything and launches neorg if inside a .norg or .org file
----@param cfg table #A table that reflects the structure of config.user_config
+--- Initializes Neorg. Parses the supplied user configuration, initializes all selected modules and adds filetype checking for `.norg`.
+--- @param cfg table A table that reflects the structure of `config.user_config`.
+--- @see config.user_config
 function neorg.setup(cfg)
     config.user_config = vim.tbl_deep_extend("force", config.user_config, cfg or {})
 
-    -- Create a new global instance of the neorg logger
+    -- Create a new global instance of the neorg logger.
     log.new(config.user_config.logger or log.get_default_config(), true)
 
-    -- Make the Neorg filetype detectable through `vim.filetype`.
-    -- TODO: Make a PR to Neovim to natively support the org and norg
-    -- filetypes.
+    -- TODO(vhyrro): Remove this after Neovim 0.10, where `norg` files will be
+    -- detected automatically.
     vim.filetype.add({
         extension = {
             norg = "norg",
         },
     })
 
-    -- If the file we have entered has a .norg extension
+    -- If the file we have entered has a `.norg` extension:
     if vim.fn.expand("%:e") == "norg" or not config.user_config.lazy_loading then
-        -- Then boot up the environment
+        -- Then boot up the environment.
         neorg.org_file_entered(false)
     else
-        -- Else listen for a BufReadPost event and fire up the Neorg environment
+        -- Else listen for a BufReadPost event for `.norg` files and fire up the Neorg environment.
         vim.cmd([[
             autocmd BufAdd *.norg ++once :lua require('neorg').org_file_entered(false)
             command! -nargs=* NeorgStart delcommand NeorgStart | lua require('neorg').org_file_entered(true, <q-args>)
@@ -45,8 +43,8 @@ function neorg.setup(cfg)
 end
 
 --- This function gets called upon entering a .norg file and loads all of the user-defined modules.
----@param manual boolean #If true then the environment was kickstarted manually by the user
----@param arguments string? #A list of arguments in the format of "key=value other_key=other_value"
+--- @param manual boolean If true then the environment was kickstarted manually by the user.
+--- @param arguments string? A list of arguments in the format of "key=value other_key=other_value".
 function neorg.org_file_entered(manual, arguments)
     -- Extract the module list from the user config
     local module_list = config.user_config and config.user_config.load or {}
@@ -124,7 +122,7 @@ function neorg.org_file_entered(manual, arguments)
 end
 
 --- Returns whether or not Neorg is loaded
----@return boolean
+--- @return boolean
 function neorg.is_loaded()
     return config.started
 end

--- a/lua/neorg.lua
+++ b/lua/neorg.lua
@@ -6,8 +6,9 @@ local neorg = require("neorg.core")
 local config, log, modules = neorg.config, neorg.log, neorg.modules
 
 --- Initializes Neorg. Parses the supplied user configuration, initializes all selected modules and adds filetype checking for `.norg`.
---- @param cfg table A table that reflects the structure of `config.user_config`.
+--- @param cfg neorg.configuration.user A table that reflects the structure of `config.user_config`.
 --- @see config.user_config
+--- @see neorg.configuration.user
 function neorg.setup(cfg)
     config.user_config = vim.tbl_deep_extend("force", config.user_config, cfg or {})
 
@@ -113,6 +114,9 @@ function neorg.org_file_entered(manual, arguments)
         referrer = "core",
         line_content = "",
         broadcast = true,
+        buffer = vim.api.nvim_get_current_buf(),
+        window = vim.api.nvim_get_current_win(),
+        mode = vim.fn.mode(),
     })
 
     -- Sometimes external plugins prefer hooking in to an autocommand

--- a/lua/neorg/core/callbacks.lua
+++ b/lua/neorg/core/callbacks.lua
@@ -2,6 +2,8 @@
 --- Defines user callbacks - ways for the user to directly interact with Neorg and respon on certain events.
 --- @brief ]]
 
+--- @module "neorg.core.modules"
+
 --- @class neorg.callbacks
 local callbacks = {
     ---@type table<string, { [1]: fun(event: neorg.event, content: table|any), [2]?: fun(event: neorg.event): boolean }>

--- a/lua/neorg/core/callbacks.lua
+++ b/lua/neorg/core/callbacks.lua
@@ -1,16 +1,17 @@
---[[
-    Neorg User Callbacks File
-    User callbacks are ways for the user to directly interact with Neorg and respond on certain events.
---]]
+--- @brief [[
+--- Defines user callbacks - ways for the user to directly interact with Neorg and respon on certain events.
+--- @brief ]]
 
+--- @class neorg.callbacks
 local callbacks = {
+    ---@type table<string, { [1]: fun(event: neorg.event, content: table|any), [2]?: fun(event: neorg.event): boolean }>
     callback_list = {},
 }
 
---- Triggers a new callback to execute whenever an event of the requested type is executed
----@param event_name string #The full path to the event we want to listen on
----@param callback fun(event, content) #The function to call whenever our event gets triggered
----@param content_filter fun(event) #A filtering function to test if a certain event meets our expectations
+--- Triggers a new callback to execute whenever an event of the requested type is executed.
+--- @param event_name string The full path to the event we want to listen on.
+--- @param callback fun(event: neorg.event, content: table|any) The function to call whenever our event gets triggered.
+--- @param content_filter fun(event: neorg.event): boolean # A filtering function to test if a certain event meets our expectations.
 function callbacks.on_event(event_name, callback, content_filter)
     -- If the table doesn't exist then create it
     callbacks.callback_list[event_name] = callbacks.callback_list[event_name] or {}
@@ -18,8 +19,9 @@ function callbacks.on_event(event_name, callback, content_filter)
     table.insert(callbacks.callback_list[event_name], { callback, content_filter })
 end
 
---- Used internally by Neorg to call all callbacks with an event
----@param event table #An event as returned by modules.create_event()
+--- Used internally by Neorg to call all callbacks with an event.
+--- @param event neorg.event An event as returned by `modules.create_event()`
+--- @see modules.create_event
 function callbacks.handle_callbacks(event)
     -- Query the list of registered callbacks
     local callback_entry = callbacks.callback_list[event.type]

--- a/lua/neorg/core/config.lua
+++ b/lua/neorg/core/config.lua
@@ -1,4 +1,34 @@
--- Grab OS info on startup
+--- @brief [[
+--- Defines the configuration table for use throughout Neorg.
+--- @brief ]]
+
+-- TODO(vhyrro): Make `norg_version` and `version` a `Version` class.
+
+--- @alias OperatingSystem
+--- | "windows"
+--- | "wsl"
+--- | "wsl2"
+--- | "mac"
+--- | "linux"
+
+--- @alias neorg.configuration.module { config?: table }
+
+--- @class (exact) neorg.configuration.user
+--- @field lazy_loading boolean                              Whether to defer loading the Neorg core until after the user has entered a `.norg` file.
+--- @field load table<string, neorg.configuration.module>    A list of modules to load, alongside their configurations.
+
+--- @class (exact) neorg.configuration
+--- @field user_config neorg.configuration.user              Stores the configuration provided by the user.
+--- @field modules table<string, neorg.configuration.module> Acts as a copy of the user's configuration that may be modified at runtime.
+--- @field manual boolean?                                   Used if Neorg was manually loaded via `:NeorgStart`. Only applicable when `user_config.lazy_loading` is `true`.
+--- @field arguments table<string, string>                   A list of arguments provided to the `:NeorgStart` function in the form of `key=value` pairs. Only applicable when `user_config.lazy_loading` is `true`.
+--- @field norg_version string                               The version of the file format to be used throughout Neorg. Used internally.
+--- @field version string                                    The version of Neorg that is currently active. Automatically updated by CI on every release.
+--- @field os_info OperatingSystem                           The operating system that Neorg is currently running under.
+--- @field pathsep "\\"|"/"                                  The operating system that Neorg is currently running under.
+
+--- Gets the current operating system.
+--- @return OperatingSystem
 local function get_os_info()
     local os = vim.loop.os_uname().sysname:lower()
 
@@ -19,11 +49,18 @@ local function get_os_info()
         end
         return "linux"
     end
+
+    error("[neorg]: Unable to determine the currently active operating system!")
 end
 
 local os_info = get_os_info()
 
--- Configuration template
+--- Stores the configuration for the entirety of Neorg.
+--- This includes not only the user configuration (passed to `setup()`), but also internal
+--- variables that describe something specific about the user's hardware.
+--- @see neorg.setup
+---
+--- @type neorg.configuration
 local config = {
     user_config = {
         lazy_loading = false,

--- a/lua/neorg/core/config.lua
+++ b/lua/neorg/core/config.lua
@@ -14,18 +14,21 @@
 --- @alias neorg.configuration.module { config?: table }
 
 --- @class (exact) neorg.configuration.user
---- @field lazy_loading boolean                              Whether to defer loading the Neorg core until after the user has entered a `.norg` file.
+--- @field hook? fun(manual: boolean, arguments?: string)    A user-defined function that is invoked whenever Neorg starts up. May be used to e.g. set custom keybindings.
+--- @field lazy_loading? boolean                             Whether to defer loading the Neorg core until after the user has entered a `.norg` file.
 --- @field load table<string, neorg.configuration.module>    A list of modules to load, alongside their configurations.
+--- @field logger? neorg.log.configuration                   A configuration table for the logger.
 
 --- @class (exact) neorg.configuration
---- @field user_config neorg.configuration.user              Stores the configuration provided by the user.
---- @field modules table<string, neorg.configuration.module> Acts as a copy of the user's configuration that may be modified at runtime.
---- @field manual boolean?                                   Used if Neorg was manually loaded via `:NeorgStart`. Only applicable when `user_config.lazy_loading` is `true`.
 --- @field arguments table<string, string>                   A list of arguments provided to the `:NeorgStart` function in the form of `key=value` pairs. Only applicable when `user_config.lazy_loading` is `true`.
+--- @field manual boolean?                                   Used if Neorg was manually loaded via `:NeorgStart`. Only applicable when `user_config.lazy_loading` is `true`.
+--- @field modules table<string, neorg.configuration.module> Acts as a copy of the user's configuration that may be modified at runtime.
 --- @field norg_version string                               The version of the file format to be used throughout Neorg. Used internally.
---- @field version string                                    The version of Neorg that is currently active. Automatically updated by CI on every release.
 --- @field os_info OperatingSystem                           The operating system that Neorg is currently running under.
 --- @field pathsep "\\"|"/"                                  The operating system that Neorg is currently running under.
+--- @field started boolean                                   Set to `true` when Neorg is fully initialized.
+--- @field user_config neorg.configuration.user              Stores the configuration provided by the user.
+--- @field version string                                    The version of Neorg that is currently active. Automatically updated by CI on every release.
 
 --- Gets the current operating system.
 --- @return OperatingSystem
@@ -80,6 +83,9 @@ local config = {
 
     os_info = os_info,
     pathsep = os_info == "windows" and "\\" or "/",
+
+    hook = nil,
+    started = false,
 }
 
 return config

--- a/lua/neorg/core/lib.lua
+++ b/lua/neorg/core/lib.lua
@@ -1,14 +1,9 @@
-local lib = {
-    -- TODO: Are the mod functions used anywhere?
-    mod = { --- Modifiers for the `map` function
-        exclude = {}, --- Filtering modifiers that exclude certain elements from a table
-    },
-}
+local lib = {}
 
---- Returns the item that matches the first item in statements
----@param value any #The value to compare against
----@param compare? function #A custom comparison function
----@return function #A function to invoke with a table of potential matches
+--- Returns the item that matches the first item in statements.
+--- @param value any The value to compare against.
+--- @param compare? fun(lhs: any, rhs: any): boolean A custom comparison function.
+--- @return fun(statements: table<any, any>): any # A function to invoke with a table of potential matches.
 function lib.match(value, compare)
     -- Returning a function allows for such syntax:
     -- match(something) { ..matches.. }
@@ -74,11 +69,12 @@ function lib.match(value, compare)
     end
 end
 
---- Wrapped around `match()` that performs an action based on a condition
----@param comparison boolean #The comparison to perform
----@param when_true function|any #The value to return when `comparison` is true
----@param when_false function|any #The value to return when `comparison` is false
----@return any #The value that either `when_true` or `when_false` returned
+--- Wrapped around `match()` that performs an action based on a condition.
+--- @param comparison boolean The comparison to perform.
+--- @param when_true function|any The value to return when `comparison` is true.
+--- @param when_false function|any The value to return when `comparison` is false.
+--- @return any # The value that either `when_true` or `when_false` returned.
+--- @see neorg.core.lib.match
 function lib.when(comparison, when_true, when_false)
     if type(comparison) ~= "boolean" then
         comparison = (comparison ~= nil)
@@ -90,12 +86,13 @@ function lib.when(comparison, when_true, when_false)
     })
 end
 
---- Maps a function to every element of a table
---  The function can return a value, in which case that specific element will be assigned
---  the return value of that function.
----@param tbl table #The table to iterate over
----@param callback function #The callback that should be invoked on every iteration
----@return table #A modified version of the original `tbl`.
+--- Maps a function to every element of a table.
+--- The function can return a value, in which case that specific element will be assigned
+--- the return value of that function.
+--- @generic K, V
+--- @param tbl table<K, V> The table to iterate over
+--- @param callback fun(key: K, value: V, tbl: table<K, V>): any? The callback that should be invoked on every iteration
+--- @return table # A modified version of the original `tbl`.
 function lib.map(tbl, callback)
     local copy = vim.deepcopy(tbl)
 
@@ -111,10 +108,10 @@ function lib.map(tbl, callback)
 end
 
 --- Iterates over all elements of a table and returns the first value returned by the callback.
----@param tbl table #The table to iterate over
----@param callback function #The callback function that should be invoked on each iteration.
---- Can return a value in which case that value will be returned from the `filter()` call.
----@return any|nil #The value returned by `callback`, if any
+--- @generic K, V
+--- @param tbl table<K, V> The table to iterate over.
+--- @param callback fun(key: K, value: V): V? The callback function that should be invoked on each iteration. Can return a value in which case that value will be returned from the `filter()` call.
+--- @return V? # The value returned by `callback`, if any.
 function lib.filter(tbl, callback)
     for k, v in pairs(tbl) do
         local cb = callback(k, v)
@@ -125,10 +122,11 @@ function lib.filter(tbl, callback)
     end
 end
 
---- Finds any key in an array
----@param tbl any #An array of values to iterate over ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
----@param element any #The item to find
----@return any|nil #The found value or `nil` if nothing could be found
+--- Finds any key in an array.
+--- @generic V
+--- @param tbl { [number]: V } An array of values to iterate over.
+--- @param element V The item to find.
+--- @return V? # The found value or `nil` if nothing could be found.
 function lib.find(tbl, element)
     return lib.filter(tbl, function(key, value)
         if value == element then
@@ -138,9 +136,9 @@ function lib.find(tbl, element)
 end
 
 --- Inserts a value into a table if it doesn't exist, else returns the existing value.
----@param tbl table #The table to insert into
----@param value number|string #The value to insert
----@return any #The item to return
+--- @param tbl table The table to insert into.
+--- @param value any The value to insert.
+--- @return `value` # The item to return.
 function lib.insert_or(tbl, value)
     local item = lib.find(tbl, value)
 
@@ -150,10 +148,10 @@ function lib.insert_or(tbl, value)
     end)()
 end
 
---- Picks a set of values from a table and returns them in an array
----@param tbl table #The table to extract the keys from
----@param values any array[string] #An array of strings, these being the keys you'd like to extract ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
----@return any array[any] #The picked values from the table ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+--- Picks a set of values from a table and returns them in an array.
+--- @param tbl table The table to extract the keys from.
+--- @param values string[] An array of strings, these being the keys you'd like to extract.
+--- @return any # The picked values from the table.
 function lib.pick(tbl, values)
     local result = {}
 
@@ -167,9 +165,9 @@ function lib.pick(tbl, values)
 end
 
 --- Tries to extract a variable in all nesting levels of a table.
----@param tbl table #The table to traverse
----@param value any #The value to look for - note that comparison is done through the `==` operator
----@return any|nil #The value if it was found, else nil
+--- @param tbl table The table to traverse.
+--- @param value any The value to look for - note that comparison is done through the `==` operator.
+--- @return any? # The value if it was found, else nil.
 function lib.extract(tbl, value)
     local results = {}
 
@@ -186,10 +184,10 @@ function lib.extract(tbl, value)
     return results
 end
 
---- Wraps a conditional "not" function in a vim.tbl callback
----@param cb function #The function to wrap
----@vararg ... #The arguments to pass to the wrapped function
----@return function #The wrapped function in a vim.tbl callback
+--- Wraps a conditional "not" function in a callback.
+--- @param cb function The function to wrap
+--- @param ... any The arguments to pass to the wrapped function
+--- @return function # The wrapped function in a callback
 function lib.wrap_cond_not(cb, ...)
     local params = { ... }
     return function(v)
@@ -197,10 +195,10 @@ function lib.wrap_cond_not(cb, ...)
     end
 end
 
---- Wraps a conditional function in a vim.tbl callback
----@param cb function #The function to wrap
----@vararg ... #The arguments to pass to the wrapped function
----@return function #The wrapped function in a vim.tbl callback
+--- Wraps a conditional function in a callback.
+--- @param cb function The function to wrap.
+--- @param ... any The arguments to pass to the wrapped function.
+--- @return function # The wrapped function in a callback.
 function lib.wrap_cond(cb, ...)
     local params = { ... }
     return function(v)
@@ -208,10 +206,11 @@ function lib.wrap_cond(cb, ...)
     end
 end
 
---- Wraps a function in a callback
----@param function_pointer function #The function to wrap
----@vararg ... #The arguments to pass to the wrapped function
----@return function #The wrapped function in a callback
+--- Wraps a function in a callback.
+--- @generic T: function, A
+--- @param function_pointer T The function to wrap.
+--- @param ... A The arguments to pass to the wrapped function.
+--- @return fun(...: A): T # The wrapped function in a callback.
 function lib.wrap(function_pointer, ...)
     local params = { ... }
 
@@ -219,7 +218,7 @@ function lib.wrap(function_pointer, ...)
         local prev = function_pointer
 
         -- luacheck: push ignore
-        function_pointer = function(...) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+        function_pointer = function()
             return prev, unpack(params)
         end
         -- luacheck: pop
@@ -230,10 +229,11 @@ function lib.wrap(function_pointer, ...)
     end
 end
 
---- Repeats an arguments `index` amount of times
----@param value any #The value to repeat
----@param index number #The amount of times to repeat the argument
----@return ... #An expanded vararg with the repeated argument
+--- Repeats an arguments `index` amount of times.
+--- @generic T
+--- @param value T The value to repeat.
+--- @param index number The amount of times to repeat the argument.
+--- @return T ... # An expanded vararg with the repeated argument.
 function lib.reparg(value, index)
     if index == 1 then
         return value
@@ -243,26 +243,27 @@ function lib.reparg(value, index)
 end
 
 --- Lazily concatenates a string to prevent runtime errors where an object may not exist
---  Consider the following example:
---
---      lib.when(str ~= nil, str .. " extra text", "")
---
---  This would fail, simply because the string concatenation will still be evaluated in order
---  to be placed inside the variable. You may use:
---
---      lib.when(str ~= nil, lib.lazy_string_concat(str, " extra text"), "")
---
---  To mitigate this issue directly.
---- @vararg string #An unlimited number of strings
----@return string #The result of all the strings concatenateA.
+--- Consider the following example:
+---
+---     lib.when(str ~= nil, str .. " extra text", "")
+---
+--- This would fail, simply because the string concatenation will still be evaluated in order
+--- to be placed inside the variable. You may use:
+---
+---     lib.when(str ~= nil, lib.lazy_string_concat(str, " extra text"), "")
+---
+--- To mitigate this issue directly.
+--- @param ... string An unlimited number of strings.
+--- @return string The result of all the strings concatenated.
 function lib.lazy_string_concat(...)
     return table.concat({ ... })
 end
 
 --- Converts an array of values to a table of keys
----@param values string[]|number[] #An array of values to store as keys
----@param default any #The default value to assign to all key pairs
----@return table #The converted table
+--- @generic K, V
+--- @param values K[] An array of values to store as keys.
+--- @param default V The default value to assign to all key pairs.
+--- @return { [K]: V } # The converted table.
 function lib.to_keys(values, default)
     local ret = {}
 
@@ -274,9 +275,9 @@ function lib.to_keys(values, default)
 end
 
 --- Constructs a new key-pair table by running a callback on all elements of an array.
----@param keys string[] #A string array with the keys to iterate over
----@param cb function #A function that gets invoked with each key and returns a value to be placed in the output table
----@return table #The newly constructed table
+--- @param keys string[] A string array with the keys to iterate over.
+--- @param cb fun(key: string): any? A function that gets invoked with each key and returns a value to be placed in the output table.
+--- @return table # The newly constructed table.
 function lib.construct(keys, cb)
     local result = {}
 
@@ -287,10 +288,10 @@ function lib.construct(keys, cb)
     return result
 end
 
---- If `val` is a function, executes it with the desired arguments, else just returns `val`
----@param val any|function #Either a function or any other value
----@vararg any #Potential arguments to give `val` if it is a function
----@return any #The returned evaluation of `val`
+--- If `val` is a function, executes it with the desired arguments, else just returns `val`.
+--- @param val function|any Either a function or any other value.
+--- @param ... any Potential arguments to give `val` if it is a function.
+--- @return any # The returned evaluation of `val`.
 function lib.eval(val, ...)
     if type(val) == "function" then
         return val(...)
@@ -300,14 +301,18 @@ function lib.eval(val, ...)
 end
 
 --- Extends a list by constructing a new one vs mutating an existing
---  list in the case of `vim.list_extend`
+--- list in the case of `vim.list_extend`.
+--- @param list any[] The list to extend.
+--- @param ... any[]  A set of lists to expand the current list by.
+--- @return any[] # The lists concatenated to each other.
 function lib.list_extend(list, ...)
     return list and { unpack(list), unpack(lib.list_extend(...)) } or {}
 end
 
 --- Converts a table with `key = value` pairs to a `{ key, value }` array.
----@param tbl_with_keys table #A table with key-value pairs
----@return any array #An array of `{ key, value }` pairs. ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+--- @generic K, V
+--- @param tbl_with_keys table<K, V> A table with key-value pairs.
+--- @return { [number]: { [0]: K, [1]: V } } # An array of `{ key, value }` pairs.
 function lib.unroll(tbl_with_keys)
     local res = {}
 
@@ -319,10 +324,11 @@ function lib.unroll(tbl_with_keys)
 end
 
 --- Works just like pcall, except returns only a single value or nil (useful for ternary operations
---  which are not possible with a function like `pcall` that returns two values).
----@param func function #The function to invoke in a protected environment
----@vararg any #The parameters to pass to `func`
----@return any|nil #The return value of the executed function or `nil`
+--- which are not possible with a function like `pcall` that returns two values).
+--- @generic T
+--- @param func fun(...: any): T The function to invoke in a protected environment.
+--- @param ... any The parameters to pass to `func`.
+--- @return T? # The return value of the executed function or `nil`.
 function lib.inline_pcall(func, ...)
     local ok, ret = pcall(func, ...)
 
@@ -333,10 +339,10 @@ function lib.inline_pcall(func, ...)
     -- return nil
 end
 
---- Perform a backwards search for a character and return the index of that character
----@param str string #The string to search
----@param char string #The substring to search for
----@return number|nil #The index of the found substring or `nil` if not found
+--- Perform a backwards search for a character and return the index of that character.
+--- @param str string The string to search.
+--- @param char string The substring to search for.
+--- @return number? # The index of the found substring or `nil` if not found.
 function lib.rfind(str, char)
     local length = str:len()
     local found_from_back = str:reverse():find(char)
@@ -344,9 +350,9 @@ function lib.rfind(str, char)
 end
 
 --- Ensure that a nested set of variables exists.
---  Useful when you want to initialise a chain of nested values before writing to them.
----@param tbl table #The table you want to modify
----@vararg string #A list of indices to recursively nest into.
+--- Useful when you want to initialise a chain of nested values before writing to them.
+--- @param tbl table The table you want to modify.
+--- @param ... string A list of indices to recursively nest into.
 function lib.ensure_nested(tbl, ...)
     local ref = tbl or {}
 
@@ -357,8 +363,8 @@ function lib.ensure_nested(tbl, ...)
 end
 
 --- Capitalizes the first letter of each word in a given string.
----@param str string #The string to capitalize
----@return string #The capitalized string.
+--- @param str string The string to capitalize.
+--- @return string # The capitalized string.
 function lib.title(str)
     local result = {}
 
@@ -371,10 +377,10 @@ function lib.title(str)
 end
 
 --- Wraps a number so that it fits within a given range.
----@param value number #The number to wrap
----@param min number #The lower bound
----@param max number #The higher bound
----@return number #The wrapped number, guarantees `min <= value <= max`.
+--- @param value number The number to wrap.
+--- @param min number The lower bound.
+--- @param max number The higher bound.
+--- @return number # The wrapped number, guarantees `min <= value <= max`.
 function lib.number_wrap(value, min, max)
     local range = max - min + 1
     local wrapped_value = ((value - min) % range) + min
@@ -386,10 +392,10 @@ function lib.number_wrap(value, min, max)
     return wrapped_value
 end
 
---- Split a path into its components
---- example: /my/cool/path/file.txt --> { my, cool, path, file.txt }
----@param path string #The path to split
----@return table #The path components
+--- Split a path into its components.
+--- Example: `/my/cool/path/file.txt` --> `{ my, cool, path, file.txt }`
+--- @param path string The path to split.
+--- @return string[] # The path components.
 function lib.tokenize_path(path)
     local tokens = {}
     for capture in path:gmatch("[^/\\]+") do
@@ -399,8 +405,8 @@ function lib.tokenize_path(path)
 end
 
 --- Lazily copy a table-like object.
----@param to_copy table|any #The table to copy. If any other type is provided it will be copied immediately.
----@return table #The copied table
+--- @param to_copy table|any The table to copy. If any other type is provided it will be copied immediately.
+--- @return table|any # The copied table.
 function lib.lazy_copy(to_copy)
     if type(to_copy) ~= "table" then
         return vim.deepcopy(to_copy)
@@ -461,20 +467,20 @@ function lib.lazy_copy(to_copy)
     })
 end
 
---- Wrapper function to add two values
---  This function only takes in one argument because the second value
---  to add is provided as a parameter in the callback.
----@param amount number #The number to add
----@return function #A callback adding the static value to the dynamic amount
+--- Wrapper function to add two values.
+--- This function only takes in one argument because the second value to add is provided as a parameter in the callback.
+--- @param amount number The number to add.
+--- @return fun(_, value: number): number # A callback adding the static value to the dynamic amount.
 function lib.mod.add(amount)
     return function(_, value)
         return value + amount
     end
 end
 
---- Wrapper function to set a value to another value in a `map` sequence
----@param to any #A static value to set each element of the table to
----@return function #A callback that returns the static value
+--- Wrapper function to set a value to another value in a `map` sequence.
+--- @generic T
+--- @param to T A static value to set each element of the table to.
+--- @return fun(): T # A callback that returns the static value
 function lib.mod.modify(to)
     return function()
         return to

--- a/lua/neorg/core/lib.lua
+++ b/lua/neorg/core/lib.lua
@@ -467,6 +467,8 @@ function lib.lazy_copy(to_copy)
     })
 end
 
+lib.mod = {}
+
 --- Wrapper function to add two values.
 --- This function only takes in one argument because the second value to add is provided as a parameter in the callback.
 --- @param amount number The number to add.
@@ -486,6 +488,8 @@ function lib.mod.modify(to)
         return to
     end
 end
+
+lib.mod.exclude = {}
 
 function lib.mod.exclude.first(func, alt)
     return function(i, val)

--- a/lua/neorg/core/log.lua
+++ b/lua/neorg/core/log.lua
@@ -9,15 +9,33 @@
 
 local lib = require("neorg.core.lib")
 
--- User configuration section
+--- @alias LogLevel
+--- | "trace"
+--- | "debug"
+--- | "info"
+--- | "warn"
+--- | "error"
+--- | "fatal"
+
+--- @class (exact) neorg.log.configuration
+--- @field plugin string                                           Name of the plugin. Prepended to log messages.
+--- @field use_console boolean                                     Whether to print the output to Neovim while running.
+--- @field highlights boolean                                      Whether highlighting should be used in console (using `:echohl`).
+--- @field use_file boolean                                        Whether to write output to a file.
+--- @field level LogLevel                                          Any messages above this level will be logged.
+--- @field modes ({ name: LogLevel, hl: string, level: number })[] Level configuration.
+--- @field float_precision float                                   Can limit the number of decimals displayed for floats.
+
+--- User configuration section
+--- @type neorg.log.configuration
 local default_config = {
-    -- Name of the plugin. Prepended to log messages
+    -- 
     plugin = "neorg",
 
-    -- Should print the output to neovim while running
+    -- 
     use_console = true,
 
-    -- Should highlighting be used in console (using echohl)
+    -- 
     highlights = true,
 
     -- Should write to a file
@@ -47,8 +65,10 @@ log.get_default_config = function()
     return default_config
 end
 
-local unpack = unpack or table.unpack ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+local unpack = unpack or table.unpack
 
+--- @param config neorg.log.configuration
+--- @param standalone boolean
 log.new = function(config, standalone)
     config = vim.tbl_deep_extend("force", default_config, config)
     config.plugin = "neorg" -- Force the plugin name to be neorg

--- a/lua/neorg/core/log.lua
+++ b/lua/neorg/core/log.lua
@@ -29,22 +29,16 @@ local lib = require("neorg.core.lib")
 --- User configuration section
 --- @type neorg.log.configuration
 local default_config = {
-    -- 
     plugin = "neorg",
 
-    -- 
     use_console = true,
 
-    -- 
     highlights = true,
 
-    -- Should write to a file
     use_file = true,
 
-    -- Any messages above this level will be logged.
     level = "warn",
 
-    -- Level configuration
     modes = {
         { name = "trace", hl = "Comment", level = vim.log.levels.TRACE },
         { name = "debug", hl = "Comment", level = vim.log.levels.DEBUG },
@@ -54,7 +48,6 @@ local default_config = {
         { name = "fatal", hl = "ErrorMsg", level = 5 },
     },
 
-    -- Can limit the number of decimals displayed for floats
     float_precision = 0.01,
 }
 

--- a/lua/neorg/core/utils.lua
+++ b/lua/neorg/core/utils.lua
@@ -7,16 +7,18 @@ local version = vim.version() -- TODO: Move to a more local scope
 --- A version agnostic way to call the neovim treesitter query parser
 --- @param language string # Language to use for the query
 --- @param query_string string # Query in s-expr syntax
---- @return any # Parsed query
+--- @return Query # Parsed query
 function utils.ts_parse_query(language, query_string)
     if vim.treesitter.query.parse then
         return vim.treesitter.query.parse(language, query_string)
     else
-        return vim.treesitter.parse_query(language, query_string) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+        ---@diagnostic disable-next-line
+        return vim.treesitter.parse_query(language, query_string)
     end
 end
 
 --- An OS agnostic way of querying the current user
+--- @return string username
 function utils.get_username()
     local current_os = configuration.os_info
 
@@ -33,26 +35,31 @@ function utils.get_username()
     return ""
 end
 
---- Returns an array of strings, the array being a list of languages that Neorg can inject
----@param values boolean #If set to true will return an array of strings, if false will return a key-value table
+--- Returns an array of strings, the array being a list of languages that Neorg can inject.
+---@param values boolean If set to true will return an array of strings, if false will return a key-value table.
+---@return string[]|table<string, { type: "treesitter"|"syntax" }>
 function utils.get_language_list(values)
     local regex_files = {}
     local ts_files = {}
-    -- search for regex files in syntax and after/syntax
-    -- its best if we strip out anything but the ft name
+
+    -- Search for regex files in syntax and after/syntax.
+    -- Its best if we strip out anything but the ft name.
     for _, lang in pairs(vim.api.nvim_get_runtime_file("syntax/*.vim", true)) do
         local lang_name = vim.fn.fnamemodify(lang, ":t:r")
         table.insert(regex_files, lang_name)
     end
+
     for _, lang in pairs(vim.api.nvim_get_runtime_file("after/syntax/*.vim", true)) do
         local lang_name = vim.fn.fnamemodify(lang, ":t:r")
         table.insert(regex_files, lang_name)
     end
-    -- search for available parsers
+
+    -- Search for available parsers
     for _, parser in pairs(vim.api.nvim_get_runtime_file("parser/*.so", true)) do
-        local parser_name = vim.fn.fnamemodify(parser, ":t:r")
+        local parser_name = assert(vim.fn.fnamemodify(parser, ":t:r"))
         ts_files[parser_name] = true
     end
+
     local ret = {}
 
     for _, syntax in pairs(regex_files) do
@@ -66,7 +73,11 @@ function utils.get_language_list(values)
     return values and vim.tbl_keys(ret) or ret
 end
 
+--- Gets a list of shorthands for a given language.
+--- @param reverse_lookup boolean Whether to create a reverse lookup for the table.
+--- @return LanguageList
 function utils.get_language_shorthands(reverse_lookup)
+    ---@class LanguageList
     local langs = {
         ["bash"] = { "sh", "zsh" },
         ["c_sharp"] = { "csharp", "cs" },
@@ -98,11 +109,11 @@ function utils.get_language_shorthands(reverse_lookup)
     return reverse_lookup and vim.tbl_add_reverse_lookup(langs) or langs
 end
 
---- Checks whether Neovim is running at least at a specific version
----@param major number #The major release of Neovim
----@param minor number #The minor release of Neovim
----@param patch number #The patch number (in case you need it)
----@return boolean #Whether Neovim is running at the same or a higher version than the one given
+--- Checks whether Neovim is running at least at a specific version.
+--- @param major number The major release of Neovim.
+--- @param minor number The minor release of Neovim.
+--- @param patch number The patch number (in case you need it).
+--- @return boolean # Whether Neovim is running at the same or a higher version than the one given.
 function utils.is_minimum_version(major, minor, patch)
     if major ~= version.major then
         return major < version.major
@@ -117,16 +128,18 @@ function utils.is_minimum_version(major, minor, patch)
 end
 
 --- Parses a version string like "0.4.2" and provides back a table like { major = <number>, minor = <number>, patch = <number> }
----@param version_string string #The input string
----@return table #The parsed version string, or `nil` if a failure occurred during parsing
+--- @param version_string string The input string.
+--- @return table? # The parsed version string, or `nil` if a failure occurred during parsing.
 function utils.parse_version_string(version_string)
     if not version_string then
-        return ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+        return
     end
 
     -- Define variables that split the version up into 3 slices
     local split_version, versions, ret =
-        vim.split(version_string, ".", true), { "major", "minor", "patch" }, { major = 0, minor = 0, patch = 0 } ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+        vim.split(version_string, ".", { plain = true }),
+        { "major", "minor", "patch" },
+        { major = 0, minor = 0, patch = 0 }
 
     -- If the sliced version string has more than 3 elements error out
     if #split_version > 3 then
@@ -135,7 +148,7 @@ function utils.parse_version_string(version_string)
             version_string,
             "failed - too many version numbers provided. Version should follow this layout: <major>.<minor>.<patch>"
         )
-        return ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+        return
     end
 
     -- Loop through all the versions and check whether they are valid numbers. If they are, add them to the return table
@@ -145,7 +158,7 @@ function utils.parse_version_string(version_string)
 
             if not num then
                 log.warn("Invalid version provided, string cannot be converted to integral type.")
-                return ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                return
             end
 
             ret[ver] = num
@@ -155,16 +168,16 @@ function utils.parse_version_string(version_string)
     return ret
 end
 
---- Custom neorg notifications. Wrapper around vim.notify
----@param msg string message to send
----@param log_level integer|nil log level in `vim.log.levels`.
+--- Custom Neorg notifications. Wrapper around `vim.notify`.
+--- @param msg string Message to send.
+--- @param log_level integer? Log level in `vim.log.levels`.
 function utils.notify(msg, log_level)
     vim.notify(msg, log_level, { title = "Neorg" })
 end
 
 --- Opens up an array of files and runs a callback for each opened file.
----@param files string[] #An array of files to open.
----@param callback fun(buffer: integer, filename: string) #The callback to invoke for each file.
+--- @param files string[] An array of files to open.
+--- @param callback fun(buffer: integer, filename: string) The callback to invoke for each file.
 function utils.read_files(files, callback)
     for _, file in ipairs(files) do
         local bufnr = vim.uri_to_bufnr(vim.uri_from_fname(file))
@@ -195,7 +208,8 @@ function utils.wrap_dotrepeat(event_handler)
         utils._neorg_is_dotrepeat = false
         utils.set_operatorfunc(function()
             if utils._neorg_is_dotrepeat then
-                local pos = vim.fn.getpos(".")
+                local pos = assert(vim.fn.getpos("."))
+
                 event.buffer = pos[1]
                 event.cursor_position = { pos[2], pos[3] }
             end
@@ -206,10 +220,10 @@ function utils.wrap_dotrepeat(event_handler)
     end
 end
 
---- Truncate input str to fit inside the col_limit when displayed. Takes non-ascii chars into account.
----@param str string
----@param col_limit integer #str will be cut so that when displayed, the display length does not exceed limit
----@return string #substring of input str
+--- Truncate input string to fit inside the `col_limit` when displayed. Takes non-ascii chars into account.
+--- @param str string The string to limit.
+--- @param col_limit integer `str` will be cut so that when displayed, the display length does not exceed this limit.
+--- @return string # Substring of input str
 function utils.truncate_by_cell(str, col_limit)
     if str and str:len() == vim.api.nvim_strwidth(str) then
         return vim.fn.strcharpart(str, 0, col_limit)


### PR DESCRIPTION
This PR adds LuaCATS annotations (i.e. the annotation standard used by the lua language server) to the core of Neorg (not to all modules, but just to the core).
LuaCATS is a more modern spinoff of EmmyLua.

This gives proper type checking, better autocompletion and verifying the contents of tables provided to the `setup()` function. It's even useful to users as they can have autocompletion for their config :D