### PR TITLE
fix(export/html): use link_description for anchor content

### DIFF
--- a/lua/neorg/modules/core/export/html/module.lua
+++ b/lua/neorg/modules/core/export/html/module.lua
@@ -205,10 +205,10 @@ local function wrap_anchor()
         end
 
         local content
-        if #output > 0 and output[1] ~= "" then
-            content = output[1]
+        if state.link and state.link.link_description then
+            content = state.link.link_description
         else
-            content = state.link.link_text
+            content = state.link.link_location_text
         end
 
         output = {


### PR DESCRIPTION
The wrap_anchor() recollector used output[1] as the display text, but output ordering differs between link ({url}[text]) and anchor_definition ([text]{url}) nodes. Use state.link.link_description which is consistent regardless of syntax. Also fix the fallback from the nonexistent link_text field to link_location_text.