### PR TITLE
fix(ci): fix abs path to libs in luarc

### DIFF
--- a/.github/workflows/.luarc.json
+++ b/.github/workflows/.luarc.json
@@ -6,7 +6,7 @@
     "lua/?/init.lua"
   ],
   "workspace.library": [
-    "/github/workspace/deps/neodev.nvim/types/stable"
+    "/home/runner/work/neorg/neorg/deps/neodev.nvim/types/stable"
   ],
   "diagnostics.libraryFiles": "Disable",
   "workspace.checkThirdParty": "Disable"


### PR DESCRIPTION
> Yeah I tried to fix it by pinning to the latest version but it's still failing for some reason :thinking: 
>
> It's unable to find the neodev files, despite them being there (I've been debugging the CI for the best part of half an hour now :/)
>
> _Originally posted by @vhyrro in https://github.com/nvim-neorg/neorg/issues/1265#issuecomment-1879760949_
            