### PR TITLE
fix: swapfile bug

### DIFF
--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -497,7 +497,14 @@ module.on_event = function(event)
             end
         end
 
-        vim.cmd.edit(index_path:cmd_string())
+        local ok, _ = pcall(vim.cmd.edit, index_path:cmd_string())
+        if not ok then
+            log.warn(
+                ("Failed to edit file %s. This can result from vim finding a swapfile. If that was the case, ignore this warning."):format(
+                    index_path
+                )
+            )
+        end
         return
     end
 


### PR DESCRIPTION
Fixes a bug brought up by a discord user where calling `:Neorg index` when the index file had a swap file available would trigger a loud and confusing error.

Now `pcall`ing the source of the error, and issuing a nicer warning instead.
