### PR TITLE
fix: enable source of `nvim-cmp` only norg file type

### DIFF
--- a/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
@@ -90,6 +90,10 @@ module.public = {
             return { "@", "-", "(", " ", ".", ":", "#", "*", "^" }
         end
 
+        function module.private.source:is_available()
+            return vim.bo.filetype == "norg"
+        end
+
         module.private.cmp.register_source("neorg", module.private.source)
     end,
 


### PR DESCRIPTION
Fixed problem with sources being enabled on buffers with file types other than `norg`