### PR TITLE
fix(text-objects): nil check node's parent

### DIFF
--- a/lua/neorg/modules/core/text-objects/module.lua
+++ b/lua/neorg/modules/core/text-objects/module.lua
@@ -113,7 +113,11 @@ module.public = {
     get_element_from_cursor = function(node_pattern)
         local node_at_cursor = vim.treesitter.get_node()
 
-        if not node_at_cursor or not node_at_cursor:parent():type():match(node_pattern) then
+        if
+            not node_at_cursor
+            or not node_at_cursor:parent()
+            or not node_at_cursor:parent():type():match(node_pattern)
+        then
             log.trace(string.format("Could not find element of pattern '%s' under the cursor", node_pattern))
             return
         end


### PR DESCRIPTION
Attempting to swap with the root element threw an error b/c it doesn't have a parent, and we weren't nil checking it.
