### PR TITLE
skip folder names on journal's month hierarchy level that don' t represent months

### DIFF
--- a/lua/neorg/modules/core/journal/module.lua
+++ b/lua/neorg/modules/core/journal/module.lua
@@ -281,7 +281,6 @@ module.public = {
                         end
 
                         if mtype == "directory" then
-
                             -- Check if the folder name is a valid month (01-12)
                             local month_number = tonumber(mname)
                             if not month_number or month_number < 1 or month_number > 12 then


### PR DESCRIPTION
this could fix issue [#1648](https://github.com/nvim-neorg/neorg/issues/1648) where TOC-updates fail if other directories are present within the year folder of the journal folder tree structure.