### PR TITLE
fix: set monthly view of calendar reasonably buffer options

### DIFF
--- a/lua/neorg/modules/core/ui/calendar/views/monthly/module.lua
+++ b/lua/neorg/modules/core/ui/calendar/views/monthly/module.lua
@@ -406,6 +406,9 @@ module.private = {
                     self:select_current_day(ui_info, date)
 
                     vim.api.nvim_buf_set_option(ui_info.buffer, "modifiable", false)
+                    vim.api.nvim_buf_set_option(ui_info.buffer, "filetype", "prompt")
+                    vim.api.nvim_buf_set_option(ui_info.buffer, "cursorcolumn", true)
+                    vim.api.nvim_buf_set_option(ui_info.buffer, "cursorline", true)
                     vim.api.nvim_set_option_value("winfixbuf", true, { win = ui_info.window })
 
                     return


### PR DESCRIPTION
Set the `filetype` of monthly view of calendar buffer more reasonably. And turn cursor column and line on to help more continent locate the cursor in the dates.