### PR TITLE
fix(ci): update actions version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v10
+      - uses: DeterminateSystems/nix-installer-action@v17
       - name: Run Checks
         run: nix flake check

--- a/.github/workflows/gendoc.yml
+++ b/.github/workflows/gendoc.yml
@@ -33,10 +33,12 @@ jobs:
           neovim: true
           version: v0.10.4
 
-      - uses: luarocks/gh-actions-lua@v10
+      - uses: luarocks/gh-actions-lua@v11
         with:
           luaVersion: "luajit-2.1.0-beta3"
       - uses: luarocks/gh-actions-luarocks@v5
+        with:
+          luarocksVersion: "3.12.0"
 
       - name: Install all required modules
         run: |
@@ -52,7 +54,7 @@ jobs:
       - name: Run Documentation Generator
         run: |
           if ls wiki/*.md 1> /dev/null 2>&1; then
-            rm wiki/*.md 
+            rm wiki/*.md
           fi
           make documentation
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -20,6 +20,6 @@ jobs:
           - host: macos-14 # aarch64
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v10
+      - uses: DeterminateSystems/nix-installer-action@v17
       - name: Run Checks
         run: nix run .#integration-test

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -9,13 +9,13 @@ jobs:
   luarocks-upload:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required to count the commits
       - name: Get Version
         run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v5
+        uses: nvim-neorocks/luarocks-tag-release@v7
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -10,7 +10,7 @@ jobs:
     name: release
     runs-on: ubuntu-24.04
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
           package-name: neorg

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate Sponsors 💖
         uses: JamesIves/github-sponsors-readme-action@v1
@@ -18,6 +18,6 @@ jobs:
           template: '<a href="https://github.com/{{{ login }}}"><img src="https://github.com/{{{ login }}}.png" width="60px" alt="{{{ login }}}" /></a>&nbsp;&nbsp;&nbsp;'
 
       - name: Commit to repository
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: "docs(README): update sponsors list"

--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -1,6 +1,6 @@
 name: Formatting
 
-on: 
+on:
   push:
     branches: [ "main" ]
     paths-ignore:
@@ -12,11 +12,11 @@ jobs:
   format-with-stylua:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Cache cargo modules
         id: cache-cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -36,7 +36,7 @@ jobs:
       - name: Run formatting
         run: stylua -v --verify .
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v6
         with:
           commit_message: "chore: autoformat with stylua"
           branch: ${{ github.ref }}

--- a/.github/workflows/version_in_code.yml
+++ b/.github/workflows/version_in_code.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Release Please Automatic Semver"]
     branches: [main]
-    types: 
+    types:
       - completed
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     name: release
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Some (if not most) workflows had ancient versions of the used actions, which were causing failures or had deprecation warnings (e.g. `actions/checkout@2`). Additionally, the luarocks version in use has been bumped in the docgen workflow in order to address a failure caused by luarocks <=3.11 using an huge Lua table as manifest instead of a JSON file.