### PR TITLE
fix(latex-renderer): fixed renderer failing silently

### DIFF
--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -226,7 +226,8 @@ module.public = {
                     real = true,
                     extmark_id = existing_ext_id,
                 }
-            end
+            end,
+            buf
         )
 
         for key, limage in pairs(new_limages) do


### PR DESCRIPTION
Commit [8ec38e0](https://github.com/nvim-neorg/neorg/commit/8ec38e07ddffa84d0925faf425d4d52e5c1f91b7) changed the implementation of the treesitter module's `execute_query` function. The function asks for a non-nil source, but the latex renderer wasn't providing one (which should have caused a type error, but didn't because the way the `module.required` table works prevents lua_ls from getting the function's signature). The previous implementation happened to use a function internally that used the buffer 0 when `source` was omitted to get the parser, which is what allowed the latex renderer to work previously, but the new implementation didn't do that