### PR TITLE
docs(README): add link to Zulip chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # Neorg - An Organized Future
 
 <a href="https://neovim.io"> ![Neovim](https://img.shields.io/badge/Neovim%200.10+-brightgreen?style=for-the-badge) </a>
+<a href="https://chat.neorg.org"> ![Zulip](https://img.shields.io/badge/zulip-join-6492fe?style=for-the-badge&logo=zulip) </a>
 <a href="https://discord.gg/T6EgTAX7ht"> ![Discord](https://img.shields.io/badge/discord-join-7289da?style=for-the-badge&logo=discord) </a>
 <a href="/LICENSE"> ![License](https://img.shields.io/badge/license-GPL%20v3-brightgreen?style=for-the-badge)</a>
 <a href="https://dotfyle.com/plugins/nvim-neorg/neorg"> ![Usage](https://dotfyle.com/plugins/nvim-neorg/neorg/shield?style=for-the-badge) </a>


### PR DESCRIPTION
I think it's time for us to add the Zulip instance in the README so that everyone can easily find it without reading the announcements channel on Discord, given that we've set up Zulip as a secondary platform for more structured conversations about Neorg and other projects a few months ago, alongside the future archive of the development channels on Discord (they'll be publicly visible, but won't be writable anymore).