### PR TITLE
fix(dirman): respect force option in dirman create_file

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -30,4 +30,4 @@ jobs:
             lua-utils.nvim == 1.0.2
             plenary.nvim == 0.1.4
             nui.nvim == 0.3.0
-            pathlib.nvim ~> 2.1
+            pathlib.nvim ~> 2.2

--- a/build.lua
+++ b/build.lua
@@ -16,7 +16,7 @@ vim.schedule(function()
         "lua-utils.nvim == 1.0.2",
         "plenary.nvim == 0.1.4",
         "nui.nvim == 0.3.0",
-        "pathlib.nvim ~> 2.1",
+        "pathlib.nvim ~> 2.2",
     })
 
     package.loaded["neorg"] = nil

--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -310,8 +310,11 @@ module.public = {
         -- Generate parents just in case
         destination:parent_assert():mkdir(Path.const.o755 + 4 * math.pow(8, 4), true) -- 40755(oct)
 
-        -- Touch file
-        destination:touch(Path.permission("rw-rw-rw-"), false)
+        -- Create or overwrite the file
+        local fd = destination:fs_open(opts.force and "w" or "a", Path.const.o644, false)
+        if fd then
+            vim.loop.fs_close(fd)
+        end
 
         -- Broadcast file creation event
         local bufnr = module.public.get_file_bufnr(destination:tostring())

--- a/neorg-scm-1.rockspec
+++ b/neorg-scm-1.rockspec
@@ -16,7 +16,7 @@ dependencies = {
     -- "norgopolis-client.lua >= 0.2.0",
     -- "norgopolis-server.lua >= 1.3.1",
     "lua-utils.nvim",
-    "pathlib.nvim ~> 2.1",
+    "pathlib.nvim ~> 2.2",
 }
 
 source = {


### PR DESCRIPTION
I noticed that I ignored the `opts.force` flag in `dirman.create_file`.

Now respects `opts.force` to decide whether to create a new empty file, or, append to the file  to just update the timestamp.

I also had a bug in pathlib `self:touch` so I changed to use `fs_open` instead.
This is fixed in `pathlib.nvim ~> 2.2` so bumped the version as well just in case.

Fixes: https://github.com/nvim-neorg/neorg/issues/1365