### PR TITLE
doc: pin version to v7.0.0 in tldr

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ For neovim beginners who don't want to tinker with the configurations:
     },
     {
       "nvim-neorg/neorg",
+      tag = "v7.0.0",
       build = ":Neorg sync-parsers",
       dependencies = { "nvim-lua/plenary.nvim" },
       config = function()


### PR DESCRIPTION
Otherwise the tl;dr instruction fails due to https://github.com/nvim-neorg/neorg/commit/56ad8056b6180dba60ddbd5bca2f29de12f3bd1d.