### PR TITLE
chore: mark finished clipboard todo

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ It will be switched to a `.norg` file when possible.
 
 ## Miscellaneous
 
-- [ ] Make `core.clipboard.code-blocks` work with a visual selection.
+- [x] Make `core.clipboard.code-blocks` work with a visual selection.
 - [ ] Reimplement the `core.maneouvre` module, which has been deprecated since `1.0`.
 - [ ] The `a` and `b` commands in the hop module are not implemented.
 - [ ] Readd colouring to TODO items.

--- a/lua/neorg/modules/core/clipboard/code-blocks/module.lua
+++ b/lua/neorg/modules/core/clipboard/code-blocks/module.lua
@@ -22,8 +22,6 @@ local module = modules.create("core.clipboard.code-blocks")
 module.load = function()
     modules.await("core.clipboard", function(clipboard)
         clipboard.add_callback("ranged_verbatim_tag_content", function(node, content, position)
-            -- TODO: Handle visual/visual line/visual block modes
-
             -- The end of "ranged_tag_content" spans one line too many
             if position["end"][1] > node:end_() - 1 then
                 return


### PR DESCRIPTION
The clipboard TODO on the roadmap is finished as far as I can tell. Copying from a code block via a visual selection does remove the leading white space from the selection.
