### PR TITLE
feat(keybinds): add back keybind "gO" for ToC

### DIFF
--- a/lua/neorg/modules/core/keybinds/module.lua
+++ b/lua/neorg/modules/core/keybinds/module.lua
@@ -213,6 +213,14 @@ module.private = {
                         "<Plug>(neorg.dirman.new-note)",
                         opts = { desc = "[neorg] Create New Note" },
                     },
+
+                    -- Create a Table of Contents
+                    -- ^Table of Contents
+                    {
+                        "gO",
+                        "<cmd>Neorg toc<CR>",
+                        opts = { desc = "[neorg] Create Table of Contents" },
+                    },
                 },
             },
             norg = {


### PR DESCRIPTION
Add back the "gO" keybind for ToC, which was removed in https://github.com/nvim-neorg/neorg/commit/3dd946ae976ee45147a60eeb5174f0f951f04f94.