### PR TITLE
chore(docs): fixup and add to some docs

### DIFF
--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -12,7 +12,7 @@ or [`nvim-compe`](@core.integrations.nvim-compe)) to complete setup.
 Completions are provided in the following cases (examples in (), `|` represents the cursor location):
 - TODO items (`- (|`)
 - @ tags (`@|`)
-- # tags (`#|`)
+- \# tags (`#|`)
 - file path links (`{:|`) provides workspace relative paths (`:$/workspace/relative/path:`)
 - header links (`{*|`)
 - fuzzy header links (`{#|`)

--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -13,6 +13,9 @@ masks, or sometimes completely hides many categories of markup.
 
 The concealer depends on [Nerd Fonts >=v3.0.1](https://github.com/ryanoasis/nerd-fonts/releases/latest) to be
 installed on your system.
+
+This module respects `:h conceallevel` and `:h concealcursor`. Setting the wrong values for these options can
+make it look like this module isn't working.
 --]]
 
 -- utils  to be refactored

--- a/lua/neorg/modules/core/integrations/image/module.lua
+++ b/lua/neorg/modules/core/integrations/image/module.lua
@@ -3,6 +3,10 @@
     title: Images Directly within Neovim.
     description: The `image` module uses various terminal backends to display images within your Neovim instance.
     summary: Module for interacting with and managing images in the terminal.
+    internal: true
+    ---
+
+`core.integrations.image` is an internal module that wraps image.nvim, exposing methods to display images in neovim.
 --]]
 
 local neorg = require("neorg.core")

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -1,8 +1,20 @@
+--[[
+    file: Core-Latex-Renderer
+    title: Rendering LaTeX with image.nvim
+    summary: An experimental module for inline rendering latex images
+    ---
+
+This is an experimental module that requires nvim 0.10+. It renders LaTeX snippets as images
+making use of the image.nvim plugin. By default, images are only rendered after running the
+command: `:Neorg render-latex`.
+
+Requires [image.nvim](https://github.com/3rd/image.nvim).
+--]]
 local neorg = require("neorg.core")
 local module = neorg.modules.create("core.latex.renderer")
 local modules = neorg.modules
 
-assert(vim.re ~= nil, "Neovim 0.10.0+ is required to run the `core.renderer.latex` module! ")
+assert(vim.re ~= nil, "Neovim 0.10.0+ is required to run the `core.renderer.latex` module!")
 
 module.setup = function()
     return {
@@ -163,11 +175,20 @@ module.public = {
 }
 
 module.config.public = {
-    -- TODO: Documentation
+    -- When true, images of rendered LaTeX will cover the source LaTeX they were produced from
     conceal = true,
+
+    -- "Dots Per Inch" increasing this value will result in crisper images at the expense of
+    -- performance
     dpi = 350,
+
+    -- When true, images will render when a `.norg` buffer is entered
     render_on_enter = false,
+
+    -- Module that renders the images. This is currently the only option
     renderer = "core.integrations.image",
+
+    -- make the images larger or smaller by adjusting the scale
     scale = 1,
 }
 


### PR DESCRIPTION
Fixes the completion doc issue that I introduced in link auto complete PR.

Also adds:
- Latex render documentation
- `conceallevel` and `concealcursor` mention in the concealer docs
- internal image module doc string
