### PR TITLE
feat: configurable orderd list icons

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -405,7 +405,7 @@ local function format_ordered_icon(pattern, index)
         return gen(index)
     end
 
-    for char_one, number_table in pairs(ordered_icon_table) do
+    for char_one, number_table in pairs(module.config.public.ordered_icons) do
         local l, r = pattern:find(char_one:find("%w") and "%f[%w]" .. char_one .. "%f[%W]" or char_one)
         if l then
             gen = function(index_)
@@ -683,6 +683,12 @@ module.config.public = {
     -- When set to `always`, Neorg will always open all folds when opening new documents.
     -- When set to `never`, Neorg will not do anything.
     init_open_folds = "auto",
+
+    -- Provide custom ordered icons for ordered lists.
+    -- - keys are a string matched against the first character of the values in `icons.ordered.icons`
+    -- - value are either a list of string icons to use (one for each index), or a function that
+    --   takes the index and returns the string value
+    ordered_icons = ordered_icon_table,
 
     -- Configuration for icons.
     --


### PR DESCRIPTION
Allow the user to configure ordered list icons.

ex:
```lua
["core.concealer"] = {
  config = {
    ordered_icons = {
      ["1"] = function(i)
        if i < 10 then
          return "0" .. i
        end
        return tostring(i)
      end,
    },
  },
},
```

Yields:
![image](https://github.com/user-attachments/assets/698d1a55-6664-4a8b-a978-e754a72ae560)

---

This partially addresses a small issue where ordered lists that exceed 9 items in length, will not line up (b/c `10` is a char longer than `1`). This allows people to pad single digits, but the padding will _always_ be present. 

Ideally the function above could take an index but also some context that includes the length of the list it's a part of. But this would require a more complex change