### PR TITLE
feat(esupports.hop): Add tab drop as option for open_mode

### DIFF
--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -42,6 +42,7 @@ module.load = function()
     dirman_utils = module.required["core.dirman.utils"]
     vim.keymap.set("", "<Plug>(neorg.esupports.hop.hop-link)", module.public.hop_link)
     vim.keymap.set("", "<Plug>(neorg.esupports.hop.hop-link.vsplit)", lib.wrap(module.public.hop_link, "vsplit"))
+    vim.keymap.set("", "<Plug>(neorg.esupports.hop.hop-link.tab-drop)", lib.wrap(module.public.hop_link, "tab-drop"))
 end
 
 module.config.public = {
@@ -216,9 +217,16 @@ module.public = {
                 end,
 
                 buffer = function()
-                    open_split()
+                    if open_mode ~= "tab-drop" then
+                        open_split()
+                    end
 
                     if located_link_information.buffer ~= vim.api.nvim_get_current_buf() then
+                        if open_mode == "tab-drop" then
+                            vim.cmd("tab drop " .. vim.api.nvim_buf_get_name(located_link_information.buffer))
+                            return
+                        end
+
                         vim.api.nvim_buf_set_option(located_link_information.buffer, "buflisted", true)
                         vim.api.nvim_set_current_buf(located_link_information.buffer)
                     end

--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -17,6 +17,8 @@ mapping them):
 
 - `neorg.esupports.hop.hop-link` - Follow the link under the cursor, seeks forward
 - `neorg.esupports.hop.hop-link.vsplit` - Same, but open the link in a vertical split
+- `neorg.esupports.hop.hop-link.tab-drop` - Same as hop-link, but open the link in a new tab; if the destination is already
+                                            open in an existing tab then just navigate to that tab (check :help :drop)
 --]]
 
 local neorg = require("neorg.core")

--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -19,6 +19,8 @@ mapping them):
 - `neorg.esupports.hop.hop-link.vsplit` - Same, but open the link in a vertical split
 - `neorg.esupports.hop.hop-link.tab-drop` - Same as hop-link, but open the link in a new tab; if the destination is already
                                             open in an existing tab then just navigate to that tab (check :help :drop)
+- `neorg.esupports.hop.hop-link.drop` - Same as hop-link, but navigate to the buffer if the destination is already open
+                                        in an existing buffer (check :help :drop)
 --]]
 
 local neorg = require("neorg.core")
@@ -44,6 +46,7 @@ module.load = function()
     dirman_utils = module.required["core.dirman.utils"]
     vim.keymap.set("", "<Plug>(neorg.esupports.hop.hop-link)", module.public.hop_link)
     vim.keymap.set("", "<Plug>(neorg.esupports.hop.hop-link.vsplit)", lib.wrap(module.public.hop_link, "vsplit"))
+    vim.keymap.set("", "<Plug>(neorg.esupports.hop.hop-link.drop)", lib.wrap(module.public.hop_link, "drop"))
     vim.keymap.set("", "<Plug>(neorg.esupports.hop.hop-link.tab-drop)", lib.wrap(module.public.hop_link, "tab-drop"))
 end
 
@@ -219,13 +222,16 @@ module.public = {
                 end,
 
                 buffer = function()
-                    if open_mode ~= "tab-drop" then
+                    if open_mode ~= "tab-drop" and open_mode ~= "drop" then
                         open_split()
                     end
 
                     if located_link_information.buffer ~= vim.api.nvim_get_current_buf() then
                         if open_mode == "tab-drop" then
                             vim.cmd("tab drop " .. vim.api.nvim_buf_get_name(located_link_information.buffer))
+                            return
+                        elseif open_mode == "drop" then
+                            vim.cmd("drop " .. vim.api.nvim_buf_get_name(located_link_information.buffer))
                             return
                         end
 

--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -229,14 +229,12 @@ module.public = {
                     if located_link_information.buffer ~= vim.api.nvim_get_current_buf() then
                         if open_mode == "tab-drop" then
                             vim.cmd("tab drop " .. vim.api.nvim_buf_get_name(located_link_information.buffer))
-                            return
                         elseif open_mode == "drop" then
                             vim.cmd("drop " .. vim.api.nvim_buf_get_name(located_link_information.buffer))
-                            return
+                        else
+                            vim.api.nvim_buf_set_option(located_link_information.buffer, "buflisted", true)
+                            vim.api.nvim_set_current_buf(located_link_information.buffer)
                         end
-
-                        vim.api.nvim_buf_set_option(located_link_information.buffer, "buflisted", true)
-                        vim.api.nvim_set_current_buf(located_link_information.buffer)
                     end
 
                     if located_link_information.line then

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -306,6 +306,13 @@ module.private = {
                         opts = { desc = "[neorg] Jump to Link (Tab Drop)" },
                     },
 
+                    -- Same as `<CR>`, except if destination is already open in a buffer, just navigate to it
+                    {
+                        "<C-d>",
+                        "<Plug>(neorg.esupports.hop.hop-link.drop)",
+                        opts = { desc = "[neorg] Jump to Link (Drop)" },
+                    },
+
                     -- Promote an object non-recursively
                     {
                         ">.",

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -298,6 +298,14 @@ module.private = {
                         opts = { desc = "[neorg] Jump to Link (Vertical Split)" },
                     },
 
+                    -- Same as `<CR>`, except open the destination in a new tab
+                    -- If destination is already open in an existing tab, just navigate to it
+                    {
+                        "<C-t>",
+                        "<Plug>(neorg.esupports.hop.hop-link.tab-drop)",
+                        opts = { desc = "[neorg] Jump to Link (Tab Drop)" },
+                    },
+
                     -- Promote an object non-recursively
                     {
                         ">.",

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -301,7 +301,7 @@ module.private = {
                     -- Same as `<CR>`, except open the destination in a new tab
                     -- If destination is already open in an existing tab, just navigate to it
                     {
-                        "<C-t>",
+                        "<M-t>",
                         "<Plug>(neorg.esupports.hop.hop-link.tab-drop)",
                         opts = { desc = "[neorg] Jump to Link (Tab Drop)" },
                     },

--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -306,13 +306,6 @@ module.private = {
                         opts = { desc = "[neorg] Jump to Link (Tab Drop)" },
                     },
 
-                    -- Same as `<CR>`, except if destination is already open in a buffer, just navigate to it
-                    {
-                        "<C-d>",
-                        "<Plug>(neorg.esupports.hop.hop-link.drop)",
-                        opts = { desc = "[neorg] Jump to Link (Drop)" },
-                    },
-
                     -- Promote an object non-recursively
                     {
                         ">.",


### PR DESCRIPTION
This adds `:tab drop` as an option for opening a file when clicking a file link. Tab drop as an option would be helpful to avoid opening a file a new tab, when it has already been open somewhere else.

IMO, this could be a replacement for the `tabnew` option itself, as tab drop will open a new tab normally if the same file is already not open. But it can be kept as a separate option as well. Also IMO, never bad to have multiple options :)

Do let me know your thoughts on this. If this looks good and needs any documenting, happy to work on that as well.

Thanks!