### PR TITLE
fix: correct cursor position when moving to a line by its number

### DIFF
--- a/lua/neorg/modules/core/esupports/hop/module.lua
+++ b/lua/neorg/modules/core/esupports/hop/module.lua
@@ -183,7 +183,7 @@ module.public = {
         end
 
         local function jump_to_line(line)
-            local status, _ = pcall(vim.api.nvim_win_set_cursor, 0, { line, 1 })
+            local status, _ = pcall(vim.api.nvim_win_set_cursor, 0, { line, 0 })
 
             if not status then
                 log.error("Failed to jump to line:", line, "- make sure the line number exists!")


### PR DESCRIPTION
<https://neovim.io/doc/user/api.html#nvim_win_set_cursor()>:
> Sets the (1,0)-indexed cursor position in the window.

After changing `1` to `0` in the call to `nvim_win_set_cursor`, when moving to a line by its number, the cursor is placed on the first character in the line instead of the second.