### PR TITLE
feat(dirman): dynamically set default workspace

### DIFF
--- a/lua/neorg/modules/core/dirman/module.lua
+++ b/lua/neorg/modules/core/dirman/module.lua
@@ -92,7 +92,7 @@ module.load = function()
 
     if module.config.public.open_last_workspace and vim.fn.argc(-1) == 0 then
         if module.config.public.open_last_workspace == "default" then
-            if not module.config.public.default_workspace then
+            if not module.public.get_default_workspace() then
                 log.warn(
                     'Configuration error in `core.dirman`: the `open_last_workspace` option is set to "default", but no default workspace is provided in the `default_workspace` configuration variable. Defaulting to opening the last known workspace.'
                 )
@@ -100,12 +100,12 @@ module.load = function()
                 return
             end
 
-            module.public.open_workspace(module.config.public.default_workspace)
+            module.public.open_workspace(module.public.get_default_workspace())
         else
             module.public.set_last_workspace()
         end
-    elseif module.config.public.default_workspace then
-        module.public.set_workspace(module.config.public.default_workspace)
+    elseif module.public.get_default_workspace() then
+        module.public.set_workspace(module.public.get_default_workspace())
     end
 end
 
@@ -123,6 +123,7 @@ module.config.public = {
     -- The index file is the "entry point" for all of your notes.
     index = "index.norg",
     -- The default workspace to set whenever Neovim starts.
+    -- If a function, will be called with the current workspace and should resolve to a valid workspace name
     default_workspace = nil,
     -- Whether to open the last workspace's index file when `nvim` is executed
     -- without arguments.
@@ -157,6 +158,15 @@ module.public = {
     --- Returns a table in the format { "workspace_name", "path" }
     get_current_workspace = function()
         return module.private.current_workspace
+    end,
+    --- The default workspace, may be set dynamically based on cwd
+    ---@return string? # Should evaluate to a valid workspace name
+    get_default_workspace = function()
+        if type(module.config.public.default_workspace) == "function" then
+            return module.config.public.default_workspace()
+        end
+
+        return module.config.public.default_workspace
     end,
     --- Sets the workspace to the one specified (if it exists) and broadcasts the workspace_changed event
     ---@param ws_name string #The name of a valid namespace we want to switch to
@@ -353,7 +363,7 @@ module.public = {
 
         local last_workspace = storage.retrieve("last_workspace")
         last_workspace = type(last_workspace) == "string" and last_workspace
-            or module.config.public.default_workspace
+            or module.public.get_default_workspace()
             or ""
 
         local workspace_path = module.public.get_workspace(last_workspace)


### PR DESCRIPTION
Ability to dynamically set the default workspace based on the `cwd`.

This gives you the ability to open different workspaces based on context for example:
```lua
config = {
  workspaces = {
    dev = '~/notes/dev',
    personal = '~/notes/personal',
  },
  default_workspace = function()
    local git_root = vim.fs.root(0, '.git')
    local basename = vim.fs.basename(git_root)

    if basename == 'dotfiles' then
      return 'dev'
    end

    return 'personal'
  end,
},

```