### PR TITLE
feat: auto complete links

### DIFF
--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -444,7 +444,7 @@ module.public = {
             complete = module.private.generate_file_links,
 
             options = {
-                type = "Path",
+                type = "File",
                 completion_start = "{",
             },
         },
@@ -456,7 +456,7 @@ module.public = {
             node = module.private.normal_norg,
 
             options = {
-                type = "Heading",
+                type = "Reference",
                 completion_start = "#",
             },
         },
@@ -468,7 +468,7 @@ module.public = {
             node = module.private.normal_norg,
 
             options = {
-                type = "Heading",
+                type = "Reference",
                 completion_start = "*",
             },
         },
@@ -480,7 +480,7 @@ module.public = {
             node = module.private.normal_norg,
 
             options = {
-                type = "Heading",
+                type = "Reference",
                 completion_start = "#",
             },
         },
@@ -494,7 +494,7 @@ module.public = {
             node = module.private.normal_norg,
 
             options = {
-                type = "Heading",
+                type = "Reference",
                 completion_start = "*",
             },
         },
@@ -506,7 +506,7 @@ module.public = {
             node = module.private.normal_norg,
 
             options = {
-                type = "Footnote",
+                type = "Reference",
                 completion_start = "^",
             },
         },
@@ -518,7 +518,7 @@ module.public = {
             node = module.private.normal_norg,
 
             options = {
-                type = "Footnote",
+                type = "Reference",
                 completion_start = "^",
             },
         },

--- a/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
@@ -50,6 +50,8 @@ module.public = {
             Property = module.private.cmp.lsp.CompletionItemKind.Property,
             Format = module.private.cmp.lsp.CompletionItemKind.Property,
             Embed = module.private.cmp.lsp.CompletionItemKind.Property,
+            Reference = module.private.cmp.lsp.CompletionItemKind.Reference,
+            File = module.private.cmp.lsp.CompletionItemKind.File,
         }
 
         module.private.source.new = function()

--- a/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
@@ -85,7 +85,7 @@ module.public = {
         end
 
         function module.private.source:get_trigger_characters()
-            return { "@", "-", "(", " ", "." }
+            return { "@", "-", "(", " ", ".", ":", "#", "*", "^" }
         end
 
         module.private.cmp.register_source("neorg", module.private.source)


### PR DESCRIPTION
Adds auto completion for links to the completion module.

closes #752 

https://github.com/nvim-neorg/neorg/assets/56943754/69e7fb8e-1055-49a5-bc3a-41517f842036

Here's a list of the completions:
- `{:|}` workspace relative file paths
- `{#|}` all headings in the current file
- `{*|}` level 1 headings in current file (TODO status is removed)
- `{**|}` level 2 headings in current file (and so on)
- `{^|}` footnotes in the current file
- `{:path:#}` headings from the file at path
- `{:path:*}` level n headings from the file at path
- `{:path:^}` footnotes from the file at path. Will find `^ footnote` and `^^ long footnote`

All of these should work with spaces after the item (ie. `{# |}` will still complete correctly).

All of them should close the link correctly if it's not closed (ie. selecting a completion when the text looks like this: `{:|` will close the link with `:}`).

---

- [x] Currently the completion source shows as `text`. I'm not sure how to change that. It would be nice to change them to like `Keyword` or `Symbol` or something so that it's more clear that these are valid headings/paths being suggested by neorg, not just text from the buffer.

- [ ] There might be more links that I'm missing, I want to make sure I've covered them all.
- [ ] this might be really slow in large workspaces. It's not a problem for me though, but admittedly I don't have a ton of notes.