### PR TITLE
fix(concealer): invalidate extmarks when range is deleted

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -139,6 +139,11 @@ local function set_mark(bufid, row_0b, col_0b, text, highlight, ext_opts)
         ui_watched = nil,
     }
 
+    -- proxy for nvim 0.10+
+    if vim.version then
+        opt["invalidate"] = true
+    end
+
     if ext_opts then
         table_extend_in_place(opt, ext_opts)
     end


### PR DESCRIPTION
fixes #1447 for nvim 0.10+ users