### PR TITLE
fix(keybinds): fixed tempus insert date insert mode default keybind command

### DIFF
--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -342,7 +342,7 @@ module.private = {
                     -- ^Date
                     {
                         "<M-d>",
-                        "<Plug>(neorg.tempus.insert-date-insert-mode)",
+                        "<Plug>(neorg.tempus.insert-date.insert-mode)",
                         opts = { desc = "[neorg] Insert Date" },
                     },
                 },


### PR DESCRIPTION
The command is defined in the tempus module as `neorg.tempus.insert-date.insert-mode`, but the default mapping was using `neorg.tempus.insert-date-insert-mode` and thus not working properly