### PR TITLE
Automatically typed module.required dependencies

### DIFF
--- a/lua/neorg/core/modules.lua
+++ b/lua/neorg/core/modules.lua
@@ -13,6 +13,47 @@ local utils = require("neorg.core.utils")
 
 --- @alias neorg.module.public { version: string, [any]: any }
 
+--- @class (exact) neorg.module.resolver
+--- @field ["core.autocommands"] core.autocommands
+--- @field ["core.clipboard"] core.clipboard
+--- @field ["core.completion"] core.completion
+--- @field ["core.concealer"] core.concealer
+--- @field ["core.dirman"] core.dirman
+--- @field ["core.esupports.hop"] core.esupports.hop
+--- @field ["core.esupports.indent"] core.esupports.indent
+--- @field ["core.esupports.metagen"] core.esupports.metagen
+--- @field ["core.export"] core.export
+--- @field ["core.export.markdown"] core.export.markdown
+--- @field ["core.fs"] core.fs
+--- @field ["core.highlights"] core.highlights
+--- @field ["core.integrations.treesitter"] core.integrations.treesitter
+--- @field ["core.itero"] core.itero
+--- @field ["core.journal"] core.journal
+--- @field ["core.keybinds"] core.keybinds
+--- @field ["core.latex.renderer"] core.latex.renderer
+--- @field ["core.links"] core.links
+--- @field ["core.looking-glass"] core.looking-glass
+--- @field ["core.neorgcmd"] core.neorgcmd
+--- @field ["core.pivot"] core.pivot
+--- @field ["core.presenter"] core.presenter
+--- @field ["core.promo"] core.promo
+--- @field ["core.qol.toc"] core.qol.toc
+--- @field ["core.qol.todo_items"] core.qol.todo_items
+--- @field ["core.queries.native"] core.queries.native
+--- @field ["core.scanner"] core.scanner
+--- @field ["core.storage"] core.storage
+--- @field ["core.summary"] core.summary
+--- @field ["core.syntax"] core.syntax
+--- @field ["core.tangle"] core.tangle
+--- @field ["core.tempus"] core.tempus
+--- @field ["core.text-objects"] core.text-objects
+--- @field ["core.todo-introspector"] core.todo-introspector
+--- @field ["core.ui"] core.ui
+--- @field ["core.ui.calendar"] core.ui.calendar
+--- @field ["core.ui.calendar.views.monthly"] core.ui.calendar.views.monthly
+--- @field ["core.ui.selection_popup"] core.ui.selection_popup
+--- @field ["core.ui.text_popup"] core.ui.text_popup
+
 --- Defines both a public and private configuration for a Neorg module.
 --- Public configurations may be tweaked by the user from the `neorg.setup()` function,
 --- whereas private configurations are for internal use only.
@@ -41,7 +82,7 @@ local utils = require("neorg.core.utils")
 --- @field path string The full path to the module (a more verbose version of `name`). May be used in lua's `require()` statements.
 --- @field public private? table A convenience table to place all of your private variables that you don't want to expose.
 --- @field public public? neorg.module.public Every module can expose any set of information it sees fit through this field. All functions and variables declared in this table will be visiable to any other module loaded.
---- @field required? table<string, neorg.module.public> Contains the public tables of all modules that were required via the `requires` array provided in the `setup()` function of this module.
+--- @field required? neorg.module.resolver Contains the public tables of all modules that were required via the `requires` array provided in the `setup()` function of this module.
 --- @field setup? fun(): neorg.module.setup? Function that is invoked before any other loading occurs. Should perform preliminary startup tasks.
 --- @field replaced? boolean If `true`, this means the module is a replacement for a core module. This flag is set automatically whenever `setup().replaces` is set to a value.
 --- @field on_event fun(event: neorg.event) A callback that is invoked any time an event the module has subscribed to has fired.

--- a/lua/neorg/modules/core/clipboard/module.lua
+++ b/lua/neorg/modules/core/clipboard/module.lua
@@ -79,6 +79,7 @@ module.private = {
     callbacks = {},
 }
 
+--- @class core.clipboard
 module.public = {
     add_callback = function(node_type, func, strict)
         module.private.callbacks[node_type] = module.private.callbacks[node_type] or {}

--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -206,6 +206,7 @@ module.config.public = {
     extension = "md",
 }
 
+--- @class core.export.markdown
 module.public = {
     export = {
         init_state = function()

--- a/lua/neorg/modules/core/export/module.lua
+++ b/lua/neorg/modules/core/export/module.lua
@@ -69,6 +69,7 @@ module.config.public = {
     export_dir = "<export-dir>/<language>-export",
 }
 
+---@class core.export
 module.public = {
     --- Returns a module that can handle conversion from `.norg` to the target filetype
     ---@param ftype string #The filetype to export to

--- a/lua/neorg/modules/core/fs/module.lua
+++ b/lua/neorg/modules/core/fs/module.lua
@@ -13,6 +13,7 @@ local modules = neorg.modules
 
 local module = modules.create("core.fs")
 
+---@class core.fs
 module.public = {
     directory_map = function(path, callback)
         for name, type in vim.fs.dir(path) do

--- a/lua/neorg/modules/core/itero/module.lua
+++ b/lua/neorg/modules/core/itero/module.lua
@@ -79,6 +79,7 @@ module.load = function()
     vim.keymap.set("!", "<Plug>(neorg.itero.next-iteration)", module.public.next_iteration_cr)
 end
 
+---@class core.itero
 module.public = {
     next_iteration_cr = function()
         local cursor = vim.api.nvim_win_get_cursor(0)

--- a/lua/neorg/modules/core/journal/module.lua
+++ b/lua/neorg/modules/core/journal/module.lua
@@ -414,6 +414,7 @@ module.config.private = {
     },
 }
 
+---@class core.journal
 module.public = {
     version = "0.0.9",
 }

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -109,6 +109,7 @@ module.config.public = {
     preset = "neorg",
 }
 
+---@class core.keybinds
 module.public = {
     --- Adds a set of default keys for Neorg to bind.
     --- Should be used exclusively by external modules wanting to provide their own default keymaps.

--- a/lua/neorg/modules/core/latex/renderer/module.lua
+++ b/lua/neorg/modules/core/latex/renderer/module.lua
@@ -154,6 +154,7 @@ module.private.get_key = function(range)
     return ("%d:%d"):format(range[1], range[2])
 end
 
+---@class core.latex.renderer
 module.public = {
     ---@async
     ---@param buf number

--- a/lua/neorg/modules/core/looking-glass/module.lua
+++ b/lua/neorg/modules/core/looking-glass/module.lua
@@ -33,6 +33,7 @@ module.load = function()
     vim.keymap.set("", "<Plug>(neorg.looking-glass.magnify-code-block)", module.public.magnify_code_block)
 end
 
+---@class core.looking-glass
 module.public = {
     sync_text_segment = function(source, source_window, source_start, source_end, target, target_window)
         -- Create a unique but deterministic namespace name for the code block

--- a/lua/neorg/modules/core/pivot/module.lua
+++ b/lua/neorg/modules/core/pivot/module.lua
@@ -84,6 +84,7 @@ module.private = {
     end,
 }
 
+---@class core.pivot
 module.public = {
     ---@param invert boolean
     change_list = neorg.utils.wrap_dotrepeat(function(invert)

--- a/lua/neorg/modules/core/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/qol/todo_items/module.lua
@@ -116,7 +116,6 @@ module.config.public = {
 ---|"urgent"
 ---|"uncertain"
 
----@class core.qol.todo_items
 module.private = {
     --- Updates the parent todo item for the current todo item if it exists
     ---@param recursion_level number the index of the parent to change. The higher the number the more the code will traverse up the syntax tree.
@@ -420,6 +419,7 @@ local function task_set(character, name)
     end)
 end
 
+---@class core.qol.todo_items
 module.public = {
     ["task-done"] = task_set("x", "done"),
     ["task-undone"] = task_set(" ", "undone"),

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -304,6 +304,7 @@ module.config.public = {
     strategy = "default",
 }
 
+---@class core.summary
 module.public = {
     ---@param buf integer? the buffer to insert the summary to
     ---@param cursor_pos integer[]? a tuple of row, col of the cursor positon (see nvim_win_get_cursor())

--- a/lua/neorg/modules/core/syntax/module.lua
+++ b/lua/neorg/modules/core/syntax/module.lua
@@ -78,6 +78,7 @@ module.private = {
     available_languages = {},
 }
 
+---@class core.syntax
 module.public = {
 
     -- fills module.private.loaded_code_blocks with the list of active code blocks in the buffer

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -219,6 +219,7 @@ local function get_comment_string(language)
     return commentstring
 end
 
+---@class core.tangle
 module.public = {
     tangle = function(buffer)
         ---@type core.integrations.treesitter

--- a/lua/neorg/modules/core/text-objects/module.lua
+++ b/lua/neorg/modules/core/text-objects/module.lua
@@ -101,7 +101,6 @@ module.config.public = {
     },
 }
 
----@class core.text-objects
 module.private = {
     get_element_from_cursor = function(node_pattern)
         local node_at_cursor = vim.treesitter.get_node()
@@ -165,6 +164,7 @@ module.private = {
     end,
 }
 
+---@class core.text-objects
 module.public = {
     move_up = function()
         local config = module.config.public.moveables

--- a/lua/neorg/modules/core/ui/calendar/views/monthly/module.lua
+++ b/lua/neorg/modules/core/ui/calendar/views/monthly/module.lua
@@ -571,6 +571,7 @@ module.private = {
     end,
 }
 
+---@class core.ui.calendar.views.monthly
 module.public = {
 
     view_name = "monthly",

--- a/lua/neorg/modules/core/ui/selection_popup/module.lua
+++ b/lua/neorg/modules/core/ui/selection_popup/module.lua
@@ -8,7 +8,7 @@ local lib = neorg.lib
 
 local module = modules.create("core.ui.selection_popup")
 
----@class core.ui
+---@class core.ui.selection_popup
 module.public = {
     --- Constructs a new selection
     ---@param buffer number #The number of the buffer the selection should attach to

--- a/lua/neorg/modules/core/ui/text_popup/module.lua
+++ b/lua/neorg/modules/core/ui/text_popup/module.lua
@@ -7,7 +7,7 @@ local modules = neorg.modules
 
 local module = modules.create("core.ui.text_popup")
 
----@class core.ui
+---@class core.ui.text_popup
 module.public = {
     --- Opens a floating window at the specified position and asks for user input
     ---@param name string #The name of the floating window


### PR DESCRIPTION
Did a quick POC for automatic typing of module resolves. Wondering if something like this would be useful to us. Benefit is that doing `local mod = module.required[{dependency}]` mod will be automatically typed with the correct class and will give us luals type hints and typechecks without having to do something like this every time:

```lua
---@type core.integrations.treesitter
local ts = module.required["core.integrations.treesitter"]
```
Type hinting:
<img width="1583" alt="Screenshot 2024-07-24 at 12 42 50 PM" src="https://github.com/user-attachments/assets/02972ebd-9f47-4b96-92ad-c1566035cd1a">

It already showed some incorrectly type methods in the codebase
<img width="1288" alt="Screenshot 2024-07-24 at 12 36 07 PM" src="https://github.com/user-attachments/assets/50d3be87-8e6f-4a94-adcf-27473a4adb30">

We also get automatic suggestions on which modules can be imported as you can see below:
<img width="513" alt="Screenshot 2024-07-24 at 12 34 48 PM" src="https://github.com/user-attachments/assets/8513042b-575a-48a7-92d8-2d83ccd7ac80">

Downside is obviously that any new added modules will have to be updated in that new `neorg.module.resolver` class

Thoughts/feedback? @vhyrro @benlubas 