### PR TITLE
fix: replace deprecated `vim.tbl_islist` with `vim.islist`

### DIFF
--- a/docgen/docgen.lua
+++ b/docgen/docgen.lua
@@ -688,7 +688,7 @@ docgen.render = function(configuration_option, open)
 
         if t == "table" then
             return (vim.tbl_isempty(self.object) and "empty " or "")
-                .. (vim.tbl_islist(self.object) and "list" or "table")
+                .. (vim.islist(self.object) and "list" or "table")
         else
             return t
         end

--- a/lua/neorg/modules/core/summary/module.lua
+++ b/lua/neorg/modules/core/summary/module.lua
@@ -155,7 +155,7 @@ module.load = function()
                     -- normalise categories into a list. Could be vim.NIL, a number, a string or a list ...
                     if not metadata.categories or metadata.categories == vim.NIL then
                         metadata.categories = { "Uncategorised" }
-                    elseif not vim.tbl_islist(metadata.categories) then ---@diagnostic disable-line
+                    elseif not vim.islist(metadata.categories) then ---@diagnostic disable-line
                         metadata.categories = { tostring(metadata.categories) }
                     end
 

--- a/lua/neorg/modules/core/tangle/module.lua
+++ b/lua/neorg/modules/core/tangle/module.lua
@@ -253,7 +253,7 @@ module.public = {
         }
 
         ---@diagnostic disable-next-line
-        if vim.tbl_islist(options.languages) then
+        if vim.islist(options.languages) then
             options.filenames_only = options.languages
             options.languages = {}
         elseif type(options.languages) == "string" then


### PR DESCRIPTION
`vim.tbl_islist` was deprecated in nvim 0.10 in favor of `vim.islist`