### PR TITLE
feat: parallel rendering of latex snippets

### DIFF
--- a/lua/neorg/modules/core/integrations/image/module.lua
+++ b/lua/neorg/modules/core/integrations/image/module.lua
@@ -26,17 +26,17 @@ module.private = {
 
 module.public = {
     new_image = function(buffernr, png_path, position, window, scale, virtual_padding)
-        local geometry = {
-            x = position.column_start,
-            y = position.row_start + (virtual_padding and 1 or 0),
-            width = position.column_end - position.column_start,
-            height = scale,
-        }
         local image = require("image").from_file(png_path, {
             window = window,
             buffer = buffernr,
             with_virtual_padding = virtual_padding,
         })
+        local geometry = {
+            x = position.column_start,
+            y = position.row_start + (virtual_padding and 1 or 0),
+            width = position.column_end - position.column_start,
+            height = scale * image.image_height,
+        }
         image:render(geometry)
     end,
     get_images = function()
@@ -44,8 +44,10 @@ module.public = {
     end,
     render = function(images)
         for _, image in pairs(images) do
-            image:clear()
-            image:render()
+            if not image.is_rendered then
+                image:clear()
+                image:render()
+            end
         end
     end,
     clear = function()

--- a/lua/neorg/modules/core/integrations/image/module.lua
+++ b/lua/neorg/modules/core/integrations/image/module.lua
@@ -35,7 +35,7 @@ module.public = {
             x = position.column_start,
             y = position.row_start + (virtual_padding and 1 or 0),
             width = position.column_end - position.column_start,
-            height = scale * image.image_height,
+            height = scale,
         }
         image:render(geometry)
     end,


### PR DESCRIPTION
Hi! I've been using the latex renderer for some of my notes and I noticed its performance scaled badly with the amount of equations in the document. In short, equations currently are rendered one by one, in a blocking manner. 
This PR performs all the renderings in parallel.

Here is an example of the difference: 
Current `main` behavior (around 13s until the user gets back control):
https://github.com/nvim-neorg/neorg/assets/31407988/f004090c-92bb-4f67-8187-d31997b05b27
This pr (3 to 4s until the user gets back control):
https://github.com/nvim-neorg/neorg/assets/31407988/1104073e-700b-44c1-a5b1-e41abf2592c3


I've made a bunch of changes to the latex renderer that I think improve its usability:
1. Refactor `latex_renderer` so that all latex_snippets are extracted and rendered in parallel jobs. This way we only need to wait for the longest render.
2. Name the rendered files according to the base64 encoding of the snippet, this way subsequent calls to `render_latex` do not need to perform the conversion from `latex` to `png`. ~~I've added the same base64 utility function that is used in `image.nvim`. Let me know if it would be better placed in another location in the project or if it is better to use other implementation (I'm not very familiar with the lua ecosystem)~~.

EDIT:
Point 3 is no longer part of this PR, as @benlubas correctly pointed out that the performance problems that I was experiencing with OnCursorMove only apply when you don't set the `conceal` option, I keep the text here for context:
3. Remove the "OnCursorMove" event handling. Unfortunately it is too costly whenever you have more than 5 or 6 equations on screen. If you try to open a document with ~10 equations like in the example you can end up with the nvim ui effectively locked if you try to move your cursor too quickly. In addition this event does not prevent the user from having to re-run `latex_render` if they are making modifications to the equations, as new equations won't get rendered on OnCursorMove event. I think it is better to just make the user re-run `latex_render`, but I'm open to revert this change if you consider it's still better to have the event as it is on `main`.