### PR TITLE
feat: text-objects and working swap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ It will be switched to a `.norg` file when possible.
 ## Miscellaneous
 
 - [ ] Make `core.clipboard.code-blocks` work with a visual selection.
-- [ ] Reimplement the `core.maneouvre` module, which has been deprecated since `1.0`.
+- [x] Reimplement the `core.maneouvre` module, which has been deprecated since `1.0`.
 - [ ] The `a` and `b` commands in the hop module are not implemented.
 - [ ] Readd colouring to TODO items.
 

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -308,6 +308,103 @@ module.public = {
 
         return table.concat(lines, "\n")
     end,
+
+    --- Get the range of a TSNode as an LspRange
+    ---@param node TSNode
+    ---@return lsp.range
+    node_to_lsp_range = function(node)
+        local start_line, start_col, end_line, end_col = node:range()
+        return {
+            start = { line = start_line, character = start_col },
+            ["end"] = { line = end_line, character = end_col },
+        }
+    end,
+
+    --- Swap two nodes in the buffer. Ignores newlines at the end of the node
+    ---@param node1 TSNode
+    ---@param node2 TSNode
+    ---@param bufnr number
+    ---@param cursor_to_second boolean move the cursor to the start of the second node (default false)
+    swap_nodes = function(node1, node2, bufnr, cursor_to_second)
+        if not node1 or not node2 then
+            return
+        end
+        local range1 = module.public.node_to_lsp_range(node1)
+        local range2 = module.public.node_to_lsp_range(node2)
+
+        local text1 = module.public.get_node_text(node1, bufnr)
+        local text2 = module.public.get_node_text(node2, bufnr)
+
+        if not text1 or not text2 then return end
+
+        text1 = vim.split(text1, "\n")
+        text2 = vim.split(text2, "\n")
+
+        ---remove trailing blank lines from the text, and update the corresponding range appropriately
+        ---@param text string[]
+        ---@param range table
+        local function remove_trailing_blank_lines(text, range)
+            local end_line_offset = 0
+            while text[#text] == "" do
+                text[#text] = nil
+                end_line_offset = end_line_offset + 1
+            end
+            range["end"] = {
+                character = string.len(text[#text]),
+                line = range["end"].line - end_line_offset,
+            }
+            if #text == 1 then -- ie. start and end lines are equal
+                range["end"].character = range["end"].character + range.start.character
+            end
+        end
+
+        remove_trailing_blank_lines(text1, range1)
+        remove_trailing_blank_lines(text2, range2)
+
+        local edit1 = { range = range1, newText = table.concat(text2, "\n") }
+        local edit2 = { range = range2, newText = table.concat(text1, "\n") }
+
+        vim.lsp.util.apply_text_edits({ edit1, edit2 }, bufnr, "utf-8")
+
+        if cursor_to_second then
+            -- set jump location
+            vim.cmd "normal! m'"
+
+            local char_delta = 0
+            local line_delta = 0
+            if
+                range1["end"].line < range2.start.line
+                or (range1["end"].line == range2.start.line and range1["end"].character <= range2.start.character)
+            then
+                line_delta = #text2 - #text1
+            end
+
+            if range1["end"].line == range2.start.line and range1["end"].character <= range2.start.character then
+                if line_delta ~= 0 then
+                    --- why?
+                    --correction_after_line_change =  -range2.start.character
+                    --text_now_before_range2 = #(text2[#text2])
+                    --space_between_ranges = range2.start.character - range1["end"].character
+                    --char_delta = correction_after_line_change + text_now_before_range2 + space_between_ranges
+                    --- Equivalent to:
+                    char_delta = #text2[#text2] - range1["end"].character
+
+                    -- add range1.start.character if last line of range1 (now text2) does not start at 0
+                    if range1.start.line == range2.start.line + line_delta then
+                        char_delta = char_delta + range1.start.character
+                    end
+                else
+                    char_delta = #text2[#text2] - #text1[#text1]
+                end
+            end
+
+            vim.api.nvim_win_set_cursor(
+                vim.api.nvim_get_current_win(),
+                { range2.start.line + 1 + line_delta, range2.start.character + char_delta }
+            )
+        end
+    end,
+
     --- Returns the first node of given type if present
     ---@param type string #The type of node to search for
     ---@param buf number #The buffer to search in

--- a/lua/neorg/modules/core/text-objects/module.lua
+++ b/lua/neorg/modules/core/text-objects/module.lua
@@ -113,7 +113,7 @@ module.public = {
     get_element_from_cursor = function(node_pattern)
         local node_at_cursor = vim.treesitter.get_node()
 
-        if not node_at_cursor:parent():type():match(node_pattern) then
+        if not node_at_cursor or not node_at_cursor:parent():type():match(node_pattern) then
             log.trace(string.format("Could not find element of pattern '%s' under the cursor", node_pattern))
             return
         end

--- a/lua/neorg/modules/core/text-objects/module.lua
+++ b/lua/neorg/modules/core/text-objects/module.lua
@@ -4,8 +4,48 @@
     summary: A Neorg module for moving and selecting elements of the document.
     ---
 
+**WARNING:** Requires nvim 0.10+
+
 - Easily move items up and down in the document
 - Provides text objects for headings, tags, and lists
+
+## Usage
+
+Users can create keybinds for some or all of the different events this module exposes. Those are:
+
+those events are:
+
+- `core.text-objects.item_up` - Moves the current "item" up
+- `core.text-objects.item_down` - same but down
+- `core.text-objects.textobject.heading.outer`
+- `core.text-objects.textobject.heading.inner`
+- `core.text-objects.textobject.tag.inner`
+- `core.text-objects.textobject.tag.outer`
+- `core.text-objects.textobject.list.outer` - around the entire list
+
+_Movable "items" include headings, and list items (ordered/unordered/todo)_
+
+### Example
+
+Example keybinds that would go in your Neorg configuration:
+
+```lua
+["core.keybinds"] = {
+    config = {
+        hook = function(keybinds)
+            -- Binds to move items up or down
+            keybinds.remap_event("norg", "n", "<up>", "core.text-objects.item_up")
+            keybinds.remap_event("norg", "n", "<down>", "core.text-objects.item_down")
+
+            -- text objects, these binds are available as `vaH` to "visual select around a header" or
+            -- `diH` to "delete inside a header"
+            keybinds.remap_event("norg", { "o", "x" }, "iH", "core.text-objects.textobject.heading.inner")
+            keybinds.remap_event("norg", { "o", "x" }, "aH", "core.text-objects.textobject.heading.outer")
+        end,
+    },
+},
+```
+
 --]]
 
 local neorg = require("neorg.core")

--- a/lua/neorg/modules/core/text-objects/module.lua
+++ b/lua/neorg/modules/core/text-objects/module.lua
@@ -55,8 +55,8 @@ local ts
 local module = modules.create("core.text-objects")
 
 module.setup = function()
-    if not utils.is_minimum_version(0, 7, 0) then
-        log.error("This module requires at least Neovim 0.7 to run!")
+    if not utils.is_minimum_version(0, 10, 0) then
+        log.error("This module requires at least Neovim 0.10 to run!")
 
         return {
             success = false,

--- a/lua/neorg/modules/core/text-objects/module.lua
+++ b/lua/neorg/modules/core/text-objects/module.lua
@@ -206,9 +206,7 @@ module.on_event = function(event)
             local textobj_lookup = module.config.private.textobjects[textobject_type]
 
             if textobj_lookup then
-                return textobj_lookup(
-                    module.required["core.integrations.treesitter"].get_ts_utils().get_node_at_cursor()
-                )
+                return textobj_lookup(vim.treesitter.get_node())
             end
         end
     end

--- a/lua/neorg/modules/core/text-objects/module.lua
+++ b/lua/neorg/modules/core/text-objects/module.lua
@@ -33,11 +33,11 @@ end
 local tags = {
     "item_up",
     "item_down",
-    "textobject.around-heading",
-    "textobject.inner-heading",
-    "textobject.around-tag",
-    "textobject.inner-tag",
-    "textobject.around-whole-list",
+    "textobject.heading.outer",
+    "textobject.heading.inner",
+    "textobject.tag.inner",
+    "textobject.tag.outer",
+    "textobject.list.outer",
 }
 
 module.load = function()
@@ -166,20 +166,20 @@ end
 
 module.config.private = {
     textobjects = {
-        ["around-heading"] = function(node)
+        ["heading.outer"] = function(node)
             return highlight_node(find(node, "^heading%d+$"))
         end,
-        ["inner-heading"] = function(node)
+        ["heading.inner"] = function(node)
             return highlight_node(find_content(node, "^heading%d+$"))
         end,
-        ["around-tag"] = function(node)
+        ["tag.outer"] = function(node)
             return highlight_node(find(node, "ranged_tag$"))
         end,
-        ["inner-tag"] = function(node)
+        ["tag.inner"] = function(node)
             -- TODO: Fix Treesitter, this is currently buggy
             return highlight_node(find_content(node, "ranged_tag$"))
         end,
-        ["around-whole-list"] = function(node)
+        ["list.outer"] = function(node)
             return highlight_node(find(node, "generic_list"))
         end,
     },


### PR DESCRIPTION
The rebirth of the manoeuvre module, and the death of that awful (to spell) name.

- Rips the `swap_node` function from `nivm-treesitter/nvim-treesitter`'s `ts_utils` and fixes the way it handles trailing blank lines
- Changed text object names to be more normal (ie. `around-heading` -> `heading.outer`)
- update the roadmap to reflect that this work is done

---

~~Text object ranges are kinda bad right now. They select onto the line of the next heading.. probably just an off by one, I'll correct that.~~

This might be fine the way it is. it's just including the last newline in the selection, I think that it looks weird, but it's not he end of the world. Would want to see your thoughts.