### PR TITLE
hop to relative paths (file:./rel/path)

### DIFF
--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -158,7 +158,8 @@ version: 0.1
     - `:path:` (another norg file at a given path without specific target)
     - `/ path` (a non-norg file at a given path)
     - `https://github.com` (a URL)
-    - `file:///some/path` (any file, opened via `(xdg-)open`)
+    - `file:///some/path` (any file, opened via `(xdg-)open`). Note neorg also supports relative
+      paths (e.g. `file:./subdir/path`)
 
     Any of the paths used in `:path:` or `/ path` can be formatted in either of the following ways:
     - `:path/to/norg/file:` relative to the file which contains this link

--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -89,6 +89,9 @@ module.public = {
 
         local function os_open_link(link_location)
             local o = {}
+
+            link_location = module.private.file_link_to_absolute_path(link_location)
+
             if config.os_info == "windows" then
                 o.command = "rundll32.exe"
                 o.args = { "url.dll,FileProtocolHandler", link_location }
@@ -948,6 +951,24 @@ module.private = {
                 )
         )
     end,
+
+    --- convert "file:./path" to abolute to match the uri-scheme (https://en.wikipedia.org/wiki/File_URI_scheme)
+    ---@param link_str string of "file:" followed by a relative path (if it consists of "file://" followed by an absolute)
+    ---@return string of the form "file://" followed by
+    -- https://en.wikipedia.org/wiki/File_URI_scheme
+    file_link_to_absolute_path = function(link_str)
+        if not vim.startswith(link_str, "file:///") then
+            -- convert the relative path to absolute
+            local tgt_loc = string.gsub(link_str, "file:", "")
+
+            local cwd = vim.fn.expand('%:p:h')
+            local tgt_loc_abs = cwd .. "/" .. tgt_loc
+            return "file://" .. tgt_loc_abs
+        else
+            return link_str
+        end
+    end,
+
 }
 
 module.on_event = function(event)


### PR DESCRIPTION
This pull request adds a feature discussed here (https://github.com/nvim-neorg/neorg/discussions/456). Currently a user can open a file in an external program with `{file:///absolute/path/to/file}`. On my end where I put my notes in a repository that may end up on different machines with different paths, it is way more useful to be able to specify a relative path, e.g. `{file:./relative/path}`.

This pull request adds the ability to add `{file:./relative/path}`.

Example:

Put `mypic.png` in a directory somewhere and `foo.norg` in the same directory with the following:

```
{file:./mypic.png}
```

Place the cursor over the link and hit `<cr>`. It should open in an external program.