### PR TITLE
feat(concealer): code block background `min_width`

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -638,7 +638,7 @@ module.public = {
             end
 
             local line_lengths = {}
-            local max_len = 0
+            local max_len = config.min_width or 0
             for row_0b = row_start_0b, row_end_0bin do
                 local len = get_line_length(bufid, row_0b)
                 if len > max_len then
@@ -928,6 +928,10 @@ module.config.public = {
             -- When set to `content`, will only span as far as the longest line
             -- within the code block.
             width = "fullwidth",
+
+            -- When set to a number, the code block background will be at least
+            -- this many chars wide. Useful in conjunction with `width = "content"`
+            min_width = nil,
 
             -- Additional padding to apply to either the left or the right. Making
             -- these values negative is considered undefined behaviour (it is


### PR DESCRIPTION
closes #1327

_It doesn't quite do what that issue says, but I like this better._

Lets you set a min width for code cell background highlights. It's also an incredibly simple change.

## Example

New configuration looks like this:

```lua
-- ...
["core.concealer"] = {
  config = {
    icons = {
      code_block = {
        width = "content",
        min_width = 85,
      },
    },
  },
},
-- ...
```

And the result:
![image](https://github.com/nvim-neorg/neorg/assets/56943754/c8c42c86-675a-4349-b1a7-04e65f73590b)
