### PR TITLE
fix: Tangle should close fd for files

### DIFF
--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -526,6 +526,7 @@ module.on_event = function(event)
                         )
                     end
                 end)
+                vim.uv.fs_close(fd)
             end)
         end
     end


### PR DESCRIPTION
The current implementation keeps the fd open for each file it is tangling, which results in tangled shell scripts not being able to be run until the instance is closed