### PR TITLE
cleanup: remove `ftdetect` from rockspec

### DIFF
--- a/neorg-scm-1.rockspec
+++ b/neorg-scm-1.rockspec
@@ -43,7 +43,6 @@ build = {
    type = "builtin",
    copy_directories = {
        "queries",
-       "ftdetect",
        "doc",
    }
 }


### PR DESCRIPTION
I found #1083 forgot to delete the `ftdetect` from the rockspec.
This gives error when I try to install neorg with luarocks.

```
$ luarocks --force-lock --lua-version=5.1 --dev install neorg
Installing https://luarocks.org/dev/neorg-dev-1.rockspec
Cloning into 'neorg'...
remote: Enumerating objects: 29624, done.
remote: Counting objects: 100% (1687/1687), done.
remote: Compressing objects: 100% (631/631), done.
remote: Total 29624 (delta 806), reused 1413 (delta 626), pack-reused 27937
Receiving objects: 100% (29624/29624), 4.68 MiB | 16.54 MiB/s, done.
Resolving deltas: 100% (15183/15183), done.
Missing dependencies for neorg dev-1:
   nvim-nio ~> 1.7 (not installed)
   lua-utils.nvim 1.0.2 (not installed)

neorg dev-1 depends on lua >= 5.1, < 5.4 (5.1-1 provided by VM: success)
neorg dev-1 depends on nvim-nio ~> 1.7 (not installed)
Installing https://luarocks.org/nvim-nio-1.7.0-1.src.rock

nvim-nio 1.7.0-1 depends on lua >= 5.1 (5.1-1 provided by VM: success)
nvim-nio 1.7.0-1 is now installed in /home/ubuntu/.local/share/nvim-noplugin/rocks (license: MIT)

neorg dev-1 depends on lua-utils.nvim 1.0.2 (not installed)
Installing https://luarocks.org/lua-utils.nvim-1.0.2-1.src.rock

lua-utils.nvim 1.0.2-1 depends on lua >= 5.1 (5.1-1 provided by VM: success)
lua-utils.nvim 1.0.2-1 is now installed in /home/ubuntu/.local/share/nvim-noplugin/rocks (license: MIT)


Error: Directory 'ftdetect' not found
```