### PR TITLE
fix(rockspec): add `nvim-treesitter-legacy-api` dependency

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v10

--- a/.github/workflows/gendoc.yml
+++ b/.github/workflows/gendoc.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
     name: Generate Markdown Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           - host: ubuntu-24.04
           # - host: windows-2019
-          - host: macos-11 # x86_64
+          - host: macos-13 # x86_64
           - host: macos-14 # aarch64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - host: ubuntu-20.04
+          - host: ubuntu-24.04
           # - host: windows-2019
           - host: macos-11 # x86_64
           - host: macos-14 # aarch64

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   luarocks-upload:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -27,3 +27,4 @@ jobs:
             plenary.nvim == 0.1.4
             nui.nvim == 0.3.0
             pathlib.nvim ~> 2.2
+            nvim-treesitter-legacy-api == 0.9.2

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -5,7 +5,7 @@ on:
     - cron: 30 15 * * 0-6
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2

--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   format-with-stylua:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/version_in_code.yml
+++ b/.github/workflows/version_in_code.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     name: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ One way of installing Neorg is via [rocks.nvim](https://github.com/nvim-neorocks
   require("neorg").setup()
   ```
 
-For the time being you also need `nvim-treesitter` installed, but the plugin is not readily available on luarocks yet.
-To counter this, you also need to run the following:
-- `:Rocks install rocks-git.nvim`
-- `:Rocks install nvim-treesitter/nvim-treesitter`
+<!-- TODO: rewrite this section once a new luarocks release is made, as it will automatically download nvim-treesitter-legacy-api as a dependency -->
+For the time being you also need `nvim-treesitter` installed.
+- `:Rocks install nvim-treesitter-legacy-api`
 - Just like the `neorg.lua` file, create a `lua/plugins/treesitter.lua` file and place the following content inside:
   ```lua
   require("nvim-treesitter.configs").setup({
@@ -147,7 +146,7 @@ It is not recommended to use packer as it is now unmaintained.
 ```lua
 use {
   "nvim-neorg/neorg",
-  rocks = { "lua-utils.nvim", "nvim-nio", "nui.nvim", "plenary.nvim", "pathlib.nvim" },
+  rocks = { "lua-utils.nvim", "nvim-nio", "nui.nvim", "plenary.nvim", "pathlib.nvim", "nvim-treesitter-legacy-api" },
   tag = "*", -- Pin Neorg to the latest stable release
   config = function()
       require("neorg").setup()

--- a/neorg-scm-1.rockspec
+++ b/neorg-scm-1.rockspec
@@ -36,7 +36,7 @@ end
 test_dependencies = {
     "nlua",
     -- Placed here as we plan on removing nvim-treesitter as a dependency soon, but it's still required for various tests.
-    "nvim-treesitter == 0.9.2",
+    "nvim-treesitter-legacy-api == 0.9.2",
 }
 
 build = {


### PR DESCRIPTION
The original `nvim-treesitter` package has been removed from luarocks a year ago, however there is a `nvim-treesitter-legacy-api` package which exposes the legacy module system API from `nvim-treesitter` that neorg requires in order to work properly, e.g. being able to install the norg parsers and interacting with them.