### PR TITLE
chore: fix luacheck warnings

### DIFF
--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -533,9 +533,11 @@ module.on_event = function(event)
                         )
                     end
                 end)
+                -- luacheck: push ignore 432
                 vim.uv.fs_close(fd, function(err)
                     assert(not err, lib.lazy_string_concat("Failed to close file '", file, "' for tangling: ", err))
                 end)
+                -- luacheck: pop
             end)
             ::continue::
         end


### PR DESCRIPTION
This should in theory fix the codebase checks CI failing