### PR TITLE
feat: auto tangle

### DIFF
--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -193,6 +193,16 @@ module.load = function()
             },
         })
     end)
+
+    if module.config.public.tangle_on_write then
+        local augroup = vim.api.nvim_create_augroup("norg_auto_tangle", { clear = true })
+        vim.api.nvim_create_autocmd("BufWritePost", {
+            desc = "Tangle the current file on write",
+            pattern = "*.norg",
+            group = augroup,
+            command = "Neorg tangle current-file",
+        })
+    end
 end
 
 local function get_comment_string(language)
@@ -421,6 +431,9 @@ module.public = {
 module.config.public = {
     -- Notify when there is nothing to tangle (INFO) or when the content is empty (WARN).
     report_on_empty = true,
+
+    -- Tangle all code blocks in the current norg file on file write.
+    tangle_on_write = false,
 }
 
 module.on_event = function(event)


### PR DESCRIPTION
Adds the `tangle_on_write` option to the tangle module. Defaults to false, when true, call `:Neorg tangle current-file` on `BufWritePost`.

Fixes an annoying "bug" where tangling fails when code is de-dented. This is just a qol thing, I don't see a point in failing with a loud error in this case when we can easily handle the error and correctly export anyway.
