### PR TITLE
Don't update metadata unless buffer is modified

### DIFF
--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -314,10 +314,10 @@ module.public = {
             return
         end
 
-				local modified = vim.api.nvim_buf_get_option(buf, "modified")
-				if not modified then
-					return
-				end
+        local modified = vim.api.nvim_buf_get_option(buf, "modified")
+        if not modified then
+            return
+        end
 
         -- Extract the root node of the norg_meta language
         -- This process should be abstracted into a core.integrations.treesitter

--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -314,6 +314,11 @@ module.public = {
             return
         end
 
+				local modified = vim.api.nvim_buf_get_option(buf, "modified")
+				if not modified then
+					return
+				end
+
         -- Extract the root node of the norg_meta language
         -- This process should be abstracted into a core.integrations.treesitter
         -- function.


### PR DESCRIPTION
Hi, I am new to neovim plugin development and this is my first PR.
I've introduced a check to verify if your buffer has been modified before updating the date in the metadata module. This prevents accidentally updating the last modified date when closing vim with :wq or ZZ even when no changes have been made.