### PR TITLE
Fix for error Invalid window id: -1

### DIFF
--- a/lua/neorg/core/modules.lua
+++ b/lua/neorg/core/modules.lua
@@ -751,6 +751,11 @@ function modules.create_event(module, type, content, ev)
 
     local bufid = ev and ev.buf or vim.api.nvim_get_current_buf()
     local winid = assert(vim.fn.bufwinid(bufid))
+
+    if winid == -1 then
+        winid = vim.api.nvim_get_current_win()
+    end
+
     new_event.cursor_position = vim.api.nvim_win_get_cursor(winid)
 
     local row_1b = new_event.cursor_position[1]


### PR DESCRIPTION
When I open a `.norg` file from a command and the current buffer is not a file or an editable buffer,
such as the `neo-tree` buffer it throws this error:

```
Error executing Lua callback: vim/_editor.lua:0: nvim_exec2()..BufEnter Autocommands for "*.norg": Vim(append):Error executing lua callback: .../.local/share/nvim/lazy/neorg/lua/neorg/core/modules.lua:759: Invalid window id: -1
stack traceback:
	[C]: in function 'nvim_win_get_cursor'
	.../.local/share/nvim/lazy/neorg/lua/neorg/core/modules.lua:759: in function 'create_event'
	...azy/neorg/lua/neorg/modules/core/autocommands/module.lua:49: in function '_neorg_module_autocommand_triggered'
	...azy/neorg/lua/neorg/modules/core/autocommands/module.lua:84: in function <...azy/neorg/lua/neorg/modules/core/autocommands/module.lua:83>
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	...nvim/lazy/neorg/lua/neorg/modules/core/dirman/module.lua:448: in function 'open_workspace'
	...nvim/lazy/neorg/lua/neorg/modules/core/dirman/module.lua:487: in function 'on_event'
	.../.local/share/nvim/lazy/neorg/lua/neorg/core/modules.lua:794: in function 'broadcast_event'
	...im/lazy/neorg/lua/neorg/modules/core/neorgcmd/module.lua:298: in function <...im/lazy/neorg/lua/neorg/modules/core/neorgcmd/module.lua:205>
stack traceback:
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	...nvim/lazy/neorg/lua/neorg/modules/core/dirman/module.lua:448: in function 'open_workspace'
	...nvim/lazy/neorg/lua/neorg/modules/core/dirman/module.lua:487: in function 'on_event'
	.../.local/share/nvim/lazy/neorg/lua/neorg/core/modules.lua:794: in function 'broadcast_event'
	...im/lazy/neorg/lua/neorg/modules/core/neorgcmd/module.lua:298: in function <...im/lazy/neorg/lua/neorg/modules/core/neorgcmd/module.lua:205>
```

I replicate it by having the focus on the `neo-tree` buffer and running `:Neorg workspace work`.