### PR TITLE
refactor!: make Neovim 0.10 a requirement for Neorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Neorg - An Organized Future
 
-<a href="https://neovim.io"> ![Neovim](https://img.shields.io/badge/Neovim%200.8+-brightgreen?style=for-the-badge) </a>
+<a href="https://neovim.io"> ![Neovim](https://img.shields.io/badge/Neovim%200.10+-brightgreen?style=for-the-badge) </a>
 <a href="https://discord.gg/T6EgTAX7ht"> ![Discord](https://img.shields.io/badge/discord-join-7289da?style=for-the-badge&logo=discord) </a>
 <a href="/LICENSE"> ![License](https://img.shields.io/badge/license-GPL%20v3-brightgreen?style=for-the-badge)</a>
 <a href="https://dotfyle.com/plugins/nvim-neorg/neorg"> ![Usage](https://dotfyle.com/plugins/nvim-neorg/neorg/shield?style=for-the-badge) </a>
@@ -70,7 +70,9 @@ A video tutorial may be found on Youtube:
 
 Neorg's setup process is slightly more complex than average, so we encourage you to be patient :)
 
-**After you're done with the installation process, run `:checkhealth neorg` to see if everything's correct!**
+**Neorg requires Neovim 0.10 or above to function. After you're done with the
+installation process, run `:checkhealth neorg` to see if everything's
+correct!**
 
 ### `rocks.nvim`
 

--- a/lua/neorg/init.lua
+++ b/lua/neorg/init.lua
@@ -36,14 +36,6 @@ function neorg.setup(cfg)
     -- Create a new global instance of the neorg logger.
     log.new(config.user_config.logger or log.get_default_config(), true)
 
-    -- TODO(vhyrro): Remove this after Neovim 0.10, where `norg` files will be
-    -- detected automatically.
-    vim.filetype.add({
-        extension = {
-            norg = "norg",
-        },
-    })
-
     -- If the file we have entered has a `.norg` extension:
     if vim.fn.expand("%:e") == "norg" or not config.user_config.lazy_loading then
         -- Then boot up the environment.

--- a/lua/neorg/init.lua
+++ b/lua/neorg/init.lua
@@ -3,7 +3,7 @@
 --- @brief ]]
 
 local neorg = require("neorg.core")
-local config, log, modules = neorg.config, neorg.log, neorg.modules
+local config, log, modules, utils = neorg.config, neorg.log, neorg.modules, neorg.utils
 
 --- @module "neorg.core.config"
 
@@ -12,6 +12,9 @@ local config, log, modules = neorg.config, neorg.log, neorg.modules
 --- @see config.user_config
 --- @see neorg.configuration.user
 function neorg.setup(cfg)
+    -- Ensure that we are running Neovim 0.10+
+    assert(utils.is_minimum_version(0, 10, 0), "Neorg requires at least Neovim version 0.10 to operate!")
+
     -- If the user supplied no configuration then generate a default one (assume the user wants the defaults)
     cfg = cfg or {
         load = {


### PR DESCRIPTION
stacked on #1506

This PR bumps the required version of Neovim for Neorg. This allows users to access:
- The calendar
- Date-related utilities
- Native filetype detection for .norg files