### PR TITLE
fix: intuitive default undone icon

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -709,7 +709,7 @@ module.config.public = {
                 render = module.public.icon_renderers.on_left,
             },
             undone = {
-                icon = "×",
+                icon = " ",
                 nodes = { "todo_item_undone" },
                 render = module.public.icon_renderers.on_left,
             },


### PR DESCRIPTION
This has come up enough times that I feel justified in making this PR even though you intentionally changed it to the x a while ago.