### PR TITLE
fix(promo): promote/demote range + keybinds

### DIFF
--- a/lua/neorg/modules/core/esupports/indent/module.lua
+++ b/lua/neorg/modules/core/esupports/indent/module.lua
@@ -145,7 +145,7 @@ module.public = {
         end
 
         local leading_whitespace = line:match("^%s*"):len()
-        return vim.api.nvim_buf_set_text(buffer, start_row, 0, start_row, leading_whitespace, { (" "):rep(new_indent) })
+        vim.api.nvim_buf_set_text(buffer, start_row, 0, start_row, leading_whitespace, { (" "):rep(new_indent) })
     end,
 }
 

--- a/lua/neorg/modules/core/esupports/indent/module.lua
+++ b/lua/neorg/modules/core/esupports/indent/module.lua
@@ -122,6 +122,31 @@ module.public = {
 
         return new_indent
     end,
+
+    ---re-evaluate the indent expression for each line in the range, and apply the new indentation
+    ---@param buffer number
+    ---@param row_start number 0 based
+    ---@param row_end number 0 based exclusive
+    reindent_range = function(buffer, row_start, row_end)
+        for i = row_start, row_end - 1 do
+            local indent_level = module.public.indentexpr(buffer, i)
+            module.public.buffer_set_line_indent(buffer, i, indent_level)
+        end
+    end,
+
+    ---Set the indent of the given line to the new value
+    ---@param buffer number
+    ---@param start_row number 0 based
+    ---@param new_indent number
+    buffer_set_line_indent = function(buffer, start_row, new_indent)
+        local line = vim.api.nvim_buf_get_lines(buffer, start_row, start_row + 1, true)[1]
+        if line:match("^%s*$") then
+            return
+        end
+
+        local leading_whitespace = line:match("^%s*"):len()
+        return vim.api.nvim_buf_set_text(buffer, start_row, 0, start_row, leading_whitespace, { (" "):rep(new_indent) })
+    end,
 }
 
 module.config.public = {

--- a/lua/neorg/modules/core/keybinds/keybinds.lua
+++ b/lua/neorg/modules/core/keybinds/keybinds.lua
@@ -120,11 +120,10 @@ module.config.public = {
                     { "<M-d>", "core.tempus.insert-date-insert-mode", opts = { desc = "[neorg] Insert Date" } },
                 },
 
-                -- TODO: Readd these
-                -- v = {
-                --     { ">>", ":<cr><cmd>Neorg keybind all core.promo.promote_range<cr>" },
-                --     { "<<", ":<cr><cmd>Neorg keybind all core.promo.demote_range<cr>" },
-                -- },
+                v = {
+                    { ">", "core.promo.promote_range", opts = { desc = "[neorg] Promote Objects in Range" } },
+                    { "<", "core.promo.demote_range", opts = { desc = "[neorg] Demote Objects in Range" } },
+                },
             }, {
                 silent = true,
                 noremap = true,


### PR DESCRIPTION
what it says on the tin. These were broken/removed a while ago. Presumably due to concealer changes but I'm not sure. Someone asked about bringing them back today, so here they are.

The re-indentation code in this module seems to struggle a little though. Not sure what's up with that.