### PR TITLE
feat(dirman)!: use pathlib for all dirman operations 

### DIFF
--- a/.github/workflows/.luarc.json
+++ b/.github/workflows/.luarc.json
@@ -6,6 +6,7 @@
     "lua/?/init.lua"
   ],
   "Lua.workspace.library": [
+    "/home/runner/work/neorg/neorg/lua_modules/share/lua/5.1",
     "/home/runner/work/neorg/neorg/deps/neodev.nvim/types/stable"
   ],
   "Lua.diagnostics.libraryFiles": "Disable",

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -30,3 +30,4 @@ jobs:
             lua-utils.nvim == 1.0.2
             plenary.nvim == 0.1.4
             nui.nvim == 0.3.0
+            pathlib.nvim ~> 2

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: install dependencies
         run: |
-          luarocks install --only-deps ./neorg-scm-1.rockspec
+          luarocks init
+          luarocks install --only-deps ./*.rockspec
 
       - name: Type Check Code Base
         uses: mrcjkb/lua-typecheck-action@v0.2.1

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -20,6 +20,15 @@ jobs:
           repository: "folke/neodev.nvim"
           path: "deps/neodev.nvim"
 
+      - uses: leafo/gh-actions-lua@v9
+        with:
+          luaVersion: "5.1"
+      - uses: leafo/gh-actions-luarocks@v4
+
+      - name: install dependencies
+        run: |
+          luarocks install --only-deps ./neorg-scm-1.rockspec
+
       - name: Type Check Code Base
         uses: mrcjkb/lua-typecheck-action@v0.2.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 wiki/
 test.norg
+/luarocks
+/lua_modules
+/.luarocks

--- a/.luarc.json
+++ b/.luarc.json
@@ -5,5 +5,9 @@
         "_neorg_module_autocommand_triggered",
         "vim"
     ],
-    "workspace.checkThirdParty": false
+    "Lua.workspace.library": [
+      "lua_modules/share/lua/5.1/"
+    ],
+    "Lua.diagnostics.libraryFiles": "Disable",
+    "Lua.workspace.checkThirdParty": false
 }

--- a/build.lua
+++ b/build.lua
@@ -16,6 +16,7 @@ vim.schedule(function()
         "lua-utils.nvim == 1.0.2",
         "plenary.nvim == 0.1.4",
         "nui.nvim == 0.3.0",
+        "pathlib.nvim ~> 2",
     })
 
     package.loaded["neorg"] = nil

--- a/lua/neorg/core/modules.lua
+++ b/lua/neorg/core/modules.lua
@@ -512,8 +512,9 @@ function modules.load_module_as_dependency(module_name, parent_module, cfg)
 end
 
 --- Retrieves the public API exposed by the module.
---- @param module_name string The name of the module to retrieve.
---- @return neorg.module.public?
+--- @generic T
+--- @param module_name `T` The name of the module to retrieve.
+--- @return T?
 function modules.get_module(module_name)
     if not modules.is_module_loaded(module_name) then
         log.trace("Attempt to get module with name", module_name, "failed - module is not loaded.")

--- a/lua/neorg/core/utils.lua
+++ b/lua/neorg/core/utils.lua
@@ -175,10 +175,11 @@ function utils.notify(msg, log_level)
 end
 
 --- Opens up an array of files and runs a callback for each opened file.
---- @param files string[] An array of files to open.
+--- @param files (string|PathlibPath)[] An array of files to open.
 --- @param callback fun(buffer: integer, filename: string) The callback to invoke for each file.
 function utils.read_files(files, callback)
     for _, file in ipairs(files) do
+        file = tostring(file)
         local bufnr = vim.uri_to_bufnr(vim.uri_from_fname(file))
 
         local should_delete = not vim.api.nvim_buf_is_loaded(bufnr)

--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -50,7 +50,7 @@ module.private = {
     engine = nil,
 
     --- Get a list of all norg files in current workspace. Returns { workspace_path, norg_files }
-    --- @return table?
+    --- @return { [1]: PathlibPath, [2]: PathlibPath[]|nil }|nil
     get_norg_files = function()
         ---@type core.dirman
         local dirman = neorg.modules.get_module("core.dirman")
@@ -182,14 +182,16 @@ module.private = {
         end
 
         local closing_chars = module.private.get_closing_chars(context, true)
-        for _, file in pairs(files[2]) do
-            assert(type(file) == "string")
+        for _, filepath in pairs(files[2]) do
+            local file = tostring(filepath)
             local bufnr = dirman.get_file_bufnr(file)
 
             if vim.api.nvim_get_current_buf() ~= bufnr then
-                -- using -6 to go to the end (-1) and remove '.norg' 5 more chars
-                local link = "{:$" .. file:sub(#files[1] + 1, -6) .. closing_chars
-                table.insert(res, link)
+                local rel = filepath:relative_to(files[1], false)
+                if rel and rel:len() > 0 then
+                    local link = "{:$/" .. rel:with_suffix(""):tostring() .. closing_chars
+                    table.insert(res, link)
+                end
             end
         end
 

--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -52,6 +52,7 @@ module.private = {
     --- Get a list of all norg files in current workspace. Returns { workspace_path, norg_files }
     --- @return table?
     get_norg_files = function()
+        ---@type core.dirman
         local dirman = neorg.modules.get_module("core.dirman")
         if not dirman then
             return nil
@@ -89,6 +90,7 @@ module.private = {
     --- @param file string file path, norg syntax accepted
     --- @return table<string>
     get_lines = function(file)
+        ---@type core.dirman.utils
         local dirutils = neorg.modules.get_module("core.dirman.utils")
         if not dirutils then
             return {}
@@ -168,6 +170,7 @@ module.private = {
 
     generate_file_links = function(context, _prev, _saved, _match)
         local res = {}
+        ---@type core.dirman
         local dirman = neorg.modules.get_module("core.dirman")
         if not dirman then
             return {}
@@ -219,7 +222,7 @@ module.private = {
     end,
 
     --- The node context for normal norg (ie. not in a code block)
-    normal_norg = function(current, previous)
+    normal_norg = function(current, previous, _, _)
         -- If no previous node exists then try verifying the current node instead
         if not previous then
             return current and (current:type() ~= "translation_unit" or current:type() == "document") or false
@@ -251,7 +254,7 @@ module.load = function()
     end
 
     -- Set a special function in the integration module to allow it to communicate with us
-    module.private.engine.invoke_completion_engine = function(context)
+    module.private.engine.invoke_completion_engine = function(context) ---@diagnostic disable-line
         return module.public.complete(context) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
     end
 
@@ -526,8 +529,8 @@ module.public = {
 
     --- Parses the public completion table and attempts to find all valid matches
     ---@param context table #The context provided by the integration engine
-    ---@param prev table #The previous table of completions - used for descent
-    ---@param saved string #The saved regex in the form of a string, used to concatenate children nodes with parent nodes' regexes
+    ---@param prev table? #The previous table of completions - used for descent
+    ---@param saved string? #The saved regex in the form of a string, used to concatenate children nodes with parent nodes' regexes
     complete = function(context, prev, saved)
         -- If the save variable wasn't passed then set it to an empty string
         saved = saved or ""
@@ -560,7 +563,7 @@ module.public = {
                         -- If the type of completion data we're dealing with is a string then attempt to parse it
                         if type(completion_data.node) == "string" then
                             -- Split the completion node string down every pipe character
-                            local split = vim.split(completion_data.node, "|")
+                            local split = vim.split(completion_data.node --[[@as string]], "|")
                             -- Check whether the first character of the string is an exclamation mark
                             -- If this is present then it means we're looking for a node that *isn't* the one we specify
                             local negate = split[1]:sub(0, 1) == "!"

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -139,6 +139,7 @@ module.public = {
     get_workspaces = function()
         return module.config.public.workspaces
     end,
+    ---@return string[]
     get_workspace_names = function()
         return vim.tbl_keys(module.config.public.workspaces)
     end,

--- a/lua/neorg/modules/core/dirman/utils/module.lua
+++ b/lua/neorg/modules/core/dirman/utils/module.lua
@@ -8,6 +8,8 @@ Currently the only exposed API function is `expand_path`, which takes a path lik
 converts `$name` into the full path of the workspace called `name`.
 --]]
 
+local Path = require("pathlib")
+
 local neorg = require("neorg.core")
 local log, modules = neorg.log, neorg.modules
 
@@ -16,43 +18,66 @@ local module = neorg.modules.create("core.dirman.utils")
 ---@class core.dirman.utils
 module.public = {
     ---Resolve `$<workspace>/path/to/file` and return the real path
-    ---@param path string # path
-    ---@param raw_path boolean? # If true, returns resolved path, else, return with appended ".norg"
-    ---@return string? # Resolved path. If path does not start with `$` or not absolute, adds relative from current file.
-    expand_path = function(path, raw_path)
+    ---@param path string|PathlibPath # path
+    ---@param raw_path boolean? # If true, returns resolved path, otherwise, returns resolved path and append ".norg"
+    ---@return PathlibPath? # Resolved path. If path does not start with `$` or not absolute, adds relative from current file.
+    expand_pathlib = function(path, raw_path)
+        local filepath = Path(path)
         -- Expand special chars like `$`
-        local custom_workspace_path = path:match("^%$([^/\\]*)[/\\]")
-
+        local custom_workspace_path = filepath:match("^%$([^/\\]*)[/\\]")
         if custom_workspace_path then
+            ---@type core.dirman
             local dirman = modules.get_module("core.dirman")
-
             if not dirman then
-                log.error(
-                    "Unable to jump to link with custom workspace: `core.dirman` is not loaded. Please load the module in order to get workspace support."
-                )
+                log.error(table.concat({
+                    "Unable to jump to link with custom workspace: `core.dirman` is not loaded.",
+                    "Please load the module in order to get workspace support.",
+                }, " "))
                 return
             end
-
             -- If the user has given an empty workspace name (i.e. `$/myfile`)
             if custom_workspace_path:len() == 0 then
-                path = dirman.get_current_workspace()[2] .. "/" .. path:sub(3)
+                filepath = dirman.get_current_workspace()[2] / filepath:relative_to(Path("$"))
             else -- If the user provided a workspace name (i.e. `$my-workspace/myfile`)
-                local workspace_path = dirman.get_workspace(custom_workspace_path)
-
-                if not workspace_path then
-                    log.warn("Unable to expand path: workspace does not exist")
+                local workspace = dirman.get_workspace(custom_workspace_path)
+                if not workspace then
+                    local msg = "Unable to expand path: workspace '%s' does not exist"
+                    log.warn(string.format(msg, custom_workspace_path))
                     return
                 end
-
-                path = workspace_path .. "/" .. path:sub(custom_workspace_path:len() + 3)
+                filepath = workspace / filepath:relative_to(Path("$" .. custom_workspace_path))
             end
+        elseif filepath:is_relative() then
+            local this_file = Path(vim.fn.expand("%:p")):absolute()
+            filepath = this_file:parent_assert() / filepath
         else
-            -- If the path isn't absolute (doesn't begin with `/` nor `~`) then prepend the current file's
-            -- filehead in front of the path
-            path = (vim.tbl_contains({ "/", "~" }, path:sub(1, 1)) and "" or (vim.fn.expand("%:p:h") .. "/")) .. path
+            filepath = filepath:absolute()
         end
-
-        return path .. (raw_path and "" or ".norg")
+        -- requested to expand norg file
+        if not raw_path then
+            if type(path) == "string" and (path:sub(#path) == "/" or path:sub(#path) == "\\") then
+                -- if path ends with `/`, it is an invalid request!
+                log.error(table.concat({
+                    "Norg file location cannot point to a directory.",
+                    string.format("Current link points to '%s'", path),
+                    "which ends with a `/`.",
+                }, " "))
+                return
+            end
+            filepath = filepath:with_suffix(".norg")
+        end
+        return filepath
+    end,
+    ---Resolve `$<workspace>/path/to/file` and return the real path
+    -- NOTE: Use `expand_pathlib` which returns a PathlibPath object instead.
+    ---
+    ---\@deprecate Use `expand_pathlib` which returns a PathlibPath object instead. TODO: deprecate this <2024-03-27>
+    ---@param path string|PathlibPath # path
+    ---@param raw_path boolean? # If true, returns resolved path, otherwise, returns resolved path and append ".norg"
+    ---@return string? # Resolved path. If path does not start with `$` or not absolute, adds relative from current file.
+    expand_path = function(path, raw_path)
+        local res = module.public.expand_pathlib(path, raw_path)
+        return res and res:tostring() or nil
     end,
 }
 

--- a/lua/neorg/modules/core/dirman/utils/module.lua
+++ b/lua/neorg/modules/core/dirman/utils/module.lua
@@ -13,6 +13,7 @@ local log, modules = neorg.log, neorg.modules
 
 local module = neorg.modules.create("core.dirman.utils")
 
+---@class core.dirman.utils
 module.public = {
     ---Resolve `$<workspace>/path/to/file` and return the real path
     ---@param path string # path

--- a/lua/neorg/modules/core/esupports/indent/module.lua
+++ b/lua/neorg/modules/core/esupports/indent/module.lua
@@ -29,6 +29,7 @@ module.setup = function()
     }
 end
 
+---@class core.esupports.indent
 module.public = {
     indentexpr = function(buf, line, node)
         line = line or (vim.v.lnum - 1)

--- a/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
@@ -61,7 +61,7 @@ module.public = {
         function module.private.source.complete(_, request, callback)
             local abstracted_context = module.public.create_abstracted_context(request)
 
-            local completion_cache = module.public.invoke_completion_engine(abstracted_context) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+            local completion_cache = module.public.invoke_completion_engine(abstracted_context)
 
             if completion_cache.options.pre then
                 completion_cache.options.pre(abstracted_context)
@@ -113,6 +113,12 @@ module.public = {
             },
             full_line = request.context.cursor_line,
         }
+    end,
+
+    invoke_completion_engine = function(context)
+        error("`invoke_completion_engine` must be set from outside.")
+        assert(context)
+        return {}
     end,
 }
 

--- a/lua/neorg/modules/core/integrations/nvim-compe/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-compe/module.lua
@@ -184,6 +184,12 @@ module.public = {
             full_line = context.line,
         }
     end,
+
+    invoke_completion_engine = function(context)
+        error("`invoke_completion_engine` must be set from outside.")
+        assert(context)
+        return {}
+    end,
 }
 
 return module

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -54,6 +54,7 @@ module.load = function()
     end)
 end
 
+---@class core.latex.renderer
 module.public = {
     latex_renderer = function()
         module.private.ranges = {}

--- a/lua/neorg/modules/core/promo/module.lua
+++ b/lua/neorg/modules/core/promo/module.lua
@@ -81,6 +81,7 @@ module.private = {
     },
 }
 
+---@class core.promo
 module.public = {
     get_promotable_node_prefix = function(node)
         for _, data in pairs(module.private.types) do

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -150,7 +150,7 @@ module.load = function()
                     if not norgname then
                         norgname = filename
                     end
-                    norgname = string.sub(norgname, string.len(ws_root) + 1)
+                    norgname = string.sub(norgname, ws_root:len() + 1)
 
                     -- normalise categories into a list. Could be vim.NIL, a number, a string or a list ...
                     if not metadata.categories or metadata.categories == vim.NIL then
@@ -237,7 +237,7 @@ module.load = function()
                     local category = path_tokens[#path_tokens - 1] or "Uncategorised"
 
                     local norgname = filename:match("(.+)%.norg$") or filename -- strip extension for link destinations
-                    norgname = string.sub(norgname, string.len(ws_root) + 1)
+                    norgname = string.sub(norgname, ws_root:len() + 1)
 
                     if not metadata.title then
                         metadata.title = get_first_heading_title(bufnr) or vim.fs.basename(norgname)
@@ -290,7 +290,7 @@ module.config.public = {
     -- - "default" - read the metadata to categorize and annotate files. Files
     --   without metadata will use the top level heading as the title. If no headings are present, the filename will be used.
     -- - "by_path" - Similar to "default" but uses the capitalized name of the folder containing a *.norg file as category.
-    -- ---@type string|fun(files: string[], ws_root: string, heading_level: number?, include_categories: string[]?): string[]?
+    ---@type string|fun(files: PathlibPath[], ws_root: PathlibPath, heading_level: number?, include_categories: string[]?): string[]?
     strategy = "default",
 }
 

--- a/lua/neorg/modules/core/tempus/module.lua
+++ b/lua/neorg/modules/core/tempus/module.lua
@@ -217,6 +217,7 @@ local timezone_list = {
 
 ---@alias Date {weekday: {name: string, number: number}?, day: number?, month: {name: string, number: number}?, year: number?, timezone: string?, time: {hour: number, minute: number, second: number?}?}
 
+---@class core.tempus
 module.public = {
     --- Converts a parsed date with `parse_date` to a lua date.
     ---@param parsed_date Date #The date to convert

--- a/lua/neorg/modules/core/ui/calendar/module.lua
+++ b/lua/neorg/modules/core/ui/calendar/module.lua
@@ -86,6 +86,7 @@ module.private = {
     end,
 }
 
+---@class core.ui.calendar
 module.public = {
     add_mode = function(name, factory)
         module.private.modes[name] = factory

--- a/neorg-scm-1.rockspec
+++ b/neorg-scm-1.rockspec
@@ -16,6 +16,7 @@ dependencies = {
     -- "norgopolis-client.lua >= 0.2.0",
     -- "norgopolis-server.lua >= 1.3.1",
     "lua-utils.nvim",
+    "pathlib.nvim ~> 2",
 }
 
 source = {


### PR DESCRIPTION
## Pathlib.nvim

[pathlib.nvim](https://pysan3.github.io/pathlib.nvim/README.html) is a plugin which aims to decrease the difficulties of path management across mutliple OSs in neovim. The plugin API is heavily inspired by Python’s pathlib.path with tweaks to fit neovim usage.

You can search through the methods at: https://pysan3.github.io/pathlib.nvim/search.html

## Commits

### feat(spec): add pathlib.nvim to dependency

This adds pathlib.nvim to neorg's dependencies managed by `.github/workflows/luarocks.yml` and `build.lua`.

This commit also changes the typecheck CI to install all its dependencies defined by `*.rockspec` and use the packages for type annotations. Thanks to this change, types like `PathlibPath` (defined in pathlib.nvim) also get annotated as a valid type and will be type-checked against.

You will want to do this with local development as well.

```bash
$ luarocks init --no-gitignore  # RUN THIS ONLY ONCE

$ luarocks install --only-deps ./neorg-scm-1.rockspec  # Run this each time dependency changes
```

After running these commands, packages will be installed under `./lua_modules` and those packages will be picked up by `lua_ls` thanks to config in `./.luarc.json` and you will get all nvim-cmp completions!

### docs(annotation): add better type annotations

Some updates to type annotations **unrelated to dirman** to make life easier with completions.

### feat(dirman)!: use pathlib for all dirman operations

This commit contains all the breaking changes.

Some of the public facing APIs from dirman now returns a `PathlibPath` object instead of a string.
Besides, there is a new function `dirman.utils.expand_pathlib` which is meant to replace `dirman.utils.expand_path`.
I have not deprecated `expand_path` just yet since it is used in some places in the codebase, and if I deprecate it now, typecheck CI will complain about it resulting to ❌.

Some notable changes to modules **other than dirman** are as follows.

- `core.completion`
  - This uses `dirman.get_norg_files` to get the list of norg files under the workspace.
  - It does string manipulation of the file paths to generate the completion options.
  - I changed the code to make it work with pathlib which result in a much cleaner code.
- `core.summary`
  - `path:len() == string.len(tostring(path))` so,
  - `string.len(ws_root)` won't work but `ws_root:len()` will call `Path.len` or `string.len` based on the type but result in the same value.
    - How clever!

@vhyrro I know you are busy but please take your time to read through the changes.
I tried my best to keep the diff as little as possible so that the diff explains what pathlib brings to the table (especially [this commit](https://github.com/nvim-neorg/neorg/pull/1354/commits/5f3b6dd02b6867321446ff03e286fd17191f57f2)).
I hope after you read through the changes, you already have some good understanding of how to use the library.
Of course if you have any question, feel free to ping me anytime.

I labeled this PR with `feat!` flagging it as a breaking change (which will increase the major version). Do you agree?
I think neorg v9 is labeled to bring the v3 parser so I'm not sure if introducing pathlib is worth making a major jump already.
