### PR TITLE
fix(docgen): load buffers after opening them

### DIFF
--- a/docgen/docgen.lua
+++ b/docgen/docgen.lua
@@ -56,6 +56,7 @@ end
 docgen.open_file = function(path)
     local uri = vim.uri_from_fname(path)
     local buf = vim.uri_to_bufnr(uri)
+    vim.fn.bufload(buf)
 
     return buf
 end


### PR DESCRIPTION
#1655 caused the docgen to run for the first time in a while, and it's using nightly, so I think that something in nightly changed, and it's totally broken everything

attempting to fix