### PR TITLE
feat(latex-renderer): add toggle renderer command

### DIFF
--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -135,6 +135,10 @@ module.load = function()
                         args = 0,
                         name = "latex.render.disable",
                     },
+                    toggle = {
+                        args = 0,
+                        name = "latex.render.toggle",
+                    },
                 },
                 condition = "norg",
             },
@@ -483,6 +487,14 @@ local function disable_rendering()
     module.private.latex_images = {}
 end
 
+local function toggle_rendering()
+    if module.private.do_render then
+        disable_rendering()
+    else
+        enable_rendering()
+    end
+end
+
 local function show_hidden()
     local buf = vim.api.nvim_get_current_buf()
     if not module.private.do_render then
@@ -510,6 +522,7 @@ local event_handlers = {
     ["core.neorgcmd.events.latex.render.render"] = enable_rendering,
     ["core.neorgcmd.events.latex.render.enable"] = enable_rendering,
     ["core.neorgcmd.events.latex.render.disable"] = disable_rendering,
+    ["core.neorgcmd.events.latex.render.toggle"] = toggle_rendering,
     ["core.autocommands.events.bufreadpost"] = render_latex,
     ["core.autocommands.events.bufwinenter"] = show_hidden,
     ["core.autocommands.events.cursormoved"] = clear_at_cursor,
@@ -541,6 +554,7 @@ module.events.subscribed = {
         ["latex.render.render"] = true,
         ["latex.render.enable"] = true,
         ["latex.render.disable"] = true,
+        ["latex.render.toggle"] = true,
     },
 }
 return module


### PR DESCRIPTION
Adds a new `:Neorg render-latex toggle` command that simply enables the renderer if it was off and disables it if it was on. A user couldn't do this themselves because the renderer enabled state was private

https://github.com/nvim-neorg/neorg/assets/43814863/90fa28a9-a207-417a-8a91-21edc5b78fde