### PR TITLE
fix(latex-renderer): handle broken latex

### DIFF
--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -403,13 +403,16 @@ local function render_latex()
         render_timer = nil
 
         if not running_proc then
-            running_proc = nio.run(function()
-                nio.scheduler()
-                module.public.async_latex_renderer(buf)
-            end, function()
-                module.public.render_inline_math(module.private.latex_images[buf] or {}, buf)
-                running_proc = nil
-            end)
+            running_proc = nio.run(
+                function()
+                    nio.scheduler()
+                    module.public.async_latex_renderer(buf)
+                end,
+                vim.schedule_wrap(function()
+                    module.public.render_inline_math(module.private.latex_images[buf] or {}, buf)
+                    running_proc = nil
+                end)
+            )
         end
     end)
 end


### PR DESCRIPTION
Adds another call to yield to the scheduler so that we don't call a vim function when we're not supposed to.

It's only by shear luck that this didn't break on us all the time.

also, this commit was the problem: https://github.com/nvim-neorg/neorg/commit/2a9c3fab1bb6beabc4160264835be7f3b9a579e7 
