### PR TITLE
docs(README): lazy load neorg for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ the [Lua for Windows](https://github.com/rjpcomputing/luaforwindows) all-in-one 
 ```lua
 {
     "nvim-neorg/neorg",
-    lazy = false, -- Disable lazy loading as some `lazy.nvim` distributions set `lazy = true` by default
+    cmd = { "Neorg" }, -- Load neorg upon :Neorg command...
+    ft = { "norg" }, -- ...or on "norg" filetype
     version = "*", -- Pin Neorg to the latest stable release
     config = true,
 }


### PR DESCRIPTION
Forcing the load of the neorg plugin with the lazy = false statement leads to a 60ms increase in startup time, even when only opening regular files and not using the plugin.

The main goal of lazy.nvim is to load plugins just-in-time and avoid unecessary loads when not required.

Update the installation instructions for lazy.nvim users to lazy load neorg upon `:Neorg` invocation, or when opening `norg` filetype files.