### PR TITLE
fix: supress swap file errors

### DIFF
--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -53,13 +53,14 @@ local Path = require("pathlib")
 
 local neorg = require("neorg.core")
 local log, modules, utils = neorg.log, neorg.modules, neorg.utils
+local dirman_utils
 
 local module = modules.create("core.dirman")
 
 module.setup = function()
     return {
         success = true,
-        requires = { "core.autocommands", "core.ui", "core.storage" },
+        requires = { "core.autocommands", "core.ui", "core.storage", "core.dirman.utils" },
     }
 end
 
@@ -69,6 +70,8 @@ module.load = function()
         -- module.config.public.workspaces[name] = vim.fn.expand(vim.fn.fnameescape(workspace_location)) ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
         module.config.public.workspaces[name] = Path(workspace_location):resolve():to_absolute()
     end
+
+    dirman_utils = module.required["core.dirman.utils"]
 
     modules.await("core.keybinds", function(keybinds)
         keybinds.register_keybind(module.name, "new.note")
@@ -497,14 +500,7 @@ module.on_event = function(event)
             end
         end
 
-        local ok, _ = pcall(vim.cmd.edit, index_path:cmd_string())
-        if not ok then
-            log.warn(
-                ("Failed to edit file %s. This can result from vim finding a swapfile. If that was the case, ignore this warning."):format(
-                    index_path
-                )
-            )
-        end
+        dirman_utils.edit_file(index_path:cmd_string())
         return
     end
 

--- a/lua/neorg/modules/core/dirman/utils/module.lua
+++ b/lua/neorg/modules/core/dirman/utils/module.lua
@@ -68,6 +68,22 @@ module.public = {
         end
         return filepath
     end,
+
+    ---Call attempt to edit a file, catches and suppresses the error caused by a swap file being
+    ---present. Re-raises other errors via log.error
+    ---@param path string
+    edit_file = function(path)
+        local ok, err = pcall(vim.cmd.edit, path)
+        if not ok then
+            -- Vim:E325 is the swap file error, in which case, a lengthy message already shows to
+            -- the user, and we don't have to crash out of this function (which creates a long and
+            -- misleading error message).
+            if err and not err:match("Vim:E325") then
+                log.error("Failed to edit file %s. Error:\n%s"):format(path, err)
+            end
+        end
+    end,
+
     ---Resolve `$<workspace>/path/to/file` and return the real path
     -- NOTE: Use `expand_pathlib` which returns a PathlibPath object instead.
     ---

--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -13,7 +13,7 @@ prompted with a set of actions that you can perform on the broken link.
 
 local neorg = require("neorg.core")
 local config, lib, log, modules, utils = neorg.config, neorg.lib, neorg.log, neorg.modules, neorg.utils
-local links
+local links, dirman_utils
 
 local module = modules.create("core.esupports.hop")
 
@@ -31,6 +31,7 @@ end
 
 module.load = function()
     links = module.required["core.links"]
+    dirman_utils = module.required["core.dirman.utils"]
     modules.await("core.keybinds", function(keybinds)
         keybinds.register_keybind(module.name, "hop-link")
     end)
@@ -151,7 +152,7 @@ module.public = {
                 external_file = function()
                     open_split()
 
-                    vim.api.nvim_cmd({ cmd = "edit", args = { located_link_information.path } }, {})
+                    dirman_utils.edit_file(located_link_information.path)
 
                     if located_link_information.line then
                         jump_to_line(located_link_information.line)
@@ -499,7 +500,7 @@ module.public = {
         -- Check whether our target is from a different file
         if parsed_link_information.link_file_text then
             local expanded_link_text =
-                module.required["core.dirman.utils"].expand_path(parsed_link_information.link_file_text)
+                dirman_utils.expand_path(parsed_link_information.link_file_text)
 
             if expanded_link_text ~= vim.fn.expand("%:p") then
                 -- We are dealing with a foreign file
@@ -781,7 +782,7 @@ module.private = {
 
         if parsed_link_information.link_file_text then
             local expanded_link_text =
-                module.required["core.dirman.utils"].expand_path(parsed_link_information.link_file_text)
+                dirman_utils.expand_path(parsed_link_information.link_file_text)
 
             if expanded_link_text ~= vim.fn.expand("%:p") then
                 -- We are dealing with a foreign file


### PR DESCRIPTION
#1451 caught an error caused by swap files and produced an error message that heavily suggested the error was caused by swap and could be ignored when that was never confirmed. Some concern was raised about this approach, and an additional cases of the same bug was found...

So this PR checks the error message (via pattern match) to confirm that a swap error was the cause of `vim.cmd.edit` failing, and in these cases eats the error message. It's okay (and I'd say preferred) to eat this error b/c a lengthy swap message will pop up on screen for the user, so users will not be confused about what's happening.

In case the error is not caused be swap, it's now re-raised with the exact error message.

#1451 handled the edit call in `:Neorg index`, this pr additionally handles a call in the hop module when following a link that's opened in nvim.