### PR TITLE
fix(modules): avoid crash when broadcasting an event for a hidden buffer

### DIFF
--- a/lua/neorg/core/modules.lua
+++ b/lua/neorg/core/modules.lua
@@ -783,10 +783,20 @@ function modules.create_event(module, type, content, ev)
         winid = vim.api.nvim_get_current_win()
     end
 
-    new_event.cursor_position = vim.api.nvim_win_get_cursor(winid)
+    -- Only read the cursor from `winid` when it actually displays `bufid`; otherwise its
+    -- cursor row belongs to a different buffer and may be out of range for `bufid`, which
+    -- would crash `nvim_buf_get_lines`. This happens when an event is broadcast while
+    -- `bufid` is not shown in any window (e.g. `set_workspace` during startup).
+    if vim.api.nvim_win_is_valid(winid) and vim.api.nvim_win_get_buf(winid) == bufid then
+        new_event.cursor_position = vim.api.nvim_win_get_cursor(winid)
 
-    local row_1b = new_event.cursor_position[1]
-    new_event.line_content = vim.api.nvim_buf_get_lines(bufid, row_1b - 1, row_1b, true)[1]
+        local row_1b = new_event.cursor_position[1]
+        new_event.line_content = vim.api.nvim_buf_get_lines(bufid, row_1b - 1, row_1b, false)[1] or ""
+    else
+        new_event.cursor_position = { 0, 0 }
+        new_event.line_content = ""
+    end
+
     new_event.referrer = module.name
     new_event.broadcast = true
     new_event.buffer = bufid

--- a/lua/neorg/core/modules_tests.lua
+++ b/lua/neorg/core/modules_tests.lua
@@ -1,0 +1,28 @@
+local tests = require("neorg.tests")
+
+describe("core.modules.create_event", function()
+    local neorg = tests.neorg_with("core.dirman", {
+        workspaces = { test = "./test-workspace" },
+    })
+    local modules = neorg.modules
+
+    it("does not crash when the target buffer is not shown in a window", function()
+        -- Put the current window on a buffer with a cursor row past the end of `bufid`.
+        vim.api.nvim_buf_set_lines(0, 0, -1, false, { "a", "b", "c", "d", "e" })
+        vim.api.nvim_win_set_cursor(0, { 5, 0 })
+
+        -- `bufid` has a single line and is not displayed in any window, mirroring an event
+        -- broadcast during startup (e.g. `set_workspace`).
+        local bufid = vim.api.nvim_create_buf(false, true)
+
+        local event = modules.create_event(
+            { name = "core.dirman" },
+            "core.dirman.events.workspace_changed",
+            nil,
+            { buf = bufid }
+        )
+
+        assert.same({ 0, 0 }, event.cursor_position)
+        assert.equal("", event.line_content)
+    end)
+end)


### PR DESCRIPTION
Fixes #1817.

When an event is broadcast for a buffer that is not shown in any window (for example the `workspace_changed` event that `set_workspace` fires during startup), `create_event` falls back to the current window. That window shows a different buffer, so its cursor row can be past the end of the target buffer, and `nvim_buf_get_lines(bufid, ..., true)` then throws, taking down the whole load sequence.

This only reads the cursor and line content when the resolved window actually displays the target buffer, and otherwise uses the same `{ 0, 0 }` / `""` defaults events already use elsewhere. Added a regression test that broadcasts an event for a hidden buffer.
