### PR TITLE
small true-zen integration folder structure fix

### DIFF
--- a/lua/neorg/modules/core/integrations/truezen/module.lua
+++ b/lua/neorg/modules/core/integrations/truezen/module.lua
@@ -4,18 +4,23 @@
     summary: Integrates the TrueZen module for use within Neorg.
     internal: true
     ---
-This is a basic wrapper around truezen that allows one to toggle the atraxis mode programatically.
+This is a basic wrapper around truezen that allows one to toggle the atraxis mode programmatically.
 --]]
 
 local neorg = require("neorg.core")
-local modules = neorg.modules
+local modules, log = neorg.modules, neorg.log
 
 local module = modules.create("core.integrations.truezen")
 
+
 module.setup = function()
     local success, truezen = pcall(require, "true-zen.main")
+    local success, truezen = pcall(require, "true-zen")
+
 
     if not success then
+        log.warn("Could not find module: `true-zen`. Please ensure you have true-zen installed.")
+
         return { success = false }
     end
 
@@ -34,3 +39,4 @@ module.public = {
 }
 
 return module
+


### PR DESCRIPTION
Updates the module to reflect the true-zen folder structure. As pointed out by `TwoNine` on neorg [discord](https://canary.discord.com/channels/834325286664929280/1254590615279112202/1254599573989490739)

Prevents error on startup 

```                                                                                                                    
Recovering from error...                                                                                                                                                                       
Press ENTER or type command to continue
```