### PR TITLE
fix: insert template at the end of a new note

### DIFF
--- a/lua/neorg/modules/core/journal/module.lua
+++ b/lua/neorg/modules/core/journal/module.lua
@@ -142,7 +142,7 @@ module.private = {
             and module.config.public.use_template
             and module.required["core.dirman"].file_exists(workspace_path .. "/" .. folder_name .. "/" .. template_name)
         then
-            vim.cmd("0read " .. workspace_path .. "/" .. folder_name .. "/" .. template_name .. "| w")
+            vim.cmd("$read " .. workspace_path .. "/" .. folder_name .. "/" .. template_name .. "| w")
         end
     end,
 


### PR DESCRIPTION
I noticed this small bug as I've begun using journal entries in my notes.

I believe the problem occurs because I've set metagen.type = "auto".

This fixes a bug where metadata is injected into the newly created file before the template contents. Which results in the template content being placed above the metadata.

By changing the 0 to a $ we always insert the template at the end of the file. I believe this is safe as this only occurs on newly created journal entries, which should therefore always be empty (except for some possible metadata injected by metagen).