### PR TITLE
fix comment

### DIFF
--- a/lua/neorg/core/callbacks.lua
+++ b/lua/neorg/core/callbacks.lua
@@ -1,5 +1,5 @@
 --- @brief [[
---- Defines user callbacks - ways for the user to directly interact with Neorg and respon on certain events.
+--- Defines user callbacks - ways for the user to directly interact with Neorg and respond on certain events.
 --- @brief ]]
 
 --- @module "neorg.core.modules"

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -300,7 +300,9 @@ module.config.public = {
     -- - "default" - read the metadata to categorize and annotate files. Files
     --   without metadata will use the top level heading as the title. If no headings are present, the filename will be used.
     -- - "by_path" - Similar to "default" but uses the capitalized name of the folder containing a *.norg file as category.
-    ---@type string|fun(files: PathlibPath[], ws_root: PathlibPath, heading_level: number?, include_categories: string[]?): string[]?
+    -- - A custom function with the signature:
+    --   `fun(files: PathlibPath[], ws_root: PathlibPath, heading_level: number?, include_categories: string[]?): string[]?`.
+    --   Returning a list of lines that make up the summary
     strategy = "default",
 }
 


### PR DESCRIPTION
fixes documentation of https://github.com/nvim-neorg/neorg/wiki/Summary
by removing a leftover comment
