### PR TITLE
docs: Add template example to metagen docs

### DIFF
--- a/lua/neorg/modules/core/esupports/metagen/module.lua
+++ b/lua/neorg/modules/core/esupports/metagen/module.lua
@@ -145,6 +145,24 @@ module.config.public = {
     delimiter = ": ",
 
     -- Custom template to use for generating content inside `@document.meta` tag
+    -- The template is a list of lists, each defining a key-value pair of metadata
+    --
+    -- Example:
+    -- ```
+    -- template = {
+    --   -- Default field name without a value will fall back to the default behavior
+    --   { "title" },
+    --   -- Set a custom value for "authors" field
+    --   { "authors", "Vhyrro" },
+    --   -- Fields can be set by lua functions
+    --   {
+    --     "categories",
+    --     function()
+    --       return {"Category-1", "Category-2"}
+    --     end
+    --   }
+    -- }
+    -- ```
     template = default_template,
 
     -- Custom author name that overrides default value if not nil or empty


### PR DESCRIPTION
Hello, I was setting up a custom metagen template in my config to change how `title` was formatted and found the docs lacking. I think an example configuration for the template would be helpful here, particularly want the docs to mention #1079, is useful and I discovered this behavior by searching issues.