### PR TITLE
Disallow keybind clashes

### DIFF
--- a/lua/neorg/health.lua
+++ b/lua/neorg/health.lua
@@ -90,18 +90,35 @@ return {
             if key_healthcheck.preset_exists then
                 vim.health.info(string.format("Neorg is configured to use keybind preset `%s`", keybinds_config.preset))
             else
-                vim.health.error(string.format("Invalid configuration found: preset `%s` does not exist! Did you perhaps make a typo?", keybinds_config.preset))
+                vim.health.error(
+                    string.format(
+                        "Invalid configuration found: preset `%s` does not exist! Did you perhaps make a typo?",
+                        keybinds_config.preset
+                    )
+                )
                 return
             end
 
             for remap_key, remap_rhs in vim.spairs(key_healthcheck.remaps) do
-                vim.health.ok(string.format("Action `%s` (bound to `%s` by default) has been remapped to something else in your configuration.", remap_rhs, remap_key))
+                vim.health.ok(
+                    string.format(
+                        "Action `%s` (bound to `%s` by default) has been remapped to something else in your configuration.",
+                        remap_rhs,
+                        remap_key
+                    )
+                )
             end
 
             local ok = true
 
             for conflict_key, rhs in vim.spairs(key_healthcheck.conflicts) do
-                vim.health.warn(string.format("Key `%s` conflicts with a key bound by the user. Neorg will not bind this key.", conflict_key), string.format("consider mapping `%s` to a different key than the one bound by Neorg.", rhs))
+                vim.health.warn(
+                    string.format(
+                        "Key `%s` conflicts with a key bound by the user. Neorg will not bind this key.",
+                        conflict_key
+                    ),
+                    string.format("consider mapping `%s` to a different key than the one bound by Neorg.", rhs)
+                )
                 ok = false
             end
 

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -46,8 +46,8 @@ files. There are two ways to combat this:
   ```
 - Create an autocommand using `vim.api.nvim_create_autocmd`:
   ```lua
-  vim.api.nvim_create_autocmd("BufEnter", {
-      pattern = "*.norg",
+  vim.api.nvim_create_autocmd("Filetype", {
+      pattern = "norg",
       callback = function()
           vim.keymap.set("n", "my-key-here", "<Plug>(neorg.pivot.list.toggle)", { buffer = true })
       end,

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -121,7 +121,7 @@ module.public = {
         local function set_keys_for(data)
             for mode, keybinds in pairs(data) do
                 for _, keybind in ipairs(keybinds) do
-                    if vim.fn.hasmapto(keybind[2], mode, false) == 0 then
+                    if vim.fn.hasmapto(keybind[2], mode, false) == 0 and vim.fn.mapcheck(keybind[1], mode, false):len() == 0 then
                         local opts = vim.tbl_deep_extend("force", { buffer = buffer or true }, keybinds.opts or {})
                         vim.keymap.set(mode, keybind[1], keybind[2], opts)
                     end


### PR DESCRIPTION
This PR introduces three key changes:
- Don't forcefully override the user's keys
- Add proper `:checkhealth` integration which looks for various conflicts and remaps
- Set global keybinds only once, and apply all norg-specific keys on `Filetype` instead of `BufEnter`

All in all, this concludes the major changes I wanted to make to the keybind system. I personally consider the system to be very close to perfect now, just like the Neovim overlords intended.