### PR TITLE
feat: proper quote concealing

### DIFF
--- a/doc/neorg.norg
+++ b/doc/neorg.norg
@@ -50,11 +50,6 @@ version: 0.1
 
 *** Unordered lists
 
-    |example
-    - Unordered list level 1
-    -- Unordered list level 2
-    |end
-
     - Unordered list level 1
     -- Unordered list level 2
     --- Unordered list level 3
@@ -64,20 +59,15 @@ version: 0.1
 
 *** Ordered lists
 
-    |example
     ~ Ordered list level 1
     ~~ Ordered list level 2
     ~~~ Ordered list level 3
     ~~~~ Ordered list level 4
     ~~~~~ Ordered list level 5
     ~~~~~~ Ordered list level 6
-    |end
-
-    *NOTE: For proper ordered list rendering ensure you are running Neovim >= `0.10.0`*
 
 *** Tasks
 
-    |example
     - ( ) Undone -> not done yet
     - (x) Done -> done with that
     - (?) Needs further input
@@ -88,17 +78,12 @@ version: 0.1
     - (-) Pending -> currently in progress
     - (=) Task put on hold
     - (_) Task cancelled (put down)
-    |end
 
     The task modifier can be placed on any detached modifier, including
     headings, definitions, footnotes etc. to track their state.
 
 *** Quotes
 
-    |example
-    > 1. level quote
-    >> 2. level quote
-    |end
     > 1. level quote
     >> 2. level quote
     >>> 3. level quote
@@ -238,7 +223,7 @@ version: 0.1
 
 *** Multi-paragraph definitions
 
-    $$ Object to be defined
+    $$ Term
     Here, I can place any number of paragraphs or other format objects.
 
     Even a code example:
@@ -258,8 +243,7 @@ version: 0.1
     ^ This is the title of my footnote. I can use this as a link target.
     This is the actual footnote content.
 
-    This is no longer part of the {^ This is the title of my footnote. I can use this as a link
-    target}[footnote].
+    This is no longer part of the footnote.
 
 *** Multi-paragraph footnotes
 
@@ -355,11 +339,7 @@ version: 0.1
 
     Note: You can:*not* combine sub- and superscripts like so:
 
-    ^,This should be super- and subscript.,^ - why though?
-
-    You will notice that this gets highlighted as an error:
-
-    ^,This should be super- and subscript.,^
+    ^,This should be super- and subscript.,^ - gets highlighted as an error.
 
 *** Variables
 

--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -495,22 +495,32 @@ module.public = {
             end
         end,
 
-        multilevel_copied = function(config, bufid, node)
+        ---@param node TSNode
+        quote_concealed = function(config, bufid, node)
             if not config.icons then
                 return
             end
-            local row_0b, col_0b, len = get_node_position_and_text_length(bufid, node)
+
+            local lines_count_0b = vim.api.nvim_buf_line_count(bufid) - 1
+
+            local prefix = node:named_child(0)
+
+            local row_0b, col_0b, len = get_node_position_and_text_length(bufid, prefix)
+            local row_last_0b = node:end_()
+
             local last_icon, last_highlight
-            for i = 1, len do
-                if config.icons[i] ~= nil then
-                    last_icon = config.icons[i]
+            for line=row_0b, row_last_0b > lines_count_0b and lines_count_0b or row_last_0b do
+                for col = 1, len do
+                    if config.icons[col] ~= nil then
+                        last_icon = config.icons[col]
+                    end
+                    if not last_icon then
+                        goto continue
+                    end
+                    last_highlight = config.highlights[col] or last_highlight
+                    set_mark(bufid, line, col_0b + (col - 1), last_icon, last_highlight)
+                    ::continue::
                 end
-                if not last_icon then
-                    goto continue
-                end
-                last_highlight = config.highlights[i] or last_highlight
-                set_mark(bufid, row_0b, col_0b + (i - 1), last_icon, last_highlight)
-                ::continue::
             end
         end,
 
@@ -730,12 +740,12 @@ module.config.public = {
         quote = {
             icons = { "│" },
             nodes = {
-                "quote1_prefix",
-                "quote2_prefix",
-                "quote3_prefix",
-                "quote4_prefix",
-                "quote5_prefix",
-                "quote6_prefix",
+                "quote1",
+                "quote2",
+                "quote3",
+                "quote4",
+                "quote5",
+                "quote6",
             },
             highlights = {
                 "@neorg.quotes.1.prefix",
@@ -745,7 +755,7 @@ module.config.public = {
                 "@neorg.quotes.5.prefix",
                 "@neorg.quotes.6.prefix",
             },
-            render = module.public.icon_renderers.multilevel_copied,
+            render = module.public.icon_renderers.quote_concealed,
         },
         heading = {
             icons = { "◉", "◎", "○", "✺", "▶", "⤷" },


### PR DESCRIPTION
Please help test this PR before it's merged! This PR adds proper quote concealing to Neorg, by displaying the box chars for every separate line. Example:

```
> This is a quote
   and this still belongs to said quote!
```

Previously, the second line would not be highlighted, even though it absolutely should.

This change fundamentally changes some concealer functionality. If you find any concealer bugs that weren't present earlier, please let me know!

@benlubas would you have some time to try and break this thing?