### PR TITLE
fix: load buffer before parsing with TS

### DIFF
--- a/lua/neorg/modules/core/integrations/treesitter/module.lua
+++ b/lua/neorg/modules/core/integrations/treesitter/module.lua
@@ -658,6 +658,9 @@ module.public = {
         if type(src) == "string" then
             parser = vim.treesitter.get_string_parser(src, filetype)
         else
+            if src ~= 0 then
+                vim.fn.bufload(src)
+            end
             parser = vim.treesitter.get_parser(src or 0, filetype)
         end
 


### PR DESCRIPTION
Little late, but, fixing the breakage caused by this commit https://github.com/neovim/neovim/commit/a0b52e7cb3d211e30c21464c4a4f4acecd6418c9

There are other places where we call `vim.treesitter.get_parser` without explicitly loading the buffer, but it seems like in all of those cases the buffer is already loaded.

I'm sure we'll find more and just fix them as we go