### PR TITLE
fix(esupports.indent): keep indentation of verbatim blocks without an injected TS parser

### DIFF
--- a/lua/neorg/modules/core/esupports/indent/module.lua
+++ b/lua/neorg/modules/core/esupports/indent/module.lua
@@ -149,7 +149,7 @@ module.public = {
     ---@param new_indent number
     buffer_set_line_indent = function(buffer, start_row, new_indent)
         local line = vim.api.nvim_buf_get_lines(buffer, start_row, start_row + 1, true)[1]
-        if line:match("^%s*$") then
+        if line:match("^%s*$") or new_indent == -1 then
             return
         end
 

--- a/lua/neorg/modules/core/promo/module.lua
+++ b/lua/neorg/modules/core/promo/module.lua
@@ -298,7 +298,7 @@ module.public = {
         for i = start_pos[1], end_pos[1] do
             module.private.promote_or_demote(buffer, "promote", i - 1, false, false)
         end
-        indent.reindent_range(buffer, start_pos[1], end_pos[1])
+        indent.reindent_range(buffer, start_pos[1] - 1, end_pos[1])
     end),
     demote = neorg.utils.wrap_dotrepeat(function()
         local buffer = vim.api.nvim_get_current_buf()
@@ -320,7 +320,7 @@ module.public = {
         for i = start_pos[1], end_pos[1] do
             module.private.promote_or_demote(buffer, "demote", i - 1, false, false)
         end
-        indent.reindent_range(buffer, start_pos[1], end_pos[1])
+        indent.reindent_range(buffer, start_pos[1] - 1, end_pos[1])
     end),
 }
 


### PR DESCRIPTION
This fixes `=` messing with the indentation of verbatim blocks when no language is injected (either because a parser doesn't exist/isn't installed, or because no language was specified). Sometimes this is used for diagrams, which get messed up if all lines are aligned with the tag start. The current implementation doesn't handle code blocks with `norg` as language (which i can't see a good use case for) and thus those won't get auto indented either

https://github.com/user-attachments/assets/c6d021cb-865c-4c3f-8df6-254d74096418

