### PR TITLE
todo_item parent update behaviors

### DIFF
--- a/lua/neorg/modules/core/qol/todo_items/module.lua
+++ b/lua/neorg/modules/core/qol/todo_items/module.lua
@@ -333,6 +333,7 @@ module.private = {
             local row, _, _, column = node:named_child(0):range() ---@diagnostic disable-line -- TODO: type error workaround <pysan3>
 
             vim.api.nvim_buf_set_text(buf, row, column, row, column, { "(" .. char .. ") " })
+            module.private.update_parent(buf, row, 0)
         else
             local range = module.required["core.integrations.treesitter"].get_node_range(first_status_extension)
 
@@ -344,6 +345,7 @@ module.private = {
                 range.column_end,
                 { char }
             )
+            module.private.update_parent(buf, range.row_start, 0)
         end
 
         for child in node:iter_children() do ---@diagnostic disable-line -- TODO: type error workaround <pysan3>


### PR DESCRIPTION
I'm not sure when this changed, or exactly what broke it, but parent items used to update when a keybind was used to change a child state, and sometime around the keybinds refactor, this broke (bisecting to an exact commit is tricky b/c there are multiple commits where the plugin fails to load around this time).

I took this opportunity to make this behavior configurable, b/c personally I've always hated it :P 