### PR TITLE
fix(export/markdown): avoid over-stripping indentation in ranged tags

### DIFF
--- a/lua/neorg/modules/core/export/markdown/module.lua
+++ b/lua/neorg/modules/core/export/markdown/module.lua
@@ -492,7 +492,9 @@ module.public = {
                 split_text[1] = string.rep(" ", ranged_tag_content_column_start - state.tag_indent) .. split_text[1]
 
                 for i = 2, #split_text do
-                    split_text[i] = split_text[i]:sub(state.tag_indent + 1)
+                    local leading_ws = split_text[i]:match("^(%s*)")
+                    local strip = math.min(#leading_ws, state.tag_indent)
+                    split_text[i] = split_text[i]:sub(strip + 1)
                 end
 
                 return state.tag_close and (table.concat(split_text, "\n") .. "\n")


### PR DESCRIPTION
Use math.min to clamp the strip amount to the actual leading whitespace, preventing striping non-whitespace characters. when a line has less indentation than tag_indent.