### PR TITLE
Add MINGW32_NT to get_os_info

### DIFF
--- a/lua/neorg/core/config.lua
+++ b/lua/neorg/core/config.lua
@@ -36,7 +36,7 @@
 local function get_os_info()
     local os = vim.loop.os_uname().sysname:lower()
 
-    if os:find("windows_nt") then
+    if os:find("windows_nt") or os:find("mingw32_nt") then
         return "windows"
     elseif os == "darwin" then
         return "mac"


### PR DESCRIPTION
If you install neovim using [MSYS 2](https://www.msys2.org/), the operating system will be `mingw32_nt-<ver>`.
in my case it was `mingw32_nt-10.0`.

Therefore, it is necessary to add a check for the prefix `mingw32_nt` to see if the operating system is Windows