### PR TITLE
feat(latex): async image rendering

### DIFF
--- a/lua/neorg/modules/core/highlights/module.lua
+++ b/lua/neorg/modules/core/highlights/module.lua
@@ -367,6 +367,12 @@ module.config.public = {
             link = "+NonText",
             escape = "+@type",
         },
+
+        -- Rendered Latex, this will dictate the foreground color of latex images rendered via
+        -- core.latex.renderer
+        rendered = {
+            latex = "+Normal",
+        }
     },
 
     -- Handles the dimming of certain highlight groups.
@@ -593,22 +599,22 @@ module.public = {
         return "NONE"
     end,
 
+    hex_to_rgb = function(hex_colour)
+        return tonumber(hex_colour:sub(1, 2), 16),
+            tonumber(hex_colour:sub(3, 4), 16),
+            tonumber(hex_colour:sub(5), 16)
+    end,
+
     dim_color = function(colour, percent)
         if colour == "NONE" then
             return colour
-        end
-
-        local function hex_to_rgb(hex_colour)
-            return tonumber(hex_colour:sub(1, 2), 16),
-                tonumber(hex_colour:sub(3, 4), 16),
-                tonumber(hex_colour:sub(5), 16)
         end
 
         local function alter(attr)
             return math.floor(attr * (100 - percent) / 100)
         end
 
-        local r, g, b = hex_to_rgb(colour)
+        local r, g, b = module.public.hex_to_rgb(colour)
 
         if not r or not g or not b then
             return "NONE"

--- a/lua/neorg/modules/core/integrations/image/module.lua
+++ b/lua/neorg/modules/core/integrations/image/module.lua
@@ -18,6 +18,7 @@ module.load = function()
     assert(success, "Unable to load image.nvim plugin")
 
     module.private.image = image
+    module.private.image_utils = require("image.utils")
 end
 
 module.private = {
@@ -62,6 +63,35 @@ module.public = {
             end
         end
         return cleared
+    end,
+    ---Compute the image's rendered width/height without rendering
+    ---@param image any an image.nvim image
+    ---@param limit { width: number, height: number }
+    ---@return { width: number, height: number }
+    image_size = function(image, limit)
+        limit = limit or {}
+        local term_size = require("image.utils.term").get_size()
+        local gopts = image.global_state.options
+        local true_size = {
+            width = math.min(
+                image.image_width / term_size.cell_width,
+                gopts.max_width or math.huge,
+                limit.width or math.huge
+            ),
+            height = math.min(
+                image.image_height / term_size.cell_height,
+                gopts.max_height or math.huge,
+                limit.height or math.huge
+            ),
+        }
+        local width, height = module.private.image_utils.math.adjust_to_aspect_ratio(
+            term_size,
+            image.image_width,
+            image.image_height,
+            true_size.width,
+            true_size.height
+        )
+        return { width = math.ceil(width), height = math.ceil(height) }
     end,
 }
 

--- a/lua/neorg/modules/core/integrations/image/module.lua
+++ b/lua/neorg/modules/core/integrations/image/module.lua
@@ -42,7 +42,7 @@ module.public = {
     ---@param images any[]
     render = function(images)
         for _, limage in pairs(images) do
-            limage.image:render()
+            limage.image:render({ y = limage.range[1], x = limage.range[2] })
         end
     end,
     clear = function(images)

--- a/lua/neorg/modules/core/integrations/image/module.lua
+++ b/lua/neorg/modules/core/integrations/image/module.lua
@@ -34,10 +34,8 @@ module.public = {
             with_virtual_padding = virtual_padding,
             x = position.column_start,
             y = position.row_start + (virtual_padding and 1 or 0),
-            width = position.column_end - position.column_start,
             height = scale,
         })
-        -- image:render(geometry)
         return image
     end,
     ---Render an image or list of images
@@ -72,14 +70,15 @@ module.public = {
         limit = limit or {}
         local term_size = require("image.utils.term").get_size()
         local gopts = image.global_state.options
+
         local true_size = {
             width = math.min(
-                image.image_width / term_size.cell_width,
-                gopts.max_width or math.huge,
-                limit.width or math.huge
+                math.floor(image.image_width / term_size.cell_width), -- max image size (images don't scale up past their true size)
+                gopts.max_width or math.huge,                         -- image.nvim configured max size
+                limit.width or math.huge                              -- latex-renderer configured max size
             ),
             height = math.min(
-                image.image_height / term_size.cell_height,
+                math.floor(image.image_height / term_size.cell_height),
                 gopts.max_height or math.huge,
                 limit.height or math.huge
             ),

--- a/lua/neorg/modules/core/integrations/image/module.lua
+++ b/lua/neorg/modules/core/integrations/image/module.lua
@@ -42,7 +42,6 @@ module.public = {
     ---@param images any[]
     render = function(images)
         for _, limage in pairs(images) do
-            limage.image:clear()
             limage.image:render()
         end
     end,

--- a/lua/neorg/modules/core/integrations/image/module.lua
+++ b/lua/neorg/modules/core/integrations/image/module.lua
@@ -26,40 +26,42 @@ module.private = {
 
 module.public = {
     new_image = function(buffernr, png_path, position, window, scale, virtual_padding)
-        local geometry = {
+        local image = require("image").from_file(png_path, {
+            window = window,
+            buffer = buffernr,
+            inline = true, -- let image.nvim track the position for us
+            with_virtual_padding = virtual_padding,
             x = position.column_start,
             y = position.row_start + (virtual_padding and 1 or 0),
             width = position.column_end - position.column_start,
             height = scale,
-        }
-        local image = require("image").from_file(png_path, {
-            window = window,
-            buffer = buffernr,
-            with_virtual_padding = virtual_padding,
         })
-        image:render(geometry)
+        -- image:render(geometry)
+        return image
     end,
-    get_images = function()
-        return (require("image").get_images())
-    end,
+    ---Render an image or list of images
+    ---@param images any[]
     render = function(images)
-        for _, image in pairs(images) do
-            image:clear()
-            image:render()
+        for _, limage in pairs(images) do
+            limage.image:clear()
+            limage.image:render()
         end
     end,
-    clear = function()
-        local images = module.public.get_images()
-        for _, image in pairs(images) do
-            image:clear()
+    clear = function(images)
+        for _, limage in pairs(images) do
+            limage.image:clear()
         end
     end,
     clear_at_cursor = function(images, row)
-        for _, image in pairs(images) do
+        local cleared = {}
+        for id, limage in pairs(images) do
+            local image = limage.image
             if image.geometry.y == row then
                 image:clear()
+                table.insert(cleared, id)
             end
         end
+        return cleared
     end,
 }
 

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -215,9 +215,9 @@ module.public = {
         end
     end,
     ---  Gets all nodes of a given type from the AST
-    ---@param  type string #The type of node to filter out
+    ---@param  node_type string #The type of node to filter out
     ---@param opts? table #A table of two options: `buf` and `ft`, for the buffer and format to use respectively.
-    get_all_nodes = function(type, opts)
+    get_all_nodes = function(node_type, opts)
         local result = {}
         opts = opts or {}
 
@@ -231,29 +231,46 @@ module.public = {
 
         -- Do we need to go through each tree? lol
         vim.treesitter.get_parser(opts.buf, opts.ft):for_each_tree(function(tree)
-            -- Get the root for that tree
-            ---@type TSNode
-            local root = tree:root()
+            table.insert(result, module.public.search_tree(tree, node_type))
+        end)
 
-            --- Recursively searches for a node of a given type
-            ---@param node userdata #The starting point for the search
-            local function descend(node)
-                -- Iterate over all children of the node and try to match their type
-                for child, _ in node:iter_children() do ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
-                    if child:type() == type then
-                        table.insert(result, child)
-                    else
-                        -- If no match is found try descending further down the syntax tree
-                        for _, child_node in ipairs(descend(child) or {}) do
-                            table.insert(result, child_node)
-                        end
+        return vim.tbl_flatten(result)
+    end,
+    ---  Gets all nodes of a given type from the AST
+    ---@param node_type string #The type of node to filter out
+    ---@param path string path to the file to parse
+    ---@param filetype string? file type of the file or `norg` if omitted
+    get_all_nodes_in_file = function(node_type, path, filetype)
+        path = vim.fs.normalize(path)
+        if not filetype then filetype = "norg" end
+
+        local contents = io.open(path, "r"):read("*a")
+        local tree = vim.treesitter.get_string_parser(contents, filetype):parse()[1]
+        if not (tree or tree.root) then return {} end
+
+        return module.public.search_tree(tree, node_type)
+    end,
+    search_tree = function(tree, node_type)
+        local result = {}
+        local root = tree:root()
+
+        --- Recursively searches for a node of a given type
+        ---@param node userdata #The starting point for the search
+        local function descend(node)
+            -- Iterate over all children of the node and try to match their type
+            for child, _ in node:iter_children() do ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                if child:type() == node_type then
+                    table.insert(result, child)
+                else
+                    -- If no match is found try descending further down the syntax tree
+                    for _, child_node in ipairs(descend(child) or {}) do
+                        table.insert(result, child_node)
                     end
                 end
             end
+        end
 
-            descend(root)
-        end)
-
+        descend(root)
         return result
     end,
     --- Executes function callback on each child node of the root
@@ -288,11 +305,18 @@ module.public = {
         descend(root)
     end,
     get_node_text = function(node, source)
-        source = source or 0
-
+        if not node then return "" end
         local start_row, start_col = node:start()
         local end_row, end_col = node:end_()
 
+        -- when source is the string contents of the file
+        if type(source) == "string" then
+            local _, _, start_bytes = node:start()
+            local _, _, end_bytes = node:end_()
+            return string.sub(source, start_bytes, end_bytes)
+        end
+
+        source = source or 0
         local eof_row = vim.api.nvim_buf_line_count(source)
 
         if end_row >= eof_row then

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -215,9 +215,9 @@ module.public = {
         end
     end,
     ---  Gets all nodes of a given type from the AST
-    ---@param  node_type string #The type of node to filter out
+    ---@param  type string #The type of node to filter out
     ---@param opts? table #A table of two options: `buf` and `ft`, for the buffer and format to use respectively.
-    get_all_nodes = function(node_type, opts)
+    get_all_nodes = function(type, opts)
         local result = {}
         opts = opts or {}
 
@@ -231,46 +231,29 @@ module.public = {
 
         -- Do we need to go through each tree? lol
         vim.treesitter.get_parser(opts.buf, opts.ft):for_each_tree(function(tree)
-            table.insert(result, module.public.search_tree(tree, node_type))
-        end)
+            -- Get the root for that tree
+            ---@type TSNode
+            local root = tree:root()
 
-        return vim.tbl_flatten(result)
-    end,
-    ---  Gets all nodes of a given type from the AST
-    ---@param node_type string #The type of node to filter out
-    ---@param path string path to the file to parse
-    ---@param filetype string? file type of the file or `norg` if omitted
-    get_all_nodes_in_file = function(node_type, path, filetype)
-        path = vim.fs.normalize(path)
-        if not filetype then filetype = "norg" end
-
-        local contents = io.open(path, "r"):read("*a")
-        local tree = vim.treesitter.get_string_parser(contents, filetype):parse()[1]
-        if not (tree or tree.root) then return {} end
-
-        return module.public.search_tree(tree, node_type)
-    end,
-    search_tree = function(tree, node_type)
-        local result = {}
-        local root = tree:root()
-
-        --- Recursively searches for a node of a given type
-        ---@param node userdata #The starting point for the search
-        local function descend(node)
-            -- Iterate over all children of the node and try to match their type
-            for child, _ in node:iter_children() do ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
-                if child:type() == node_type then
-                    table.insert(result, child)
-                else
-                    -- If no match is found try descending further down the syntax tree
-                    for _, child_node in ipairs(descend(child) or {}) do
-                        table.insert(result, child_node)
+            --- Recursively searches for a node of a given type
+            ---@param node userdata #The starting point for the search
+            local function descend(node)
+                -- Iterate over all children of the node and try to match their type
+                for child, _ in node:iter_children() do ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
+                    if child:type() == type then
+                        table.insert(result, child)
+                    else
+                        -- If no match is found try descending further down the syntax tree
+                        for _, child_node in ipairs(descend(child) or {}) do
+                            table.insert(result, child_node)
+                        end
                     end
                 end
             end
-        end
 
-        descend(root)
+            descend(root)
+        end)
+
         return result
     end,
     --- Executes function callback on each child node of the root
@@ -305,18 +288,11 @@ module.public = {
         descend(root)
     end,
     get_node_text = function(node, source)
-        if not node then return "" end
+        source = source or 0
+
         local start_row, start_col = node:start()
         local end_row, end_col = node:end_()
 
-        -- when source is the string contents of the file
-        if type(source) == "string" then
-            local _, _, start_bytes = node:start()
-            local _, _, end_bytes = node:end_()
-            return string.sub(source, start_bytes, end_bytes)
-        end
-
-        source = source or 0
         local eof_row = vim.api.nvim_buf_line_count(source)
 
         if end_row >= eof_row then

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -154,6 +154,7 @@ module.private.clear_extmark = function(key)
 end
 
 module.public = {
+    ---@async
     async_latex_renderer = function()
         ---node range to image handle
         -- module.private.ranges = {}
@@ -230,6 +231,7 @@ module.public = {
     end,
 
     ---Writes a latex snippet to a file and wraps it with latex headers to it will render nicely
+    ---@async
     ---@param snippet string latex snippet (if it's math it should include the surrounding $$)
     ---@return string temp file path
     async_create_latex_document = function(snippet)
@@ -253,6 +255,7 @@ module.public = {
     end,
 
     ---Returns a filepath where the rendered image sits
+    ---@async
     ---@param snippet string the full latex snippet to convert to an image
     ---@return string | nil
     async_generate_image = function(snippet)
@@ -361,7 +364,7 @@ local function render_latex()
     end
 
     if not render_timer then
-        render_timer = vim.loop.new_timer()
+        render_timer = vim.uv.new_timer()
     end
 
     render_timer:start(module.config.public.debounce_ms, 0, function()

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -157,7 +157,8 @@ module.public = {
         local new_limages = {}
         for _, limage in pairs(module.private.latex_images[buf] or {}) do
             if limage.extmark_id then
-                local extmark = nio.api.nvim_buf_get_extmark_by_id(buf, module.private.extmark_ns, limage.extmark_id, {})
+                local extmark =
+                    nio.api.nvim_buf_get_extmark_by_id(buf, module.private.extmark_ns, limage.extmark_id, {})
                 local new_key = module.private.get_key({ extmark[1], extmark[2] })
                 limage.real = false
                 new_limages[new_key] = limage
@@ -336,13 +337,16 @@ module.public = {
                 id = limage.extmark_id, -- if it exists, update it, else this is nil so it will create a new one
             }
 
-            if conceal_on and range[1] ~= cursor_row - 1 then
+            if module.config.public.conceal then
                 local image = limage.image
                 local predicted_image_dimensions =
                     module.private.image_api.image_size(image, { height = module.config.public.scale })
                 ext_opts.virt_text = { { (" "):rep(predicted_image_dimensions.width) } }
-                ext_opts.conceal = ""
                 ext_opts.virt_text_pos = "inline"
+            end
+
+            if conceal_on and range[1] ~= cursor_row - 1 then
+                ext_opts.conceal = ""
             end
 
             limage.extmark_id =

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -8,8 +8,15 @@ This is an experimental module that requires nvim 0.10+. It renders LaTeX snippe
 making use of the image.nvim plugin. By default, images are only rendered after running the
 command: `:Neorg render-latex`.
 
-Requires [image.nvim](https://github.com/3rd/image.nvim).
+Requires:
+- The [image.nvim](https://github.com/3rd/image.nvim) neovim plugin.
+- `latex` executable in path
+- `dvipng` executable in path (normally comes with LaTeX)
+
+There's a highlight group that controls the foreground color of the rendered latex:
+`@norg.rendered.latex`, configurable in `core.highlights`
 --]]
+local nio
 local neorg = require("neorg.core")
 local module = neorg.modules.create("core.latex.renderer")
 local modules = neorg.modules
@@ -18,162 +25,15 @@ assert(vim.re ~= nil, "Neovim 0.10.0+ is required to run the `core.renderer.late
 
 module.setup = function()
     return {
-        wants = {
-            "core.integrations.image",
-        },
         requires = {
+            "core.integrations.image",
             "core.integrations.treesitter",
             "core.autocommands",
             "core.neorgcmd",
+            "core.highlights",
         },
     }
 end
-
-module.load = function()
-    local success, image = pcall(neorg.modules.get_module, module.config.public.renderer)
-
-    assert(success, "Unable to load image module")
-
-    module.private.image = image
-
-    module.required["core.autocommands"].enable_autocommand("BufWinEnter")
-    module.required["core.autocommands"].enable_autocommand("CursorMoved")
-    module.required["core.autocommands"].enable_autocommand("TextChanged")
-    module.required["core.autocommands"].enable_autocommand("TextChangedI")
-    module.required["core.autocommands"].enable_autocommand("TextChangedP")
-    module.required["core.autocommands"].enable_autocommand("TextChangedT")
-
-    modules.await("core.neorgcmd", function(neorgcmd)
-        neorgcmd.add_commands_from_table({
-            ["render-latex"] = {
-                name = "core.latex.renderer.render",
-                args = 0,
-                condition = "norg",
-            },
-        })
-    end)
-end
-
----@class core.latex.renderer
-module.public = {
-    latex_renderer = function()
-        module.private.ranges = {}
-        module.required["core.integrations.treesitter"].execute_query(
-            [[
-                (
-                    (inline_math) @latex
-                    (#offset! @latex 0 1 0 -1)
-                )
-            ]],
-            function(query, id, node)
-                if query.captures[id] ~= "latex" then
-                    return
-                end
-
-                local latex_snippet =
-                    module.required["core.integrations.treesitter"].get_node_text(node, vim.api.nvim_get_current_buf())
-
-                local png_location = module.public.parse_latex(latex_snippet)
-
-                module.private.image.new_image(
-                    vim.api.nvim_get_current_buf(),
-                    png_location,
-                    module.required["core.integrations.treesitter"].get_node_range(node),
-                    vim.api.nvim_get_current_win(),
-                    module.config.public.scale,
-                    not module.config.public.conceal
-                )
-
-                table.insert(module.private.ranges, { node:range() })
-            end
-        )
-        module.private.images = module.private.image.get_images()
-    end,
-    create_latex_document = function(snippet)
-        local tempname = vim.fn.tempname()
-
-        local tempfile = io.open(tempname, "w")
-
-        if not tempfile then
-            return
-        end
-
-        local content = table.concat({
-            "\\documentclass[6pt]{standalone}",
-            "\\usepackage{amsmath}",
-            "\\usepackage{amssymb}",
-            "\\usepackage{graphicx}",
-            "\\begin{document}",
-            snippet,
-            "\\end{document}",
-        }, "\n")
-
-        tempfile:write(content)
-        tempfile:close()
-
-        return tempname
-    end,
-
-    -- Returns a handle to an image containing
-    -- the rendered snippet.
-    -- This handle can then be delegated to an external renderer.
-    parse_latex = function(snippet)
-        local document_name = module.public.create_latex_document(snippet)
-
-        if not document_name then
-            return
-        end
-
-        local cwd = vim.fn.fnamemodify(document_name, ":h")
-        vim.fn.jobwait({
-            vim.fn.jobstart(
-                "latex  --interaction=nonstopmode --output-dir=" .. cwd .. " --output-format=dvi " .. document_name,
-                { cwd = cwd }
-            ),
-        })
-
-        local png_result = vim.fn.tempname()
-        -- TODO: Make the conversions async via `on_exit`
-        vim.fn.jobwait({
-            vim.fn.jobstart(
-                "dvipng -D "
-                    .. tostring(module.config.public.dpi)
-                    .. " -T tight -bg Transparent -fg 'cmyk 0.00 0.04 0.21 0.02' -o "
-                    .. png_result
-                    .. " "
-                    .. document_name
-                    .. ".dvi",
-                { cwd = vim.fn.fnamemodify(document_name, ":h") }
-            ),
-        })
-
-        return png_result
-    end,
-    render_inline_math = function(images)
-        local conceal_on = (vim.wo.conceallevel >= 2) and module.config.public.conceal
-        if conceal_on then
-            table.sort(images, function(a, b)
-                return a.internal_id < b.internal_id
-            end)
-
-            for i, range in ipairs(module.private.ranges) do
-                vim.api.nvim_buf_set_extmark(
-                    vim.api.nvim_get_current_buf(),
-                    vim.api.nvim_create_namespace("concealer"),
-                    range[1],
-                    range[2],
-                    {
-                        id = i,
-                        end_col = range[4],
-                        conceal = "",
-                        virt_text = { { (" "):rep(images[i].rendered_geometry.width) } },
-                        virt_text_pos = "inline",
-                    }
-                )
-            end
-        end
-    end,
-}
 
 module.config.public = {
     -- When true, images of rendered LaTeX will cover the source LaTeX they were produced from
@@ -189,35 +49,410 @@ module.config.public = {
     -- Module that renders the images. This is currently the only option
     renderer = "core.integrations.image",
 
+    -- Don't re-render anything until 200ms after the buffer has stopped changing
+    debounce_ms = 200,
+
     -- Make the images larger or smaller by adjusting the scale
     scale = 1,
 }
 
-local function render_latex()
-    module.private.image.clear(module.private.images)
-    neorg.modules.get_module("core.latex.renderer").latex_renderer()
-    neorg.modules.get_module("core.latex.renderer").render_inline_math(module.private.images)
+---@class Image
+---@field geometry table
+---@field rendered_geometry table
+---@field path string
+---@field is_rendered boolean
+---@field id string
+-- and many other fields that I don't necessarily need
+
+---@class MathRange
+---@field image Image our limited representation of an image
+---@field range Range4 last range of the math block. Updated based on the extmark
+---@field snippet string
+
+---Compute and set the foreground color string
+local function compute_foreground()
+    local neorg_hi = neorg.modules.get_module("core.highlights")
+    assert(neorg_hi, "Failed to load core.highlights")
+    local hi = vim.api.nvim_get_hl(0, { name = "@neorg.rendered.latex", link = false })
+    if not vim.tbl_isempty(hi) then
+        local r, g, b = neorg_hi.hex_to_rgb(("%06x"):format(hi.fg))
+        module.private.foreground = ("rgb %s %s %s"):format(r / 255., g / 255., b / 255.)
+    else
+        -- grey
+        module.private.foreground = "rgb 0.5 0.5 0.5"
+    end
 end
 
-local function clear_latex()
-    module.private.image.clear(module.private.images)
+module.load = function()
+    local success, image = pcall(neorg.modules.get_module, module.config.public.renderer)
+
+    assert(success, "Unable to load image module")
+
+    nio = require("nio")
+
+    -- compute the foreground color in rgb
+    compute_foreground()
+
+    ---@type string[] ids
+    module.private.cleared_at_cursor = {}
+
+    ---Image cache, latex_snippet to file path
+    ---@type table<string, string>
+    module.private.image_paths = {}
+
+    ---@type table<string, MathRange>
+    module.private.latex_images = {}
+
+    ---@type table<string, number>
+    module.private.extmark_ids = {}
+
+    module.private.image_api = image
+    module.private.extmark_ns = vim.api.nvim_create_namespace("neorg-latex-concealer")
+
+    module.private.do_render = module.config.public.render_on_enter
+
+    module.required["core.autocommands"].enable_autocommand("BufWinEnter")
+    module.required["core.autocommands"].enable_autocommand("CursorMoved")
+    module.required["core.autocommands"].enable_autocommand("TextChanged")
+    module.required["core.autocommands"].enable_autocommand("TextChangedI")
+
+    modules.await("core.neorgcmd", function(neorgcmd)
+        neorgcmd.add_commands_from_table({
+            ["render-latex"] = {
+                name = "latex.render.render",
+                min_args = 0,
+                max_args = 1,
+                subcommands = {
+                    enable = {
+                        args = 0,
+                        name = "latex.render.enable",
+                    },
+                    disable = {
+                        args = 0,
+                        name = "latex.render.disable",
+                    },
+                },
+                condition = "norg",
+            },
+        })
+    end)
+end
+
+---Get the key for a given range
+---@param range Range4
+module.private.get_key = function(range)
+    return ("%d:%d"):format(range[1], range[2])
+end
+
+---Clear an extmark for the given key if it exists
+---@param key string
+module.private.clear_extmark = function(key)
+    if module.private.extmark_ids[key] then
+        nio.api.nvim_buf_del_extmark(0, module.private.extmark_ns, module.private.extmark_ids[key])
+        module.private.extmark_ids[key] = nil
+    end
+end
+
+module.public = {
+    async_latex_renderer = function()
+        ---node range to image handle
+        -- module.private.ranges = {}
+        ---@type table<string, MathRange>
+        local next_images = {}
+        module.required["core.integrations.treesitter"].execute_query(
+            [[
+                (
+                    (inline_math) @latex
+                    (#offset! @latex 0 1 0 -1)
+                )
+            ]],
+            function(query, id, node)
+                if query.captures[id] ~= "latex" then
+                    return
+                end
+
+                local latex_snippet =
+                    module.required["core.integrations.treesitter"].get_node_text(node, nio.api.nvim_get_current_buf())
+                latex_snippet = string.gsub(latex_snippet, "^%$|", "$")
+                latex_snippet = string.gsub(latex_snippet, "|%$$", "$")
+
+                local png_location = module.private.image_paths[latex_snippet]
+                    or module.public.async_generate_image(latex_snippet)
+                if not png_location then
+                    return
+                end
+                module.private.image_paths[latex_snippet] = png_location
+                local range = { node:range() }
+                local key = module.private.get_key(range)
+
+                if module.private.latex_images[key] then
+                    local img = module.private.latex_images[key].image
+                    if img.path == png_location and img.geometry.y == range[1] then
+                        -- This is the same image that's already there.
+                        next_images[key] = module.private.latex_images[key]
+                        -- The range might have changed though
+                        next_images[key].range = range
+                        return
+                    end
+                end
+
+                local img = module.private.image_api.new_image(
+                    nio.api.nvim_get_current_buf(),
+                    png_location,
+                    module.required["core.integrations.treesitter"].get_node_range(node),
+                    nio.api.nvim_get_current_win(),
+                    module.config.public.scale,
+                    not module.config.public.conceal
+                )
+                next_images[key] = { image = img, range = range, snippet = latex_snippet }
+            end
+        )
+
+        -- remove any 'orphaned' images. These are images attached to a range that isn't in this
+        -- list, or images that are going to be replaced.
+        for key, limage in pairs(module.private.latex_images) do
+            if not next_images[key] or next_images[key].image.id ~= limage.image.id then
+                -- This is an image that no longer exists...
+                module.private.image_api.clear({ [key] = limage })
+                module.private.clear_extmark(key)
+            end
+        end
+        for key, limage in pairs(next_images) do
+            -- existing images in the same position, if it's a different snippet, clear it, b/c it's
+            -- no longer accurate
+            local existing_img = module.private.latex_images[key]
+            if existing_img and existing_img.snippet ~= limage.snippet then
+                module.private.image_api.clear({ [key] = existing_img })
+                module.private.clear_extmark(key)
+            end
+        end
+        module.private.latex_images = next_images
+    end,
+
+    ---Writes a latex snippet to a file and wraps it with latex headers to it will render nicely
+    ---@param snippet string latex snippet (if it's math it should include the surrounding $$)
+    ---@return string temp file path
+    async_create_latex_document = function(snippet)
+        local tempname = nio.fn.tempname()
+        local tempfile = nio.file.open(tempname, "w")
+
+        local content = table.concat({
+            "\\documentclass[6pt]{standalone}",
+            "\\usepackage{amsmath}",
+            "\\usepackage{amssymb}",
+            "\\usepackage{graphicx}",
+            "\\begin{document}",
+            snippet,
+            "\\end{document}",
+        }, "\n")
+
+        tempfile.write(content)
+        tempfile.close()
+
+        return tempname
+    end,
+
+    ---Returns a filepath where the rendered image sits
+    ---@param snippet string the full latex snippet to convert to an image
+    ---@return string | nil
+    async_generate_image = function(snippet)
+        local document_name = module.public.async_create_latex_document(snippet)
+
+        if not document_name then
+            return
+        end
+
+        local cwd = nio.fn.fnamemodify(document_name, ":h")
+        local create_dvi = nio.process.run({
+            cmd = "latex",
+            args = {
+                "--interaction=nonstopmode",
+                "--output-format=dvi",
+                document_name,
+            },
+            cwd = cwd,
+        })
+        if not create_dvi or type(create_dvi) == "string" then
+            return
+        end
+        local res = create_dvi.result()
+        if res ~= 0 then
+            return
+        end
+
+        local png_result = nio.fn.tempname()
+        png_result = ("%s.png"):format(png_result)
+
+        local dvipng = nio.process.run({
+            cmd = "dvipng",
+            args = {
+                "-D",
+                module.config.public.dpi,
+                "-T",
+                "tight",
+                "-bg",
+                "Transparent",
+                "-fg",
+                module.private.foreground,
+                "-o",
+                png_result,
+                document_name .. ".dvi",
+            },
+        })
+
+        if not dvipng or type(dvipng) == "string" then
+            return
+        end
+        res = dvipng.result()
+        if res ~= 0 then
+            return
+        end
+
+        return png_result
+    end,
+
+    ---Actually renders the images (along with any extmarks it needs)
+    ---@param images table<string, MathRange>
+    render_inline_math = function(images)
+        local conceallevel = vim.api.nvim_get_option_value("conceallevel", { win = 0 })
+        local cursor_row = vim.api.nvim_win_get_cursor(0)[1]
+        local conceal_on = conceallevel >= 2 and module.config.public.conceal
+        for key, limage in pairs(images) do
+            local range = limage.range
+            local image = limage.image
+            if range[1] == cursor_row - 1 then
+                table.insert(module.private.cleared_at_cursor, key)
+                goto continue
+            end
+            if not image.is_rendered then
+                module.private.image_api.render({ limage })
+            end
+
+            if conceal_on then
+                if not module.private.extmark_ids[key] then
+                    module.private.clear_extmark(key)
+                    local id = vim.api.nvim_buf_set_extmark(0, module.private.extmark_ns, range[1], range[2], {
+                        end_col = range[4],
+                        conceal = "",
+                        virt_text = { { (" "):rep(image.rendered_geometry.width or image.geometry.width) } },
+                        virt_text_pos = "inline",
+                        strict = false, -- this might be a problem... I'm not sure, it could also be fine.
+                        invalidate = true,
+                        undo_restore = false,
+                    })
+                    module.private.extmark_ids[key] = id
+                end
+            end
+            ::continue::
+        end
+    end,
+}
+
+local running_proc = nil
+local render_timer = nil
+local function render_latex()
+    if not module.private.do_render then
+        if render_timer then
+            render_timer:stop()
+            render_timer:close()
+            render_timer = nil
+        end
+        return
+    end
+
+    if not render_timer then
+        render_timer = vim.loop.new_timer()
+    end
+
+    render_timer:start(module.config.public.debounce_ms, 0, function()
+        render_timer:stop()
+        render_timer:close()
+        render_timer = nil
+
+        if not running_proc then
+            vim.schedule(function()
+                running_proc = nio.run(
+                    function()
+                        module.public.async_latex_renderer()
+                    end,
+                    vim.schedule_wrap(function()
+                        module.public.render_inline_math(module.private.latex_images)
+                        running_proc = nil
+                    end)
+                )
+            end)
+        end
+    end)
 end
 
 local function clear_at_cursor()
-    if module.private.images ~= nil then
-        module.private.image.render(module.private.images)
-        module.private.image.clear_at_cursor(module.private.images, vim.api.nvim_win_get_cursor(0)[1] - 1)
+    if not module.private.do_render then
+        return
+    end
+
+    if module.config.public.conceal and module.private.latex_images ~= nil then
+        local cleared =
+            module.private.image_api.clear_at_cursor(module.private.latex_images, vim.api.nvim_win_get_cursor(0)[1] - 1)
+        for _, id in ipairs(cleared) do
+            if module.private.extmark_ids[id] then
+                vim.api.nvim_buf_del_extmark(0, module.private.extmark_ns, module.private.extmark_ids[id])
+                module.private.extmark_ids[id] = nil
+            end
+        end
+        for _, key in ipairs(module.private.cleared_at_cursor) do
+            if not vim.tbl_contains(cleared, key) then
+                -- this image was cleared b/c it was at our cursor, and now it should be rendered
+                -- again
+                module.public.render_inline_math({ [key] = module.private.latex_images[key] })
+            end
+        end
+        module.private.cleared_at_cursor = cleared
+    end
+end
+
+local function enable_rendering()
+    module.private.do_render = true
+    render_latex()
+end
+
+local function disable_rendering()
+    module.private.do_render = false
+    module.private.image_api.clear(module.private.latex_images)
+    vim.api.nvim_buf_clear_namespace(0, module.private.extmark_ns, 0, -1)
+end
+
+local function show_hidden()
+    if not module.private.do_render then
+        return
+    end
+
+    module.private.image_api.render(module.private.latex_images)
+end
+
+local function colorscheme_change()
+    module.private.image_paths = {}
+    if module.private.do_render then
+        disable_rendering()
+        vim.schedule(function()
+            compute_foreground()
+            enable_rendering()
+        end)
+    else
+        vim.schedule_wrap(compute_foreground)()
     end
 end
 
 local event_handlers = {
-    ["core.neorgcmd.events.core.latex.renderer.render"] = render_latex,
-    ["core.autocommands.events.bufwinenter"] = render_latex,
+    ["core.neorgcmd.events.latex.render.render"] = enable_rendering,
+    ["core.neorgcmd.events.latex.render.enable"] = enable_rendering,
+    ["core.neorgcmd.events.latex.render.disable"] = disable_rendering,
+    ["core.autocommands.events.bufreadpost"] = render_latex,
+    ["core.autocommands.events.bufwinenter"] = show_hidden,
     ["core.autocommands.events.cursormoved"] = clear_at_cursor,
-    ["core.autocommands.events.textchanged"] = clear_latex,
-    ["core.autocommands.events.textchangedi"] = clear_latex,
-    ["core.autocommands.events.textchangedp"] = clear_latex,
-    ["core.autocommands.events.textchangedt"] = clear_latex,
+    ["core.autocommands.events.textchanged"] = render_latex,
+    ["core.autocommands.events.textchangedi"] = render_latex,
+    ["core.autocommands.events.insertleave"] = render_latex,
+    ["core.autocommands.events.colorscheme"] = colorscheme_change,
 }
 
 module.on_event = function(event)
@@ -230,15 +465,18 @@ end
 
 module.events.subscribed = {
     ["core.autocommands"] = {
-        bufwinenter = module.config.public.render_on_enter,
+        bufreadpost = module.config.public.render_on_enter,
+        bufwinenter = true,
         cursormoved = true,
         textchanged = true,
         textchangedi = true,
-        textchangedp = true,
-        textchangedt = true,
+        insertleave = true,
+        colorscheme = true,
     },
     ["core.neorgcmd"] = {
-        ["core.latex.renderer.render"] = true,
+        ["latex.render.render"] = true,
+        ["latex.render.enable"] = true,
+        ["latex.render.disable"] = true,
     },
 }
 return module

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -361,6 +361,7 @@ module.public = {
             local range = limage.range
             if range[1] == cursor_row - 1 then
                 table.insert(module.private.cleared_at_cursor, key)
+                module.private.image_api.clear({ limage })
                 goto continue
             end
             module.private.image_api.render({ limage })

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -341,7 +341,8 @@ module.public = {
                     goto continue
                 end
                 if not module.private.extmark_ids[key] then
-                    local predicted_image_dimensions = module.private.image_api.image_size(image, { height = 1})
+                    local predicted_image_dimensions =
+                        module.private.image_api.image_size(image, { height = module.config.public.scale })
                     module.private.clear_extmark(key)
                     local id = vim.api.nvim_buf_set_extmark(0, module.private.extmark_ns, range[1], range[2], {
                         end_col = range[4],

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -389,17 +389,16 @@ local function render_latex()
         render_timer = nil
 
         if not running_proc then
-            vim.schedule(function()
-                running_proc = nio.run(
-                    function()
-                        module.public.async_latex_renderer(buf)
-                    end,
-                    vim.schedule_wrap(function()
-                        module.public.render_inline_math(module.private.latex_images[buf] or {}, buf)
-                        running_proc = nil
-                    end)
-                )
-            end)
+            running_proc = nio.run(
+                function()
+                    nio.scheduler()
+                    module.public.async_latex_renderer(buf)
+                end,
+                function()
+                    module.public.render_inline_math(module.private.latex_images[buf] or {}, buf)
+                    running_proc = nil
+                end
+            )
         end
     end)
 end

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -418,6 +418,7 @@ end
 local function disable_rendering()
     module.private.do_render = false
     module.private.image_api.clear(module.private.latex_images)
+    module.private.extmark_ids = {}
     vim.api.nvim_buf_clear_namespace(0, module.private.extmark_ns, 0, -1)
 end
 

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -473,7 +473,7 @@ local function show_hidden()
         return
     end
 
-    module.private.image_api.render(module.private.latex_images[buf])
+    module.private.image_api.render(module.private.latex_images[buf] or {})
 end
 
 local function colorscheme_change()

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -331,11 +331,12 @@ module.public = {
                     goto continue
                 end
                 if not module.private.extmark_ids[key] then
+                    local predicted_image_dimensions = module.private.image_api.image_size(image, { height = 1})
                     module.private.clear_extmark(key)
                     local id = vim.api.nvim_buf_set_extmark(0, module.private.extmark_ns, range[1], range[2], {
                         end_col = range[4],
                         conceal = "",
-                        virt_text = { { (" "):rep(image.rendered_geometry.width or image.geometry.width) } },
+                        virt_text = { { (" "):rep(predicted_image_dimensions.width) } },
                         virt_text_pos = "inline",
                         strict = false, -- this might be a problem... I'm not sure, it could also be fine.
                         invalidate = true,


### PR DESCRIPTION

https://github.com/nvim-neorg/neorg/assets/56943754/d5f8e015-2cb3-4497-985d-ab9dca7f761a


Brings many many improvements to the latex renderer:

- Images are created and show asynchronously using nvim-nio
    - Creating images never blocks nvim, even with excessive amounts of images
- Images correctly position themselves in line (accounting for other virtual text, folds, etc.)
- Enable/Disable commands
- minimum length requirement to render. This allows you to type `$x$` and not have it render a massive disproportionate letter `x` for no good reason
- Better documentation
- Image caching
- Persistent images with auto update--before images would just disappear when you started typing
- Foreground color controlled by a highlight group
    - this updates and rerenders on colorscheme change
    - Default links to `Normal`
- Debounced rendering so it waits for you to finish typing, this is just to avoid an (even more) excessive amount of temp images being created.
    - Debouncing can make things look bad, it's completely configurable, default is 200ms, setting it to 10ms makes it near impossible to notice (I don't recommend setting it to less than this in case you're running a macro or something).

Unfortunately this clobbers all of the changes in #1372, but it improves on most of what's happening there I think. I started this work before that PR went up, and then I got stalled with school and other things.

---

TODO:

- [x] When images move, they flash. I know why that happens, I think I can fix it, but I don't consider it blocking for this PR
- [x] Switching buffers messes with things really heavily. All of the information that we store needs to be on a per-buffer level
- [x] Image.nvim doesn't automatically handle text concealing causing images to move
	- fixed by https://github.com/3rd/image.nvim/pull/156
- [x] Other image.nvim issues/inconcitencies
	- fixed by https://github.com/3rd/image.nvim/pull/159
- [x] image.nvim PRs need to be merged