### PR TITLE
fix(clipboard): yank to use correct regtype

### DIFF
--- a/lua/neorg/modules/core/clipboard/module.lua
+++ b/lua/neorg/modules/core/clipboard/module.lua
@@ -62,7 +62,7 @@ module.load = function()
                                     }
                                 )
                             end) or register,
-                            "l" ---@diagnostic disable-line
+                            vim.v.event.regtype ---@diagnostic disable-line
                         )
 
                         return


### PR DESCRIPTION
Fixes a bug in the clipboard module in which any text copied using it (currently applies to code in code-blocks due to clipboard/code-blocks) will use a line-wise registry type.

This means even if you copy text with visual mode or yiw, it will always paste in a new line.