### PR TITLE
fix(keybinds): use stricter test to determine if keybind was set by user

### DIFF
--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -129,7 +129,7 @@ module.public = {
             for _, keybind in ipairs(keybinds) do
                 if
                     vim.fn.hasmapto(keybind[2], mode, false) == 0
-                    and vim.fn.mapcheck(keybind[1], mode, false):len() == 0
+                    and vim.fn.maparg(keybind[1], mode, false) ~= ""
                 then
                     local opts = vim.tbl_deep_extend("force", { buffer = buffer }, keybinds.opts or {})
                     vim.keymap.set(mode, keybind[1], keybind[2], opts)
@@ -160,7 +160,7 @@ module.public = {
                     if not bound_keys[mode] or not bound_keys[mode][keybind[1]] then
                         if vim.fn.hasmapto(keybind[2], mode, false) ~= 0 then
                             remaps[keybind[1]] = keybind[2]
-                        elseif vim.fn.mapcheck(keybind[1], mode, false):len() ~= 0 then
+                        elseif vim.fn.maparg(keybind[1], mode, false) ~= "" then
                             conflicts[keybind[1]] = keybind[2]
                         end
                     end


### PR DESCRIPTION
With the latest keybinds change, we were no long clobbering keybinds, but the check to do that was very lose. This resulted in any mapping to `<localleader> causing neorg to think that there was a bind for `<localleader>anything`.

Whichkey binds to `<localleader>` so none of these mappings were being set properly.

This PR replaces `mapcheck` with `maparg` which is much stricter, and checks for exact mappings to avoid this issue.