### PR TITLE
More completions

### DIFF
--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -547,7 +547,7 @@ module.public = {
             },
         },
         { -- foreign link name suggestions `{:path:target}[|]`
-            regex = "^(.*){:([^:]*):([^}]*)}%[",
+            regex = "^(.*){:([^:]*):[#$*%^]* ([^}]*)}%[",
 
             complete = module.private.foreign_link_names,
 

--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -52,7 +52,11 @@ module.setup = function()
     }
 end
 
+---@class neorg.completion_engine
+---@field create_source function
+
 module.private = {
+    ---@type neorg.completion_engine
     engine = nil,
 
     --- Get a list of all norg files in current workspace. Returns { workspace_path, norg_files }

--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -219,6 +219,33 @@ module.private = {
     end,
 }
 
+---Suggest common link names for the given link. Suggests:
+--- - target name if the link point to a heading/footer/etc.
+--- - metadata `title` field
+--- - file description
+---@return string[]
+module.private.foreign_link_names = function(context, _prev, _saved, match)
+    print("foreign")
+    local file, target = match[2], match[3]
+    local path = dirutils.expand_pathlib(file)
+    print("Context")
+    P(context)
+    print("path:", path)
+    print("target:", target)
+    return {}
+end
+
+--- suggest the link target name
+---@return string[]
+module.private.local_link_names = function(context, _prev, _saved, match)
+    local target = match[2]
+    if target then
+        target = target:gsub("^%s+", "")
+        target = target:gsub("%s+$", "")
+    end
+    return { target }
+end
+
 module.load = function()
     -- If we have not defined an engine then bail
     if not module.config.public.engine then
@@ -517,6 +544,30 @@ module.public = {
             options = {
                 type = "Reference",
                 completion_start = "^",
+            },
+        },
+        { -- foreign link name suggestions `{:path:target}[|]`
+            regex = "^(.*){:([^:]*):([^}]*)}%[",
+
+            complete = module.private.foreign_link_names,
+
+            node = module.private.normal_norg,
+
+            options = {
+                type = "Reference",
+                completion_start = "[",
+            },
+        },
+        { -- local link name suggestions `{target}[|]` for `#`, `$`, `^`, `*` link targets
+            regex = "^(.*){[#$*%^]+ ([^}]*)}%[",
+
+            complete = module.private.local_link_names,
+
+            node = module.private.normal_norg,
+
+            options = {
+                type = "Reference",
+                completion_start = "[",
             },
         },
     },

--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -224,7 +224,7 @@ module.private = {
 --- - metadata `title` field
 --- - file description
 ---@return string[]
-module.private.foreign_link_names = function(context, _prev, _saved, match)
+module.private.foreign_link_names = function(_context, _prev, _saved, match)
     local file, target = match[2], match[3]
     local path = dirutils.expand_pathlib(file)
     local meta = treesitter.get_document_metadata(path)
@@ -261,7 +261,7 @@ end
 
 --- suggest the link target name
 ---@return string[]
-module.private.local_link_names = function(context, _prev, _saved, match)
+module.private.local_link_names = function(_context, _prev, _saved, match)
     local target = match[2]
     if target then
         target = target:gsub("^%s+", "")
@@ -626,7 +626,7 @@ module.public = {
         for _, completion_data in ipairs(completions) do
             -- If the completion data has a regex variable
             if completion_data.regex then
-                local regexes = {}
+                local regexes
 
                 if type(completion_data.regex) == "string" then
                     regexes = { completion_data.regex }

--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -456,8 +456,8 @@ module.public = {
                 completion_start = "@",
             },
         },
-        { -- TODO items `- (|)`
-            regex = "^%s*%-+%s+%(([x%*%s]?)",
+        { -- Detached Modifier Extensions `- (`, `* (`, etc.
+            regex = "^%s*[%-*$~^]+%s+%(",
 
             complete = {
                 { "( ) ", label = "( ) (undone)" },

--- a/lua/neorg/modules/core/completion/module.lua
+++ b/lua/neorg/modules/core/completion/module.lua
@@ -95,27 +95,7 @@ module.private = {
     ---@param link_type "generic" | "definition" | "footnote" | string
     get_linkables = function(source, link_type)
         local query_str = link_utils.get_link_target_query_string(link_type)
-        local norg_parser
-        local iter_src
-        if type(source) ~= "string" and type(source) ~= "number" then
-            source = tostring(source)
-        end
-        if type(source) == "string" then
-            -- check if the file is open; use the buffer contents if it is
-            if vim.fn.bufnr(source) ~= -1 then ---@diagnostic disable-line
-                source = vim.uri_to_bufnr(vim.uri_from_fname(source))
-            else
-                iter_src = io.open(source, "r"):read("*a")
-                norg_parser = vim.treesitter.get_string_parser(iter_src, "norg")
-            end
-        end
-        if type(source) == "number" then
-            if source == 0 then
-                source = vim.api.nvim_get_current_buf()
-            end
-            norg_parser = vim.treesitter.get_parser(source, "norg")
-            iter_src = source
-        end
+        local norg_parser, iter_src = treesitter.get_ts_parser(source)
         if not norg_parser then
             return {}
         end

--- a/lua/neorg/modules/core/integrations/coq_nvim/module.lua
+++ b/lua/neorg/modules/core/integrations/coq_nvim/module.lua
@@ -41,7 +41,7 @@ module.load = function()
     end
 end
 
----@class core.integrations.coq_nvim
+---@class core.integrations.coq_nvim : neorg.completion_engine
 module.public = {
     create_source = function()
         module.private.completion_item_mapping = {

--- a/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
@@ -87,7 +87,7 @@ module.public = {
         end
 
         function module.private.source:get_trigger_characters()
-            return { "@", "-", "(", " ", ".", ":", "#", "*", "^" }
+            return { "@", "-", "(", " ", ".", ":", "#", "*", "^", "[" }
         end
 
         function module.private.source:is_available()

--- a/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-cmp/module.lua
@@ -39,7 +39,7 @@ module.load = function()
     module.private.cmp = cmp
 end
 
----@class core.integrations.nvim-cmp
+---@class core.integrations.nvim-cmp : neorg.completion_engine
 module.public = {
     create_source = function()
         module.private.completion_item_mapping = {

--- a/lua/neorg/modules/core/integrations/nvim-compe/module.lua
+++ b/lua/neorg/modules/core/integrations/nvim-compe/module.lua
@@ -36,7 +36,7 @@ module.load = function()
     module.private.compe = compe
 end
 
----@class core.integrations.nvim-compe
+---@class core.integrations.nvim-compe : neorg.completion_engine
 module.public = {
     ---@param user_data table #A table of user data to supply to the source upon creation
     create_source = function(user_data)

--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -843,6 +843,37 @@ module.public = {
 
         return true
     end,
+
+    ---Create a norg TS parser from the given source
+    ---@param source string | number | PathlibPath file path or buf number or 0 for current buffer
+    ---@return vim.treesitter.LanguageTree? norg_parser
+    ---@return string | number iter_src the corresponding source that you must pass to
+    ---`iter_query()`, either the full file text, or the buffer number
+    get_ts_parser = function(source)
+        local norg_parser
+        local iter_src
+        if type(source) ~= "string" and type(source) ~= "number" then
+            source = tostring(source)
+        end
+        if type(source) == "string" then
+            -- check if the file is open; use the buffer contents if it is
+            if vim.fn.bufnr(source) ~= -1 then ---@diagnostic disable-line
+                source = vim.uri_to_bufnr(vim.uri_from_fname(source))
+            else
+                iter_src = io.open(source, "r"):read("*a")
+                norg_parser = vim.treesitter.get_string_parser(iter_src, "norg")
+            end
+        end
+        if type(source) == "number" then
+            if source == 0 then
+                source = vim.api.nvim_get_current_buf()
+            end
+            norg_parser = vim.treesitter.get_parser(source, "norg")
+            iter_src = source
+        end
+
+        return norg_parser, iter_src
+    end
 }
 
 -- this fixes the problem of installing neorg ts parsers on macOS without resorting to using gcc


### PR DESCRIPTION
Adds:
- Link names completions for links like:
    - `{:$/some/file:# Heading}[|` - suggests file title, file description, and "Heading"
    - `{:$/some/file:}[|` - suggests file title and description
    - and `{** local heading}[|` - suggests "local heading"
- Anchor completions (`[|`) with `[a1]{# something}` in the document will suggest "a1"
- additional detached modifier extensions for: `$`, `^`, `*`, and `~`

Refactors so TS helpers to take more sources, I'm slowly unifying the Neorg TS functions so they can all take buffer numbers, file paths, source strings, or nil for current buffer.

Fixes an off by one in get node text when the source was a string.

---

I think this wraps up all the completions. If there are more that I'm missing, let me know, but  I can't think of any new ones.. ~~Maybe it would be nice to get detached modifier extensions to work with more than just unordererd lists though~~