### PR TITLE
Fix(journal): Use bufload to ensure the journal TOC buffer is loaded

### DIFF
--- a/lua/neorg/modules/core/journal/module.lua
+++ b/lua/neorg/modules/core/journal/module.lua
@@ -254,6 +254,10 @@ module.public = {
         -- Gets the title from the metadata of a file, must be called in a vim.schedule
         local get_title = function(file)
             local buffer = vim.fn.bufadd(workspace_path .. config.pathsep .. folder_name .. config.pathsep .. file)
+
+            -- 💡 fix: Explicitly load the buffer's content into memory
+            vim.fn.bufload(buffer)
+
             local meta = module.required["core.integrations.treesitter"].get_document_metadata(buffer)
             return meta.title
         end


### PR DESCRIPTION
As I reported at #1720, there is an issue to update a table of contents of Neorg Journal. Updating `get_parser` function in nvim-treesitter is mainly suspected as a cause. I simply add a one line of the code to ensure loading a buffer before returning the meta.title. 