### PR TITLE
Fix for issue #1121

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -479,13 +479,11 @@ module.public = {
 
                 for _, extmark in ipairs(icon_extmarks) do
                     local extmark_details = extmark[4]
-                    local extmark_column = extmark[3] + (line_length - vim.api.nvim_strwidth(line))
 
                     for _, virt_text in ipairs(extmark_details.virt_text or {}) do
-                        line = line:sub(1, extmark_column)
+                        line = vim.fn.strcharpart( line, 0, extmark[3] )
                             .. virt_text[1]
-                            .. line:sub(extmark_column + vim.api.nvim_strwidth(virt_text[1]) + 1)
-                        line_length = vim.api.nvim_strwidth(line) - line_length + vim.api.nvim_strwidth(virt_text[1])
+                            .. vim.fn.strcharpart( line, extmark[3] + vim.api.nvim_strwidth(virt_text[1]) )
                     end
                 end
 


### PR DESCRIPTION
This should fix the problem described in #1121. Maybe with the latest greatest nvim this problem is also bypassed (see 086891d). But the fix is still relevant for older nvim versions.

The problem seems to be that lua `line:sub` method is not Unicode-aware and does not work properly with strings that contain Unicode characters. That is definitely the case when concealer required more than one substitution (one for heading, one for todo marks). First substitution (heading) would work fine, but the second one (todo mark) would become off.