### PR TITLE
docs(README): Fix navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,15 @@ Your New Life Organization Tool - All in Lua
 •
 [Tutorial](#-tutorial)
 •
-[Installation](#-installationquickstart)
+[Installation](#-installation)
 •
-[Setup](#-setup)
-•
-[Usage](#-usage)
+[Further Learning](#-further-learning)
 <br>
-[Modules](#-modules)
+[Credits](#credits)
+•
+[Support](#support)
 •
 [Roadmap](/ROADMAP.md)
-•
-[Philosophy](#-philosophy)
-•
-[FAQ](#-faq)
 
 </div>
 


### PR DESCRIPTION
The links on the main page are broken.

I edited them so that they again mirror the page's structure. I placed the line break so that the layout looks similar to before. I kept the roadmap link as it was. I suppose it is still intended to be there?
