### PR TITLE
fix(typecheck): use type definitions from nvim runtime instead

### DIFF
--- a/.github/workflows/.luarc.json
+++ b/.github/workflows/.luarc.json
@@ -6,7 +6,8 @@
     "lua/?/init.lua"
   ],
   "Lua.workspace.library": [
-    "/home/runner/work/neorg/neorg/deps/neovim/runtime/lua"
+    "/home/runner/work/neorg/neorg/deps/neovim/runtime/lua",
+    "/home/runner/work/neorg/neorg/deps/neodev.nvim/types/stable"
   ],
   "Lua.diagnostics.libraryFiles": "Disable",
   "Lua.workspace.checkThirdParty": "Disable"

--- a/.github/workflows/.luarc.json
+++ b/.github/workflows/.luarc.json
@@ -6,7 +6,7 @@
     "lua/?/init.lua"
   ],
   "Lua.workspace.library": [
-    "/home/runner/work/neorg/neorg/deps/neodev.nvim/types/stable"
+    "/home/runner/work/neorg/neorg/deps/neovim/runtime/lua"
   ],
   "Lua.diagnostics.libraryFiles": "Disable",
   "Lua.workspace.checkThirdParty": "Disable"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Checkout dependency neodev
+        uses: actions/checkout@v3
+        with:
+          repository: "folke/neodev.nvim"
+          path: "deps/neodev.nvim"
+
       - name: Checkout neovim for type annotations
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Checkout dependency neodev
+      - name: Checkout neovim for type annotations
         uses: actions/checkout@v3
         with:
-          repository: "folke/neodev.nvim"
-          path: "deps/neodev.nvim"
+          repository: "neovim/neovim"
+          path: "deps/neovim"
 
       - name: Type Check Code Base
         uses: mrcjkb/lua-typecheck-action@v0.2.1

--- a/lua/neorg/core/utils.lua
+++ b/lua/neorg/core/utils.lua
@@ -105,7 +105,10 @@ function utils.get_language_shorthands(reverse_lookup)
         ["yaml"] = { "yml" },
     }
 
-    return reverse_lookup and vim.tbl_add_reverse_lookup(langs) or langs
+    -- TODO: `vim.tbl_add_reverse_lookup` deprecated: NO ALTERNATIVES
+    -- GOOD JOB CORE DEVS
+    -- <https://github.com/neovim/neovim/pull/27639>
+    return reverse_lookup and vim.tbl_add_reverse_lookup(langs) or langs ---@diagnostic disable-line
 end
 
 --- Checks whether Neovim is running at least at a specific version.

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -232,6 +232,7 @@ module.public = {
         -- Do we need to go through each tree? lol
         vim.treesitter.get_parser(opts.buf, opts.ft):for_each_tree(function(tree)
             -- Get the root for that tree
+            ---@type TSNode
             local root = tree:root()
 
             --- Recursively searches for a node of a given type

--- a/lua/neorg/modules/core/tempus/module.lua
+++ b/lua/neorg/modules/core/tempus/module.lua
@@ -222,23 +222,16 @@ module.public = {
     ---@param parsed_date Date #The date to convert
     ---@return osdate #A Lua date
     to_lua_date = function(parsed_date)
-        return os.date( ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
-            "*t",
-            os.time(
-                vim.tbl_deep_extend(
-                    "force",
-                    os.date("*t"),
-                    { ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
-                        day = parsed_date.day,
-                        month = parsed_date.month and parsed_date.month.number or nil,
-                        year = parsed_date.year,
-                        hour = parsed_date.time and parsed_date.time.hour,
-                        min = parsed_date.time and parsed_date.time.minute,
-                        sec = parsed_date.time and parsed_date.time.second,
-                    }
-                )
-            )
-        )
+        local now = os.date("*t") --[[@as osdate]]
+        local parsed = os.time(vim.tbl_deep_extend("force", now, {
+            day = parsed_date.day,
+            month = parsed_date.month and parsed_date.month.number or nil,
+            year = parsed_date.year,
+            hour = parsed_date.time and parsed_date.time.hour,
+            min = parsed_date.time and parsed_date.time.minute,
+            sec = parsed_date.time and parsed_date.time.second,
+        }) --[[@as osdateparam]])
+        return os.date("*t", parsed) --[[@as osdate]]
     end,
 
     --- Converts a lua `osdate` to a Neorg date.


### PR DESCRIPTION
This conflicts with this PR so I'll update it later.
- https://github.com/nvim-neorg/neorg/pull/1354