### PR TITLE
fix(journal): Remove empty line when using templates

### DIFF
--- a/lua/neorg/modules/core/journal/module.lua
+++ b/lua/neorg/modules/core/journal/module.lua
@@ -216,7 +216,7 @@ module.public = {
             and module.config.public.use_template
             and module.required["core.dirman"].file_exists(workspace_path .. "/" .. folder_name .. "/" .. template_name)
         then
-            vim.cmd("$read " .. workspace_path .. "/" .. folder_name .. "/" .. template_name .. "| w")
+            vim.cmd("$read " .. workspace_path .. "/" .. folder_name .. "/" .. template_name .. "| 1d | w")
         end
     end,
 


### PR DESCRIPTION
As described in the link:
https://github.com/nvim-neorg/neorg/issues/1641 when using templates the journal entry adds an empty line at the beginning. This removes the unused line.

Found a discussion about this in the discord:
https://discord.com/channels/834325286664929280/834326555160608769/1266289489127673866