### PR TITLE
fix(latex-renderer): fixed renderer breaking when a snippet change made it stop compiling

### DIFF
--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -229,6 +229,7 @@ module.public = {
             end,
             buf
         )
+        nio.scheduler()
 
         for key, limage in pairs(new_limages) do
             if not limage.real then


### PR DESCRIPTION
Previously, when a snippet that had already been rendered was modified and the new version failed to compile, the renderer got stuck on a bad state until that snippet was fixed: the rendered image of other snippets wasn't updated when they were modified, and the last rendered image of the bad snippet would keep being shown. Additionally, if by the time the bad snippet was fixed any other snippets were different from before the bad snippet stopped compiling, those snippets would get re-rendered and their previous image would get stuck on the screen.

This patch fixes this issue: now when a snippet is modified and it stops compiling its rendered image is properly cleared and the rest of the snippets are unaffected.

Before:

https://github.com/nvim-neorg/neorg/assets/43814863/10aa2c5f-040b-4f34-a870-5ff3fa1ff23e

After:

https://github.com/nvim-neorg/neorg/assets/43814863/16245220-40aa-4972-8580-f7c3b930ee69

After a long time of debugging i found out that under the situation i mentioned, the `module.private.image_api.clear()` call in the following for loop was silently erroring out, which lead to the images not being properly cleared (since only the local copy of the images table was partly updated, but the original version actually used by the rest of the renderer was never updated with the modified local copy). After using `pcall()` to get the error from the `image_api.clear()` call, the actual error was `E5560: nvim_buf_is_valid must not be called in a lua loop callback`, which according to the stacktrace comes from `image.nvim`.

I'm not sure why the `nio.scheduler()` call is needed because it's already called before any of this code runs (right before the renderer is called) and it's weird that it's only needed in this specific case, but through trial and error it seems to be needed again after the call to `module.required["core.integrations.treesitter"].execute_query()` (right before where it's currently at) to avoid the error