### PR TITLE
docs: emphasise luarock.nvim extra install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See [this blog](https://vhyrro.github.io/posts/neorg-and-luarocks/) for more inf
 <details>
 <summary>Click for installation snippet.</summary>
 
-- Ensure you have `vhyrro/luarocks.nvim` installed:
+- Ensure you have [`vhyrro/luarocks.nvim`](https://github.com/vhyrro/luarocks.nvim) installed (**NOTE**: there are additional install steps in that README):
   ```lua
   {
       "vhyrro/luarocks.nvim",


### PR DESCRIPTION
Documentation (readme) update to make the install instructions for luarocks.nvim more clear.

- links the repo (b/c it very hard to find by nature of it being a fork)
- make it more clear that `luarocks.nvim` has additional installation steps

_also, I haven't done it in this PR, but I think that we should add Pysan's written tutorial to the README._
