### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # global rule
-* @vhyrro @mrossinek @danymat
+* @vhyrro @benlubas


### PR DESCRIPTION
This PR updates the CODEOWNERS file to reflect the current state of active maintainers. @mrossinek and I have already discussed this, he'll keep contributing but on the specification side.

@danymat, would you like to be kept for non-code things like documentation, or would you like to be removed from the CODEOWNERS file entirely? (i.e. you won't get pinged endlessly for every new PR to Neorg. You'll still remain in the nvim-neorg organization though).