### PR TITLE
Add missing parameter to string format.

### DIFF
--- a/lua/neorg/health.lua
+++ b/lua/neorg/health.lua
@@ -24,7 +24,8 @@ return {
                 elseif not modules[key] then
                     vim.health.warn(
                         string.format(
-                            "You are attempting to load a module `%s` which is not recognized by Neorg at this time. You may receive an error upon launching Neorg."
+                            "You are attempting to load a module `%s` which is not recognized by Neorg at this time. You may receive an error upon launching Neorg.",
+                            key
                         )
                     )
                 elseif type(value) ~= "table" then


### PR DESCRIPTION
Added the missing `key` to `string.format` when logging a warning about attempting to load an unknown module.