### PR TITLE
fix(concealer): apply correct extmark opts

### DIFF
--- a/lua/neorg/modules/core/concealer/module.lua
+++ b/lua/neorg/modules/core/concealer/module.lua
@@ -466,13 +466,18 @@ module.public = {
                     return
                 end
 
-                local text = (" "):rep(len - 1) .. icon
-
-                local _, first_unicode_end = text:find("[%z\1-\127\194-\244][\128-\191]*", len)
+                local _, first_unicode_end = icon:find("[%z\1-\127\194-\244][\128-\191]*", len)
                 local highlight = config.highlights and table_get_default_last(config.highlights, len)
-                set_mark(bufid, row_0b, col_0b, text:sub(1, first_unicode_end), highlight)
-                if vim.fn.strcharlen(text) > len then
-                    set_mark(bufid, row_0b, col_0b + len, text:sub(first_unicode_end + 1), highlight, {
+                -- set_mark(bufid, row_0b, 0, "", highlight, {
+                --     end_row = row_0b + 1,
+                --     end_col = 0,
+                --     hl_eol = true,
+                --     hl_group = highlight,
+                -- })
+                set_mark(bufid, row_0b, col_0b, (" "):rep(len - 1), "Normal")
+                set_mark(bufid, row_0b, col_0b + len - 1, icon:sub(1, first_unicode_end), highlight)
+                if vim.fn.strcharlen(icon) > 1 then
+                    set_mark(bufid, row_0b, col_0b + len, icon:sub(first_unicode_end + 1), highlight, {
                         virt_text_pos = "inline",
                     })
                 end


### PR DESCRIPTION
This fixes two issues with the extmarks added by the concealer:

- hides the extmarks when they flow off the screen due to horizontally scrolling
- removes highlights on the extmarks that pads the left of headings/lists with whitespace

**Demonstration of the wrapping issue**: Notice how the extmarks stay on the left side of the screen even as the screen scrolls to the right. Also notice how the whitespace before the higher level headings has the heading highlight applied to it.

_Before_:

https://github.com/user-attachments/assets/d22c609e-4fff-43cb-99f2-1cd1c8206438

_After_:

https://github.com/user-attachments/assets/5dd93d17-8295-4a1b-b3cb-34163489abdd