### PR TITLE
feat: support multi-line values in metagen

### DIFF
--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -269,10 +269,10 @@ module.public = {
                 -- override with data from metadata table
                 data = { data[1], metadata[data[1]] }
             end
-            table.insert(
-                result,
-                whitespace .. data[1] .. delimiter .. tostring(type(data[2]) == "function" and data[2]() or data[2])
-            )
+            local lines = whitespace .. data[1] .. delimiter .. tostring(type(data[2]) == "function" and data[2]() or data[2])
+            for line in ipairs(vim.split(lines, "\n")) do
+                table.insert(result, line)
+            end
         end
 
         table.insert(result, "@end")


### PR DESCRIPTION
Allow things like this:
```lua
["core.esupports.metagen"] = {
  config = {
    undojoin_updates = true,
    type = "empty",
    template = {
      { "title" },
      { "description" },
      { "authors", "[\n  benlubas\n  Zlare\n]" },
    }
  },
},
```

which generates:
```
@document.meta
title: test1
description: 
authors: [
  benlubas
  Zlare
]
@end
```

This was requested in the discord by `@zlare`