### PR TITLE
TODO Introspector version 2 electric boogaloo

### DIFF
--- a/lua/neorg/modules/core/defaults/module.lua
+++ b/lua/neorg/modules/core/defaults/module.lua
@@ -45,5 +45,6 @@ return modules.create_meta(
     "core.qol.toc",
     "core.qol.todo_items",
     "core.storage",
-    "core.tangle"
+    "core.tangle",
+    "core.todo-introspector"
 )

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -48,6 +48,19 @@ function module.public.attach_introspector(buffer)
         error(string.format("Could not attach to buffer %d, buffer is not a norg file!", buffer))
     end
 
+    module.required["core.integrations.treesitter"].execute_query(
+        [[
+    (_
+      state: (detached_modifier_extension)) @item
+    ]],
+        function(query, id, node)
+            if query.captures[id] == "item" then
+                module.public.perform_introspection(buffer, node)
+            end
+        end,
+        buffer
+    )
+
     vim.api.nvim_buf_attach(buffer, false, {
         on_lines = vim.schedule_wrap(function(_, buf, _, first)
             ---@type TSNode?

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -148,6 +148,7 @@ function module.public.perform_introspection(buffer, node)
     -- as the total also includes things like uncertain tasks.
     vim.api.nvim_buf_set_extmark(buffer, module.private.namespace, line, col, {
         virt_text = { { string.format("[%d/%d]", counts.done, total), "Normal" } },
+        invalidate = true,
     })
 end
 

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -3,6 +3,8 @@ local modules = neorg.modules
 
 local module = modules.create("core.todo-introspector")
 
+-- TODO: When searching recursive children also account for generic_list nodes
+
 module.private = {
     namespace = vim.api.nvim_create_namespace("neorg/todo-introspector"),
 
@@ -47,37 +49,91 @@ function module.public.attach_introspector(buffer)
     end
 
     vim.api.nvim_buf_attach(buffer, false, {
-        on_lines = function(_, buf, _, first)
+        on_lines = vim.schedule_wrap(function(_, buf, _, first)
             ---@type TSNode?
             local node = module.required["core.integrations.treesitter"].get_first_node_on_line(buf, first)
 
-            assert(node)
-
-            ---@type TSNode?
             local parent = node
 
             while parent do
                 local child = parent:named_child(1)
 
                 if child and child:type() == "detached_modifier_extension" then
-                    module.public.perform_introspection(buffer, node)
-                    break
+                    module.public.perform_introspection(buffer, parent)
+                    -- NOTE: do not break here as we want the introspection to propagate all the way up the syntax tree
                 end
 
                 parent = parent:parent()
             end
-        end,
+        end),
+
         on_detach = function()
             module.private.buffers[buffer] = nil
         end,
     })
 end
 
---- 
+--- Aggregates TODO item counts from children.
+---@param node TSNode
+---@return { undone: number, pending: number, done: number, cancelled: number, recurring: number, on_hold: number, urgent: number, uncertain: number }
+---@return number total
+function module.public.calculate_items(node)
+    local counts = {
+        undone = 0,
+        pending = 0,
+        done = 0,
+        cancelled = 0,
+        recurring = 0,
+        on_hold = 0,
+        urgent = 0,
+        uncertain = 0,
+    }
+
+    local total = 0
+
+    -- Go through all the children of the current todo item node and count the amount of "done" children
+    for child in node:iter_children() do
+        if child:named_child(1) and child:named_child(1):type() == "detached_modifier_extension" then
+            for status in child:named_child(1):iter_children() do
+                if status:type():match("^todo_item_") then
+                    local type = status:type():match("^todo_item_(.+)$")
+
+                    counts[type] = counts[type] + 1
+
+                    if type == "cancelled" then
+                        break
+                    end
+
+                    total = total + 1
+                end
+            end
+        end
+    end
+
+    return counts, total
+end
+
+--- Displays the amount of done items in the form of an extmark.
 ---@param buffer number
 ---@param node TSNode
 function module.public.perform_introspection(buffer, node)
-    assert(false)
+    local counts, total = module.public.calculate_items(node)
+
+    local line, col = node:start()
+
+    local unique_id = assert(tonumber(tostring(buffer) .. tostring(node:symbol()) .. tostring(line)))
+
+    if total == 0 then
+        vim.api.nvim_buf_del_extmark(buffer, module.private.namespace, unique_id)
+        return
+    end
+
+    -- TODO: Make configurable, make colours customizable, don't display [x/total]
+    -- as the total also includes things like uncertain tasks.
+    vim.api.nvim_buf_set_extmark(buffer, module.private.namespace, line, col, {
+        id = unique_id,
+        virt_text = { { string.format("[%d/%d]", counts.done, total), "Normal" } },
+    })
 end
 
 return module

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -12,6 +12,7 @@ module.private = {
 
 -- NOTE(vhyrro): This module serves as a temporary proof of concept.
 -- We will want to add a plethora of customizability options after the base behaviour is implemented.
+---@class core.todo-introspector
 module.config.public = {}
 
 module.setup = function()

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -79,6 +79,7 @@ function module.public.attach_introspector(buffer)
         end),
 
         on_detach = function()
+            vim.api.nvim_buf_clear_namespace(buffer, module.private.namespace, 0, -1)
             module.private.buffers[buffer] = nil
         end,
     })

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -156,10 +156,27 @@ function module.public.perform_introspection(buffer, node)
         return
     end
 
+    local curated_total = counts.done + counts.undone + counts.pending + counts.urgent
+
     -- TODO: Make configurable, make colours customizable, don't display [x/total]
     -- as the total also includes things like uncertain tasks.
+    --
+    -- NOTE(vhyrro): The selection of done/undone/pending/urgent is a curated arbitrary list for now (and a common-case scenario).
+    -- Yet again, should be customizable :)
+    --
+    -- TODO(vhyrro): Extract the whole string building logic to a function so that it can be used outside of Neorg for other things.
     vim.api.nvim_buf_set_extmark(buffer, module.private.namespace, line, col, {
-        virt_text = { { string.format("[%d/%d]", counts.done, total), "Normal" } },
+        virt_text = {
+            {
+                string.format(
+                    "[%d/%d] (%d%%)",
+                    counts.done,
+                    curated_total,
+                    (curated_total ~= 0 and math.floor((counts.done / curated_total) * 100) or 0)
+                ),
+                "Normal",
+            },
+        },
         invalidate = true,
     })
 end

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -1,0 +1,86 @@
+local neorg = require("neorg")
+local modules = neorg.modules
+
+local module = modules.create("core.todo-introspector")
+
+module.private = {
+    namespace = vim.api.nvim_create_namespace("neorg/todo-introspector"),
+
+    --- List of active buffers
+    buffers = {},
+}
+
+-- NOTE(vhyrro): This module serves as a temporary proof of concept.
+-- We will want to add a plethora of customizability options after the base behaviour is implemented.
+module.config.public = {}
+
+module.setup = function()
+    return {
+        success = true,
+        requires = { "core.integrations.treesitter" },
+    }
+end
+
+module.load = function()
+    vim.api.nvim_create_autocmd("Filetype", {
+        pattern = "norg",
+        desc = "Attaches the TODO introspector to any Norg buffer.",
+        callback = function(ev)
+            local buf = ev.buf
+
+            if module.private.buffers[buf] then
+                return
+            end
+
+            module.private.buffers[buf] = true
+            module.public.attach_introspector(buf)
+        end,
+    })
+end
+
+--- Attaches the introspector to a given Norg buffer.
+--- Errors if the target buffer is not a Norg buffer.
+---@param buffer number #The buffer ID to attach to.
+function module.public.attach_introspector(buffer)
+    if not vim.api.nvim_buf_is_valid(buffer) or vim.bo[buffer].filetype ~= "norg" then
+        error(string.format("Could not attach to buffer %d, buffer is not a norg file!", buffer))
+    end
+
+    local language_tree = vim.treesitter.get_parser(buffer, "norg")
+    language_tree:parse(true)
+
+    vim.api.nvim_buf_attach(buffer, false, {
+        on_lines = function(_, buf, _, first)
+            ---@type TSNode?
+            local node = module.required["core.integrations.treesitter"].get_first_node_on_line(buf, first)
+
+            assert(node)
+
+            ---@type TSNode?
+            local parent = node
+
+            while parent do
+                local child = parent:named_child(1)
+
+                if child and child:type() == "detached_modifier_extension" then
+                    module.public.perform_introspection(buffer, node)
+                    break
+                end
+
+                parent = parent:parent()
+            end
+        end,
+        on_detach = function()
+            module.private.buffers[buffer] = nil
+        end,
+    })
+end
+
+--- 
+---@param buffer number
+---@param node TSNode
+function module.public.perform_introspection(buffer, node)
+    assert(false)
+end
+
+return module

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -3,8 +3,6 @@ local modules = neorg.modules
 
 local module = modules.create("core.todo-introspector")
 
--- TODO: When searching recursive children also account for generic_list nodes
-
 module.private = {
     namespace = vim.api.nvim_create_namespace("neorg/todo-introspector"),
 

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -64,6 +64,9 @@ function module.public.attach_introspector(buffer)
             ---@type TSNode?
             local node = module.required["core.integrations.treesitter"].get_first_node_on_line(buf, first)
 
+            -- TODO: Also check the node above the current line if there is a different node there (check node ranges).
+            -- This would allow updates to both nodes whenever a list is broken into two.
+
             vim.api.nvim_buf_clear_namespace(buffer, module.private.namespace, first + 1, first + 1)
 
             local parent = node

--- a/lua/neorg/modules/core/todo-introspector/module.lua
+++ b/lua/neorg/modules/core/todo-introspector/module.lua
@@ -46,9 +46,6 @@ function module.public.attach_introspector(buffer)
         error(string.format("Could not attach to buffer %d, buffer is not a norg file!", buffer))
     end
 
-    local language_tree = vim.treesitter.get_parser(buffer, "norg")
-    language_tree:parse(true)
-
     vim.api.nvim_buf_attach(buffer, false, {
         on_lines = function(_, buf, _, first)
             ---@type TSNode?


### PR DESCRIPTION
The old introspector code was forgotten over a year ago, so time to revive it!

The introspector is the handy module which displays `[0/1] (0%)` next to things that have subtasks.

TODOs:
- [ ] Make the display super customizable (will be done in a different PR, I would like to release this in a working state beforehand) - currently the introspector will display one format only
- [x] Correctly handle the deletion of lines (somewhat inconsistent right now, difficult to fix)
- [x] Correctly handle nodes which are broken into two (one list becoming two)

Everything else is fully functional already :)