### PR TITLE
fix(export.markdown): export `authors` metadata field key as `author`

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -574,7 +574,7 @@ module.public = {
             ["weak_carryover"] = "",
 
             ["key"] = function(text, _, state)
-                return string.rep(" ", state.indent) .. text
+                return string.rep(" ", state.indent) .. (text == "authors" and "author" or text)
             end,
 
             [":"] = ": ",


### PR DESCRIPTION
When pandoc reads the metadata block of a markdown file, it uses the `author` field to set the authors' names. Neorg, however, uses the `authors` field for this. This patch converts the key name during export so the data can be properly recognized on both cases