### PR TITLE
fix(ToC): only try to open when still in norg buffer

### DIFF
--- a/lua/neorg/modules/core/qol/toc/module.lua
+++ b/lua/neorg/modules/core/qol/toc/module.lua
@@ -48,8 +48,10 @@ module.load = function()
             pattern = "*.norg",
             callback = function()
                 vim.schedule(function()
-                    next_open_is_auto = true
-                    vim.cmd([[Neorg toc]])
+                    if vim.bo.filetype == "norg" then
+                        next_open_is_auto = true
+                        vim.cmd([[Neorg toc]])
+                    end
                 end)
             end,
         })


### PR DESCRIPTION
When switching buffers really quickly with auto TOC enabled, we could enter and leave a norg buffer before the scheduled function gets to run, which results in a noisy error message from Neorg Command saying `:Neorg toc` only works from a norg buffer.