### PR TITLE
docs(README): explain lazy loading is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ the [Lua for Windows](https://github.com/rjpcomputing/luaforwindows) all-in-one 
 
 </details>
 
+While lazy [supports lazy-loading upon specific commands and
+filetypes](https://lazy.folke.io/spec#spec-lazy-loading), it is known to break
+things sometimes. Use at your own risk.
+
 ### `packer.nvim`
 
 Neorg can be installed purely via luarocks on packer, pulling in all required dependencies in the process.


### PR DESCRIPTION
After trying enable lazy-loading for lazy.nvim users [1], it seems like lazy-loading causes problems sometimes and is not supported nor encouraged.

Explain below the lazy.nvim section why lazy-loading is discouraged so that no other attempts are made to propose lazy load by other contributors.

[1] https://github.com/nvim-neorg/neorg/pull/1700